### PR TITLE
feat(config): multi-provider support (Gemini + Vertex AI)

### DIFF
--- a/src/openharness/api/provider.py
+++ b/src/openharness/api/provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from openharness.config.settings import Settings
+from openharness.config.settings import Settings, _is_gemini
 
 
 @dataclass(frozen=True)
@@ -42,6 +42,13 @@ def detect_provider(settings: Settings) -> ProviderInfo:
             voice_supported=False,
             voice_reason="voice mode is not wired for Vertex in this build",
         )
+    if _is_gemini(settings.model):
+        return ProviderInfo(
+            name="gemini",
+            auth_kind="api_key",
+            voice_supported=False,
+            voice_reason="voice mode is not wired for Gemini in this build",
+        )
     if base_url:
         return ProviderInfo(
             name="anthropic-compatible",
@@ -59,7 +66,9 @@ def detect_provider(settings: Settings) -> ProviderInfo:
 
 def auth_status(settings: Settings) -> str:
     """Return a compact auth status string."""
-    if settings.api_key:
+    try:
+        settings.resolve_api_key()
         return "configured"
-    return "missing"
+    except ValueError:
+        return "missing"
 

--- a/src/openharness/config/paths.py
+++ b/src/openharness/config/paths.py
@@ -106,6 +106,17 @@ def get_project_config_dir(cwd: str | Path) -> Path:
     return project_dir
 
 
+def get_project_runs_dir(cwd: str | Path) -> Path:
+    """Return the per-project run-artifact directory.
+
+    Each automated agent run stores its manifest, logs, and workspace
+    under a unique subdirectory of this directory.
+    """
+    runs_dir = Path(cwd).resolve() / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    return runs_dir
+
+
 def get_project_issue_file(cwd: str | Path) -> Path:
     """Return the per-project issue context file."""
     return get_project_config_dir(cwd) / "issue.md"

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -55,6 +55,10 @@ class Settings(BaseModel):
     max_tokens: int = 16384
     base_url: str | None = None
 
+    # Vertex AI / Google Cloud configuration (used when model is a Gemini variant)
+    vertex_project: str | None = None
+    vertex_location: str | None = None
+
     # Behavior
     system_prompt: str | None = None
     permission: PermissionSettings = Field(default_factory=PermissionSettings)
@@ -74,12 +78,27 @@ class Settings(BaseModel):
     verbose: bool = False
 
     def resolve_api_key(self) -> str:
-        """Resolve API key with precedence: instance value > env var > empty.
+        """Resolve the API key appropriate for the configured model.
 
-        Returns the API key string. Raises ValueError if no key is found.
+        Precedence (highest first):
+        1. ``api_key`` field set directly on this instance or via ``OPENHARNESS_API_KEY``
+        2. Provider-specific environment variable (``GEMINI_API_KEY`` / ``VERTEX_AI_API_KEY``
+           for Gemini models; ``ANTHROPIC_API_KEY`` for all others)
+
+        Raises ``ValueError`` when no key can be resolved.
         """
         if self.api_key:
             return self.api_key
+
+        if "gemini" in self.model.lower():
+            env_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("VERTEX_AI_API_KEY", "")
+            if env_key:
+                return env_key
+            raise ValueError(
+                "No API key found for Gemini model. "
+                "Set GEMINI_API_KEY or VERTEX_AI_API_KEY, "
+                "or configure api_key in ~/.openharness/settings.json"
+            )
 
         env_key = os.environ.get("ANTHROPIC_API_KEY", "")
         if env_key:
@@ -97,8 +116,16 @@ class Settings(BaseModel):
 
 
 def _apply_env_overrides(settings: Settings) -> Settings:
-    """Apply supported environment variable overrides over loaded settings."""
+    """Apply supported environment variable overrides over loaded settings.
+
+    Note: provider-specific API keys (``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``,
+    ``VERTEX_AI_API_KEY``) are intentionally **not** loaded into the ``api_key``
+    field here.  They are resolved lazily and model-aware by ``resolve_api_key()``.
+    Use ``OPENHARNESS_API_KEY`` only if you need to pin an explicit key regardless
+    of the model.
+    """
     updates: dict[str, Any] = {}
+
     model = os.environ.get("ANTHROPIC_MODEL") or os.environ.get("OPENHARNESS_MODEL")
     if model:
         updates["model"] = model
@@ -111,9 +138,21 @@ def _apply_env_overrides(settings: Settings) -> Settings:
     if max_tokens:
         updates["max_tokens"] = int(max_tokens)
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    # Explicit key override — use this only to pin a key unconditionally.
+    # Model-specific keys (ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.) are
+    # resolved lazily by Settings.resolve_api_key() so they never clobber
+    # each other when switching providers.
+    api_key = os.environ.get("OPENHARNESS_API_KEY")
     if api_key:
         updates["api_key"] = api_key
+
+    vertex_project = os.environ.get("VERTEX_PROJECT") or os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if vertex_project:
+        updates["vertex_project"] = vertex_project
+
+    vertex_location = os.environ.get("VERTEX_LOCATION") or os.environ.get("GOOGLE_CLOUD_LOCATION")
+    if vertex_location:
+        updates["vertex_location"] = vertex_location
 
     if not updates:
         return settings

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -46,6 +46,12 @@ class MemorySettings(BaseModel):
     max_entrypoint_lines: int = 200
 
 
+def _is_gemini(model: str) -> bool:
+    """Return True if *model* identifies a Google Gemini model."""
+    m = model.lower()
+    return m.startswith("gemini") or "/gemini" in m
+
+
 class Settings(BaseModel):
     """Main settings model for OpenHarness."""
 
@@ -78,19 +84,17 @@ class Settings(BaseModel):
     verbose: bool = False
 
     def resolve_api_key(self) -> str:
-        """Resolve the API key appropriate for the configured model.
+        """Resolve the API key for the configured model.
 
-        Precedence (highest first):
-        1. ``api_key`` field set directly on this instance or via ``OPENHARNESS_API_KEY``
-        2. Provider-specific environment variable (``GEMINI_API_KEY`` / ``VERTEX_AI_API_KEY``
-           for Gemini models; ``ANTHROPIC_API_KEY`` for all others)
-
-        Raises ``ValueError`` when no key can be resolved.
+        Precedence: ``api_key`` field → provider-specific env var
+        (``GEMINI_API_KEY`` / ``VERTEX_AI_API_KEY`` for Gemini;
+        ``ANTHROPIC_API_KEY`` for everything else).
+        Raises ``ValueError`` when no key is found.
         """
         if self.api_key:
             return self.api_key
 
-        if "gemini" in self.model.lower():
+        if _is_gemini(self.model):
             env_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("VERTEX_AI_API_KEY", "")
             if env_key:
                 return env_key
@@ -116,13 +120,11 @@ class Settings(BaseModel):
 
 
 def _apply_env_overrides(settings: Settings) -> Settings:
-    """Apply supported environment variable overrides over loaded settings.
+    """Apply environment variable overrides.
 
-    Note: provider-specific API keys (``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``,
-    ``VERTEX_AI_API_KEY``) are intentionally **not** loaded into the ``api_key``
-    field here.  They are resolved lazily and model-aware by ``resolve_api_key()``.
-    Use ``OPENHARNESS_API_KEY`` only if you need to pin an explicit key regardless
-    of the model.
+    Provider-specific keys (``ANTHROPIC_API_KEY``, ``GEMINI_API_KEY``, etc.) are
+    resolved lazily by ``resolve_api_key()`` — not stored here.  Use
+    ``OPENHARNESS_API_KEY`` to pin a key unconditionally.
     """
     updates: dict[str, Any] = {}
 
@@ -138,10 +140,6 @@ def _apply_env_overrides(settings: Settings) -> Settings:
     if max_tokens:
         updates["max_tokens"] = int(max_tokens)
 
-    # Explicit key override — use this only to pin a key unconditionally.
-    # Model-specific keys (ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.) are
-    # resolved lazily by Settings.resolve_api_key() so they never clobber
-    # each other when switching providers.
     api_key = os.environ.get("OPENHARNESS_API_KEY")
     if api_key:
         updates["api_key"] = api_key

--- a/tests/test_config/test_paths.py
+++ b/tests/test_config/test_paths.py
@@ -9,6 +9,8 @@ from openharness.config.paths import (
     get_config_file_path,
     get_data_dir,
     get_logs_dir,
+    get_project_config_dir,
+    get_project_runs_dir,
 )
 
 
@@ -67,3 +69,22 @@ def test_get_logs_dir_env_override(tmp_path: Path, monkeypatch):
     logs_dir = get_logs_dir()
     assert logs_dir == custom
     assert logs_dir.is_dir()
+
+
+def test_get_project_config_dir(tmp_path: Path):
+    config_dir = get_project_config_dir(tmp_path)
+    assert config_dir == tmp_path / ".openharness"
+    assert config_dir.is_dir()
+
+
+def test_get_project_runs_dir(tmp_path: Path):
+    runs_dir = get_project_runs_dir(tmp_path)
+    assert runs_dir == tmp_path / "runs"
+    assert runs_dir.is_dir()
+
+
+def test_get_project_runs_dir_creates_missing_parents(tmp_path: Path):
+    project = tmp_path / "deep" / "project"
+    runs_dir = get_project_runs_dir(project)
+    assert runs_dir == project.resolve() / "runs"
+    assert runs_dir.is_dir()

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -146,7 +146,6 @@ class TestLoadSaveSettings:
         path.write_text(json.dumps({"model": "from-file", "base_url": "https://file.example"}))
         monkeypatch.setenv("ANTHROPIC_MODEL", "from-env-model")
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://env.example/anthropic")
-        # ANTHROPIC_API_KEY is not loaded into api_key — use OPENHARNESS_API_KEY for that
         monkeypatch.setenv("OPENHARNESS_API_KEY", "sk-env-override")
 
         s = load_settings(path)
@@ -155,14 +154,7 @@ class TestLoadSaveSettings:
         assert s.base_url == "https://env.example/anthropic"
         assert s.api_key == "sk-env-override"
 
-    def test_load_anthropic_api_key_env_not_loaded_into_api_key_field(
-        self, tmp_path: Path, monkeypatch
-    ):
-        """ANTHROPIC_API_KEY must not clobber the api_key field.
-
-        It is resolved lazily by resolve_api_key() so that provider-specific
-        key routing remains correct when switching between Anthropic and Gemini.
-        """
+    def test_anthropic_api_key_not_stored_in_field(self, tmp_path: Path, monkeypatch):
         path = tmp_path / "settings.json"
         path.write_text(json.dumps({}))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-env")
@@ -170,9 +162,7 @@ class TestLoadSaveSettings:
 
         s = load_settings(path)
 
-        # api_key field stays empty — resolved dynamically by resolve_api_key()
         assert s.api_key == ""
-        # But resolve_api_key() still finds it
         assert s.resolve_api_key() == "sk-anthropic-env"
 
     def test_load_applies_vertex_env_overrides(self, tmp_path: Path, monkeypatch):

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -18,12 +18,20 @@ class TestSettings:
         assert s.max_tokens == 16384
         assert s.fast_mode is False
         assert s.permission.mode == "default"
+        assert s.vertex_project is None
+        assert s.vertex_location is None
+
+    def test_vertex_fields(self):
+        s = Settings(vertex_project="my-project", vertex_location="us-central1")
+        assert s.vertex_project == "my-project"
+        assert s.vertex_location == "us-central1"
 
     def test_resolve_api_key_from_instance(self):
         s = Settings(api_key="sk-test-123")
         assert s.resolve_api_key() == "sk-test-123"
 
-    def test_resolve_api_key_from_env(self, monkeypatch):
+    def test_resolve_api_key_anthropic_from_env(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env-456")
         s = Settings()
         assert s.resolve_api_key() == "sk-env-456"
@@ -33,11 +41,45 @@ class TestSettings:
         s = Settings(api_key="sk-instance-789")
         assert s.resolve_api_key() == "sk-instance-789"
 
-    def test_resolve_api_key_missing_raises(self, monkeypatch):
+    def test_resolve_api_key_missing_anthropic_raises(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
         s = Settings()
         with pytest.raises(ValueError, match="No API key found"):
             s.resolve_api_key()
+
+    def test_resolve_api_key_gemini_from_gemini_key(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "gm-key-abc")
+        s = Settings(model="gemini-2.0-flash")
+        assert s.resolve_api_key() == "gm-key-abc"
+
+    def test_resolve_api_key_gemini_from_vertex_key(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("VERTEX_AI_API_KEY", "vx-key-xyz")
+        s = Settings(model="gemini-2.5-pro")
+        assert s.resolve_api_key() == "vx-key-xyz"
+
+    def test_resolve_api_key_gemini_prefers_gemini_key_over_vertex(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "gm-first")
+        monkeypatch.setenv("VERTEX_AI_API_KEY", "vx-second")
+        s = Settings(model="gemini-2.0-flash")
+        assert s.resolve_api_key() == "gm-first"
+
+    def test_resolve_api_key_gemini_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("VERTEX_AI_API_KEY", raising=False)
+        s = Settings(model="gemini-2.0-flash")
+        with pytest.raises(ValueError, match="No API key found for Gemini model"):
+            s.resolve_api_key()
+
+    def test_resolve_api_key_instance_takes_precedence_over_gemini_env(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "gm-env")
+        s = Settings(model="gemini-2.0-flash", api_key="sk-explicit")
+        assert s.resolve_api_key() == "sk-explicit"
 
     def test_merge_cli_overrides(self):
         s = Settings()
@@ -104,10 +146,67 @@ class TestLoadSaveSettings:
         path.write_text(json.dumps({"model": "from-file", "base_url": "https://file.example"}))
         monkeypatch.setenv("ANTHROPIC_MODEL", "from-env-model")
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://env.example/anthropic")
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env-override")
+        # ANTHROPIC_API_KEY is not loaded into api_key — use OPENHARNESS_API_KEY for that
+        monkeypatch.setenv("OPENHARNESS_API_KEY", "sk-env-override")
 
         s = load_settings(path)
 
         assert s.model == "from-env-model"
         assert s.base_url == "https://env.example/anthropic"
         assert s.api_key == "sk-env-override"
+
+    def test_load_anthropic_api_key_env_not_loaded_into_api_key_field(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """ANTHROPIC_API_KEY must not clobber the api_key field.
+
+        It is resolved lazily by resolve_api_key() so that provider-specific
+        key routing remains correct when switching between Anthropic and Gemini.
+        """
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({}))
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic-env")
+        monkeypatch.delenv("OPENHARNESS_API_KEY", raising=False)
+
+        s = load_settings(path)
+
+        # api_key field stays empty — resolved dynamically by resolve_api_key()
+        assert s.api_key == ""
+        # But resolve_api_key() still finds it
+        assert s.resolve_api_key() == "sk-anthropic-env"
+
+    def test_load_applies_vertex_env_overrides(self, tmp_path: Path, monkeypatch):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({}))
+        monkeypatch.setenv("VERTEX_PROJECT", "my-gcp-project")
+        monkeypatch.setenv("VERTEX_LOCATION", "europe-west4")
+
+        s = load_settings(path)
+
+        assert s.vertex_project == "my-gcp-project"
+        assert s.vertex_location == "europe-west4"
+
+    def test_load_applies_google_cloud_env_overrides(self, tmp_path: Path, monkeypatch):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({}))
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "gcp-proj")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+        monkeypatch.delenv("VERTEX_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+
+        s = load_settings(path)
+
+        assert s.vertex_project == "gcp-proj"
+        assert s.vertex_location == "us-central1"
+
+    def test_vertex_project_env_takes_precedence_over_google_cloud(
+        self, tmp_path: Path, monkeypatch
+    ):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({}))
+        monkeypatch.setenv("VERTEX_PROJECT", "vertex-wins")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "gcp-loses")
+
+        s = load_settings(path)
+
+        assert s.vertex_project == "vertex-wins"


### PR DESCRIPTION
## Summary

- Adds `vertex_project` / `vertex_location` settings and env-var wiring (`VERTEX_PROJECT`, `GOOGLE_CLOUD_PROJECT`, etc.) for Vertex AI / Google Cloud
- Extracts `_is_gemini()` predicate (`startswith` + `/gemini` path variant) as the single source of truth for Gemini model detection
- `resolve_api_key()` is now model-aware: routes Gemini models to `GEMINI_API_KEY` / `VERTEX_AI_API_KEY`, Anthropic models to `ANTHROPIC_API_KEY`; use `OPENHARNESS_API_KEY` to pin a key regardless of provider
- Provider-specific keys are no longer eagerly loaded into the `api_key` field — resolution is lazy so keys never clobber each other when switching providers
- `detect_provider()` now recognises Gemini models instead of falling through to `"anthropic"`
- `auth_status()` fixed to call `resolve_api_key()` (previously read `.api_key` directly, returning `"missing"` even when `ANTHROPIC_API_KEY` was set)
- Adds `get_project_runs_dir()` for per-project run-artifact directories

## Test plan

- [ ] `uv run pytest tests/test_config/` — all 33 tests pass
- [ ] Set `GEMINI_API_KEY` and a `gemini-*` model; verify `resolve_api_key()` returns the Gemini key and `auth_status()` returns `"configured"`
- [ ] Set only `ANTHROPIC_API_KEY`; verify `auth_status()` still returns `"configured"` (regression from direct `.api_key` read)
- [ ] Verify `detect_provider()` returns `name="gemini"` for a `gemini-2.0-flash` model

Made with [Cursor](https://cursor.com)