### PR TITLE
fix: prevent double Enter submission in React TUI

### DIFF
--- a/frontend/terminal/src/App.tsx
+++ b/frontend/terminal/src/App.tsx
@@ -282,11 +282,8 @@ export function App({config}: {config: FrontendConfig}): React.JSX.Element {
 			return;
 		}
 
-		// --- Submit on Enter ---
-		if (!showPicker && key.return && input.trim()) {
-			onSubmit(input);
-			return;
-		}
+		// Note: normal Enter submission is handled by TextInput's onSubmit in
+		// PromptInput.  Do NOT duplicate it here — that causes double requests.
 	});
 
 	const onSubmit = (value: string): void => {


### PR DESCRIPTION
## Summary

- **Problem**: Every user message in the React TUI is submitted twice, causing duplicate responses from the model.
- **Root cause**: Both `ink-text-input`'s `TextInput.onSubmit` and the `useInput` hook's `key.return` handler call `onSubmit()` on Enter — two `submit_line` requests are queued and processed sequentially.
- **Fix**: Remove the duplicate `key.return` handler in `useInput`. `TextInput` already handles normal Enter submission.

## Before

<img width="1968" height="1364" alt="image" src="https://github.com/user-attachments/assets/c5818ad1-dffb-4b39-b225-66f749357d28" />

<img width="1264" height="1040" alt="image" src="https://github.com/user-attachments/assets/82f2ee1c-e513-46ed-b9ba-e49c9b5f76c5" />

## After

<img width="1258" height="790" alt="image" src="https://github.com/user-attachments/assets/d0334e84-92c0-459b-bd55-267545c10e46" />

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q`
- [x] `cd frontend/terminal && npx tsc --noEmit`
- [x] Manual testing: verified single response per Enter press

## Notes

- This bug exists on `main` and is not related to any new feature.
- The symptom is more visible with fast-responding API providers.