### PR TITLE
feat: add OpenAI-compatible API client (--api-format openai)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,23 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- OpenAI-compatible API client (`--api-format openai`) supporting any provider that implements the OpenAI `/v1/chat/completions` format, including Alibaba DashScope, DeepSeek, GitHub Models, Groq, Together AI, Ollama, and more.
+- `OPENHARNESS_API_FORMAT` environment variable for selecting the API format.
+- `OPENAI_API_KEY` fallback when using OpenAI-format providers.
 - GitHub Actions CI workflow for Python linting, tests, and frontend TypeScript checks.
 - `CONTRIBUTING.md` with local setup, validation commands, and PR expectations.
 - `docs/SHOWCASE.md` with concrete OpenHarness usage patterns and demo commands.
 - GitHub issue templates and a pull request template.
 
+### Fixed
+
+- Fixed duplicate response in React TUI caused by double Enter key submission in the input handler.
+
 ### Changed
 
 - README now links to contribution docs, changelog, showcase material, and provider compatibility guidance.
 - README quick start now includes a one-command demo and clearer provider compatibility notes.
+- README provider compatibility section updated to include OpenAI-format providers.
 
 ## [0.1.0] - 2026-04-01
 

--- a/README.md
+++ b/README.md
@@ -226,17 +226,46 @@ oh -p "Fix the bug" --output-format stream-json
 
 ## 🔌 Provider Compatibility
 
-OpenHarness currently detects and adapts to a small set of provider profiles in code. The table below is intentionally conservative and reflects the profiles implemented in `src/openharness/api/provider.py`.
+OpenHarness supports two API formats: **Anthropic** (default) and **OpenAI-compatible** (`--api-format openai`). The OpenAI format covers a wide range of providers.
 
-| Provider profile | Detection signal | Auth kind | Voice mode | Notes |
-|------------------|------------------|-----------|------------|-------|
-| **Anthropic** | Default when no custom `ANTHROPIC_BASE_URL` is set | API key | Not wired in current build | Default Claude-oriented setup |
-| **Moonshot / Kimi** | `ANTHROPIC_BASE_URL` contains `moonshot` or model starts with `kimi` | API key | Not wired in current build | Works through an Anthropic-compatible endpoint |
-| **Vertex-compatible** | Base URL contains `vertex` or `aiplatform` | GCP | Not wired in current build | Good fit for Anthropic-style gateways on Vertex |
-| **Bedrock-compatible** | Base URL contains `bedrock` | AWS | Not wired in current build | Intended for Bedrock-style deployments |
-| **Generic Anthropic-compatible** | Any other explicit `ANTHROPIC_BASE_URL` | API key | Not wired in current build | Useful for proxies and internal gateways |
+### Anthropic Format (default)
 
-If you are evaluating cross-provider workflows or want a concrete demo path, start with Anthropic or the Kimi example above, then compare behavior against your own compatible endpoint.
+| Provider profile | Detection signal | Notes |
+|------------------|------------------|-------|
+| **Anthropic** | Default when no custom `ANTHROPIC_BASE_URL` is set | Default Claude-oriented setup |
+| **Moonshot / Kimi** | `ANTHROPIC_BASE_URL` contains `moonshot` or model starts with `kimi` | Anthropic-compatible endpoint |
+| **Vertex-compatible** | Base URL contains `vertex` or `aiplatform` | Anthropic-style gateways on Vertex |
+| **Bedrock-compatible** | Base URL contains `bedrock` | Bedrock-style deployments |
+| **Generic Anthropic-compatible** | Any other explicit `ANTHROPIC_BASE_URL` | Proxies and internal gateways |
+
+### OpenAI Format (`--api-format openai`)
+
+Any provider implementing the OpenAI `/v1/chat/completions` API works out of the box:
+
+| Provider | Base URL | Example models |
+|----------|----------|----------------|
+| **Alibaba DashScope** | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen3.5-flash`, `qwen3-max`, `deepseek-r1` |
+| **DeepSeek** | `https://api.deepseek.com` | `deepseek-chat`, `deepseek-reasoner` |
+| **OpenAI** | `https://api.openai.com/v1` | `gpt-4o`, `gpt-4o-mini` |
+| **GitHub Models** | `https://models.inference.ai.azure.com` | `gpt-4o`, `Meta-Llama-3.1-405B-Instruct` |
+| **SiliconFlow** | `https://api.siliconflow.cn/v1` | `deepseek-ai/DeepSeek-V3` |
+| **Groq** | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` |
+| **Ollama (local)** | `http://localhost:11434/v1` | Any local model |
+
+```bash
+# Example: use DashScope
+uv run oh --api-format openai \
+  --base-url "https://dashscope.aliyuncs.com/compatible-mode/v1" \
+  --api-key "sk-xxx" \
+  --model "qwen3.5-flash"
+
+# Or via environment variables
+export OPENHARNESS_API_FORMAT=openai
+export OPENAI_API_KEY=sk-xxx
+export OPENHARNESS_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+export OPENHARNESS_MODEL=qwen3.5-flash
+uv run oh
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 
 dependencies = [
     "anthropic>=0.40.0",
+    "openai>=1.0.0",
     "rich>=13.0.0",
     "prompt-toolkit>=3.0.0",
     "textual>=0.80.0",

--- a/src/openharness/api/__init__.py
+++ b/src/openharness/api/__init__.py
@@ -2,11 +2,13 @@
 
 from openharness.api.client import AnthropicApiClient
 from openharness.api.errors import OpenHarnessApiError
+from openharness.api.openai_client import OpenAICompatibleClient
 from openharness.api.provider import ProviderInfo, auth_status, detect_provider
 from openharness.api.usage import UsageSnapshot
 
 __all__ = [
     "AnthropicApiClient",
+    "OpenAICompatibleClient",
     "OpenHarnessApiError",
     "ProviderInfo",
     "UsageSnapshot",

--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -1,0 +1,311 @@
+"""OpenAI-compatible API client for providers like Alibaba DashScope, GitHub Models, etc."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator
+
+from openai import AsyncOpenAI
+
+from openharness.api.client import (
+    ApiMessageCompleteEvent,
+    ApiMessageRequest,
+    ApiStreamEvent,
+    ApiTextDeltaEvent,
+)
+from openharness.api.errors import (
+    AuthenticationFailure,
+    OpenHarnessApiError,
+    RateLimitFailure,
+    RequestFailure,
+)
+from openharness.api.usage import UsageSnapshot
+from openharness.engine.messages import (
+    ConversationMessage,
+    ContentBlock,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+log = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+BASE_DELAY = 1.0
+MAX_DELAY = 30.0
+
+
+def _convert_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert Anthropic tool schemas to OpenAI function-calling format.
+
+    Anthropic format:
+        {"name": "...", "description": "...", "input_schema": {...}}
+    OpenAI format:
+        {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
+    """
+    result = []
+    for tool in tools:
+        result.append({
+            "type": "function",
+            "function": {
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "parameters": tool.get("input_schema", {}),
+            },
+        })
+    return result
+
+
+def _convert_messages_to_openai(
+    messages: list[ConversationMessage],
+    system_prompt: str | None,
+) -> list[dict[str, Any]]:
+    """Convert Anthropic-style messages to OpenAI chat format.
+
+    Key differences:
+    - Anthropic: system prompt is a separate parameter
+    - OpenAI: system prompt is a message with role="system"
+    - Anthropic: tool_use / tool_result are content blocks
+    - OpenAI: tool_calls on assistant message, tool results are separate messages
+    """
+    openai_messages: list[dict[str, Any]] = []
+
+    if system_prompt:
+        openai_messages.append({"role": "system", "content": system_prompt})
+
+    for msg in messages:
+        if msg.role == "assistant":
+            openai_msg = _convert_assistant_message(msg)
+            openai_messages.append(openai_msg)
+        elif msg.role == "user":
+            # User messages may contain text or tool_result blocks
+            tool_results = [b for b in msg.content if isinstance(b, ToolResultBlock)]
+            text_blocks = [b for b in msg.content if isinstance(b, TextBlock)]
+
+            if tool_results:
+                # Each tool result becomes a separate message with role="tool"
+                for tr in tool_results:
+                    openai_messages.append({
+                        "role": "tool",
+                        "tool_call_id": tr.tool_use_id,
+                        "content": tr.content,
+                    })
+            if text_blocks:
+                text = "".join(b.text for b in text_blocks)
+                if text.strip():
+                    openai_messages.append({"role": "user", "content": text})
+            if not tool_results and not text_blocks:
+                # Empty user message (shouldn't happen, but handle gracefully)
+                openai_messages.append({"role": "user", "content": ""})
+
+    return openai_messages
+
+
+def _convert_assistant_message(msg: ConversationMessage) -> dict[str, Any]:
+    """Convert an assistant ConversationMessage to OpenAI format."""
+    text_parts = [b.text for b in msg.content if isinstance(b, TextBlock)]
+    tool_uses = [b for b in msg.content if isinstance(b, ToolUseBlock)]
+
+    openai_msg: dict[str, Any] = {"role": "assistant"}
+
+    content = "".join(text_parts)
+    openai_msg["content"] = content if content else None
+
+    if tool_uses:
+        openai_msg["tool_calls"] = [
+            {
+                "id": tu.id,
+                "type": "function",
+                "function": {
+                    "name": tu.name,
+                    "arguments": json.dumps(tu.input),
+                },
+            }
+            for tu in tool_uses
+        ]
+
+    return openai_msg
+
+
+def _parse_assistant_response(response: Any) -> ConversationMessage:
+    """Parse an OpenAI ChatCompletion response into a ConversationMessage."""
+    choice = response.choices[0]
+    message = choice.message
+    content: list[ContentBlock] = []
+
+    if message.content:
+        content.append(TextBlock(text=message.content))
+
+    if message.tool_calls:
+        for tc in message.tool_calls:
+            try:
+                args = json.loads(tc.function.arguments)
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            content.append(ToolUseBlock(
+                id=tc.id,
+                name=tc.function.name,
+                input=args,
+            ))
+
+    return ConversationMessage(role="assistant", content=content)
+
+
+class OpenAICompatibleClient:
+    """Client for OpenAI-compatible APIs (DashScope, GitHub Models, etc.).
+
+    Implements the same SupportsStreamingMessages protocol as AnthropicApiClient
+    so it can be used as a drop-in replacement in the agent loop.
+    """
+
+    def __init__(self, api_key: str, *, base_url: str | None = None) -> None:
+        kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = AsyncOpenAI(**kwargs)
+
+    async def stream_message(self, request: ApiMessageRequest) -> AsyncIterator[ApiStreamEvent]:
+        """Yield text deltas and the final message, matching the Anthropic client interface."""
+        last_error: Exception | None = None
+
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                async for event in self._stream_once(request):
+                    yield event
+                return
+            except OpenHarnessApiError:
+                raise
+            except Exception as exc:
+                last_error = exc
+                if attempt >= MAX_RETRIES or not self._is_retryable(exc):
+                    raise self._translate_error(exc) from exc
+
+                delay = min(BASE_DELAY * (2 ** attempt), MAX_DELAY)
+                log.warning(
+                    "OpenAI API request failed (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1, MAX_RETRIES + 1, delay, exc,
+                )
+                await asyncio.sleep(delay)
+
+        if last_error is not None:
+            raise self._translate_error(last_error) from last_error
+
+    async def _stream_once(self, request: ApiMessageRequest) -> AsyncIterator[ApiStreamEvent]:
+        """Single attempt: stream an OpenAI chat completion."""
+        openai_messages = _convert_messages_to_openai(request.messages, request.system_prompt)
+        openai_tools = _convert_tools_to_openai(request.tools) if request.tools else None
+
+        params: dict[str, Any] = {
+            "model": request.model,
+            "messages": openai_messages,
+            "max_tokens": request.max_tokens,
+            "stream": True,
+        }
+        if openai_tools:
+            params["tools"] = openai_tools
+
+        # Collect full response while streaming text deltas
+        collected_content = ""
+        collected_tool_calls: dict[int, dict[str, Any]] = {}
+        finish_reason: str | None = None
+        usage_data: dict[str, int] = {}
+
+        stream = await self._client.chat.completions.create(**params)
+        async for chunk in stream:
+            if not chunk.choices:
+                # Usage-only chunk (some providers send this at the end)
+                if chunk.usage:
+                    usage_data = {
+                        "input_tokens": chunk.usage.prompt_tokens or 0,
+                        "output_tokens": chunk.usage.completion_tokens or 0,
+                    }
+                continue
+
+            delta = chunk.choices[0].delta
+            chunk_finish = chunk.choices[0].finish_reason
+
+            if chunk_finish:
+                finish_reason = chunk_finish
+
+            # Stream text content
+            if delta.content:
+                collected_content += delta.content
+                yield ApiTextDeltaEvent(text=delta.content)
+
+            # Accumulate tool calls
+            if delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in collected_tool_calls:
+                        collected_tool_calls[idx] = {
+                            "id": tc_delta.id or "",
+                            "name": "",
+                            "arguments": "",
+                        }
+                    entry = collected_tool_calls[idx]
+                    if tc_delta.id:
+                        entry["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            entry["name"] = tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            entry["arguments"] += tc_delta.function.arguments
+
+            # Usage in chunk (if provider sends it)
+            if chunk.usage:
+                usage_data = {
+                    "input_tokens": chunk.usage.prompt_tokens or 0,
+                    "output_tokens": chunk.usage.completion_tokens or 0,
+                }
+
+        # Build the final ConversationMessage
+        content: list[ContentBlock] = []
+        if collected_content:
+            content.append(TextBlock(text=collected_content))
+
+        for _idx in sorted(collected_tool_calls.keys()):
+            tc = collected_tool_calls[_idx]
+            # Skip phantom/empty tool calls that some providers send
+            if not tc["name"]:
+                continue
+            try:
+                args = json.loads(tc["arguments"])
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            content.append(ToolUseBlock(
+                id=tc["id"],
+                name=tc["name"],
+                input=args,
+            ))
+
+        final_message = ConversationMessage(role="assistant", content=content)
+
+        yield ApiMessageCompleteEvent(
+            message=final_message,
+            usage=UsageSnapshot(
+                input_tokens=usage_data.get("input_tokens", 0),
+                output_tokens=usage_data.get("output_tokens", 0),
+            ),
+            stop_reason=finish_reason,
+        )
+
+    @staticmethod
+    def _is_retryable(exc: Exception) -> bool:
+        status = getattr(exc, "status_code", None)
+        if status and status in {429, 500, 502, 503}:
+            return True
+        if isinstance(exc, (ConnectionError, TimeoutError, OSError)):
+            return True
+        return False
+
+    @staticmethod
+    def _translate_error(exc: Exception) -> OpenHarnessApiError:
+        status = getattr(exc, "status_code", None)
+        msg = str(exc)
+        if status == 401 or status == 403:
+            return AuthenticationFailure(msg)
+        if status == 429:
+            return RateLimitFailure(msg)
+        return RequestFailure(msg)

--- a/src/openharness/api/provider.py
+++ b/src/openharness/api/provider.py
@@ -28,6 +28,20 @@ def detect_provider(settings: Settings) -> ProviderInfo:
             voice_supported=False,
             voice_reason="voice mode requires a Claude.ai-style authenticated voice backend",
         )
+    if "dashscope" in base_url or model.startswith("qwen"):
+        return ProviderInfo(
+            name="dashscope-openai-compatible",
+            auth_kind="api_key",
+            voice_supported=False,
+            voice_reason="voice mode is not supported for DashScope providers",
+        )
+    if "models.inference.ai.azure.com" in base_url or "github" in base_url:
+        return ProviderInfo(
+            name="github-models-openai-compatible",
+            auth_kind="api_key",
+            voice_supported=False,
+            voice_reason="voice mode is not supported for GitHub Models",
+        )
     if "bedrock" in base_url:
         return ProviderInfo(
             name="bedrock-compatible",

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -305,6 +305,12 @@ def main(
         help="Minimal mode: skip hooks, plugins, MCP, and auto-discovery",
         rich_help_panel="System & Context",
     ),
+    api_format: str | None = typer.Option(
+        None,
+        "--api-format",
+        help="API format: 'anthropic' (default) or 'openai' (for DashScope, GitHub Models, etc.)",
+        rich_help_panel="System & Context",
+    ),
     # --- Advanced ---
     debug: bool = typer.Option(
         False,
@@ -358,6 +364,7 @@ def main(
                 system_prompt=system_prompt,
                 append_system_prompt=append_system_prompt,
                 api_key=api_key,
+                api_format=api_format,
                 permission_mode=permission_mode,
                 max_turns=max_turns,
             )
@@ -373,5 +380,6 @@ def main(
             base_url=base_url,
             system_prompt=system_prompt,
             api_key=api_key,
+            api_format=api_format,
         )
     )

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -54,6 +54,7 @@ class Settings(BaseModel):
     model: str = "claude-sonnet-4-20250514"
     max_tokens: int = 16384
     base_url: str | None = None
+    api_format: str = "anthropic"  # "anthropic" or "openai"
 
     # Behavior
     system_prompt: str | None = None
@@ -85,9 +86,15 @@ class Settings(BaseModel):
         if env_key:
             return env_key
 
+        # Also check OPENAI_API_KEY for openai-format providers
+        openai_key = os.environ.get("OPENAI_API_KEY", "")
+        if openai_key:
+            return openai_key
+
         raise ValueError(
-            "No API key found. Set ANTHROPIC_API_KEY environment variable "
-            "or configure api_key in ~/.openharness/settings.json"
+            "No API key found. Set ANTHROPIC_API_KEY (or OPENAI_API_KEY for openai-format "
+            "providers) environment variable, or configure api_key in "
+            "~/.openharness/settings.json"
         )
 
     def merge_cli_overrides(self, **overrides: Any) -> Settings:
@@ -111,9 +118,13 @@ def _apply_env_overrides(settings: Settings) -> Settings:
     if max_tokens:
         updates["max_tokens"] = int(max_tokens)
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
     if api_key:
         updates["api_key"] = api_key
+
+    api_format = os.environ.get("OPENHARNESS_API_FORMAT")
+    if api_format:
+        updates["api_format"] = api_format
 
     if not updates:
         return settings

--- a/src/openharness/ui/app.py
+++ b/src/openharness/ui/app.py
@@ -20,6 +20,7 @@ async def run_repl(
     base_url: str | None = None,
     system_prompt: str | None = None,
     api_key: str | None = None,
+    api_format: str | None = None,
     api_client: SupportsStreamingMessages | None = None,
     backend_only: bool = False,
 ) -> None:
@@ -31,6 +32,7 @@ async def run_repl(
             base_url=base_url,
             system_prompt=system_prompt,
             api_key=api_key,
+            api_format=api_format,
             api_client=api_client,
         )
         return
@@ -57,6 +59,7 @@ async def run_print_mode(
     system_prompt: str | None = None,
     append_system_prompt: str | None = None,
     api_key: str | None = None,
+    api_format: str | None = None,
     api_client: SupportsStreamingMessages | None = None,
     permission_mode: str | None = None,
     max_turns: int | None = None,
@@ -81,6 +84,7 @@ async def run_print_mode(
         base_url=base_url,
         system_prompt=system_prompt,
         api_key=api_key,
+        api_format=api_format,
         api_client=api_client,
         permission_prompt=_noop_permission,
         ask_user_prompt=_noop_ask,

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -34,6 +34,7 @@ class BackendHostConfig:
     base_url: str | None = None
     system_prompt: str | None = None
     api_key: str | None = None
+    api_format: str | None = None
     api_client: SupportsStreamingMessages | None = None
 
 
@@ -56,6 +57,7 @@ class ReactBackendHost:
             base_url=self._config.base_url,
             system_prompt=self._config.system_prompt,
             api_key=self._config.api_key,
+            api_format=self._config.api_format,
             api_client=self._config.api_client,
             permission_prompt=self._ask_permission,
             ask_user_prompt=self._ask_question,
@@ -283,6 +285,7 @@ async def run_backend_host(
     base_url: str | None = None,
     system_prompt: str | None = None,
     api_key: str | None = None,
+    api_format: str | None = None,
     cwd: str | None = None,
     api_client: SupportsStreamingMessages | None = None,
 ) -> int:
@@ -295,6 +298,7 @@ async def run_backend_host(
             base_url=base_url,
             system_prompt=system_prompt,
             api_key=api_key,
+            api_format=api_format,
             api_client=api_client,
         )
     )

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from openharness.api.client import AnthropicApiClient, SupportsStreamingMessages
+from openharness.api.openai_client import OpenAICompatibleClient
 from openharness.api.provider import auth_status, detect_provider
 from openharness.bridge import get_bridge_manager
 from openharness.commands import CommandContext, CommandResult, create_default_command_registry
@@ -93,6 +94,7 @@ async def build_runtime(
     base_url: str | None = None,
     system_prompt: str | None = None,
     api_key: str | None = None,
+    api_format: str | None = None,
     api_client: SupportsStreamingMessages | None = None,
     permission_prompt: PermissionPrompt | None = None,
     ask_user_prompt: AskUserPrompt | None = None,
@@ -103,13 +105,22 @@ async def build_runtime(
         base_url=base_url,
         system_prompt=system_prompt,
         api_key=api_key,
+        api_format=api_format,
     )
     cwd = str(Path.cwd())
     plugins = load_plugins(settings, cwd)
-    resolved_api_client = api_client or AnthropicApiClient(
-        api_key=settings.resolve_api_key(),
-        base_url=settings.base_url,
-    )
+    if api_client:
+        resolved_api_client = api_client
+    elif settings.api_format == "openai":
+        resolved_api_client = OpenAICompatibleClient(
+            api_key=settings.resolve_api_key(),
+            base_url=settings.base_url,
+        )
+    else:
+        resolved_api_client = AnthropicApiClient(
+            api_key=settings.resolve_api_key(),
+            base_url=settings.base_url,
+        )
     mcp_manager = McpClientManager(load_mcp_server_configs(settings, plugins))
     await mcp_manager.connect_all()
     tool_registry = create_default_tool_registry(mcp_manager)

--- a/tests/test_api/test_openai_client.py
+++ b/tests/test_api/test_openai_client.py
@@ -1,0 +1,169 @@
+"""Tests for the OpenAI-compatible API client."""
+
+from __future__ import annotations
+
+import json
+
+from openharness.api.openai_client import (
+    _convert_messages_to_openai,
+    _convert_tools_to_openai,
+)
+from openharness.engine.messages import (
+    ConversationMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+
+class TestConvertToolsToOpenai:
+    """Test Anthropic → OpenAI tool schema conversion."""
+
+    def test_basic_tool(self):
+        anthropic_tools = [
+            {
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path"},
+                    },
+                    "required": ["path"],
+                },
+            }
+        ]
+        result = _convert_tools_to_openai(anthropic_tools)
+        assert len(result) == 1
+        assert result[0]["type"] == "function"
+        assert result[0]["function"]["name"] == "read_file"
+        assert result[0]["function"]["description"] == "Read a file"
+        assert result[0]["function"]["parameters"]["properties"]["path"]["type"] == "string"
+
+    def test_empty_tools(self):
+        assert _convert_tools_to_openai([]) == []
+
+    def test_multiple_tools(self):
+        tools = [
+            {"name": "tool_a", "description": "A", "input_schema": {}},
+            {"name": "tool_b", "description": "B", "input_schema": {}},
+        ]
+        result = _convert_tools_to_openai(tools)
+        assert len(result) == 2
+        assert result[0]["function"]["name"] == "tool_a"
+        assert result[1]["function"]["name"] == "tool_b"
+
+
+class TestConvertMessagesToOpenai:
+    """Test Anthropic → OpenAI message format conversion."""
+
+    def test_system_prompt(self):
+        messages: list[ConversationMessage] = []
+        result = _convert_messages_to_openai(messages, "You are helpful.")
+        assert len(result) == 1
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are helpful."
+
+    def test_no_system_prompt(self):
+        messages = [ConversationMessage.from_user_text("hi")]
+        result = _convert_messages_to_openai(messages, None)
+        assert result[0]["role"] == "user"
+        assert result[0]["content"] == "hi"
+
+    def test_user_text_message(self):
+        messages = [ConversationMessage.from_user_text("hello")]
+        result = _convert_messages_to_openai(messages, None)
+        assert len(result) == 1
+        assert result[0] == {"role": "user", "content": "hello"}
+
+    def test_assistant_text_message(self):
+        msg = ConversationMessage(
+            role="assistant", content=[TextBlock(text="I'll help you.")]
+        )
+        result = _convert_messages_to_openai([msg], None)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "I'll help you."
+        assert "tool_calls" not in result[0]
+
+    def test_assistant_with_tool_calls(self):
+        msg = ConversationMessage(
+            role="assistant",
+            content=[
+                TextBlock(text="Let me read that file."),
+                ToolUseBlock(id="call_1", name="read_file", input={"path": "/tmp/x"}),
+            ],
+        )
+        result = _convert_messages_to_openai([msg], None)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "Let me read that file."
+        assert len(result[0]["tool_calls"]) == 1
+        tc = result[0]["tool_calls"][0]
+        assert tc["id"] == "call_1"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "read_file"
+        assert json.loads(tc["function"]["arguments"]) == {"path": "/tmp/x"}
+
+    def test_tool_result_messages(self):
+        # User message containing tool results
+        msg = ConversationMessage(
+            role="user",
+            content=[
+                ToolResultBlock(
+                    tool_use_id="call_1", content="file contents here", is_error=False
+                ),
+            ],
+        )
+        result = _convert_messages_to_openai([msg], None)
+        assert len(result) == 1
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "call_1"
+        assert result[0]["content"] == "file contents here"
+
+    def test_full_conversation_round_trip(self):
+        """Test a complete user → assistant(tool_call) → user(tool_result) → assistant flow."""
+        messages = [
+            ConversationMessage.from_user_text("Read /tmp/test.txt"),
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    TextBlock(text="I'll read that."),
+                    ToolUseBlock(
+                        id="call_abc", name="read_file", input={"path": "/tmp/test.txt"}
+                    ),
+                ],
+            ),
+            ConversationMessage(
+                role="user",
+                content=[
+                    ToolResultBlock(
+                        tool_use_id="call_abc", content="hello world", is_error=False
+                    )
+                ],
+            ),
+            ConversationMessage(
+                role="assistant",
+                content=[TextBlock(text="The file contains: hello world")],
+            ),
+        ]
+        result = _convert_messages_to_openai(messages, "Be helpful")
+        assert result[0] == {"role": "system", "content": "Be helpful"}
+        assert result[1] == {"role": "user", "content": "Read /tmp/test.txt"}
+        assert result[2]["role"] == "assistant"
+        assert len(result[2]["tool_calls"]) == 1
+        assert result[3]["role"] == "tool"
+        assert result[3]["tool_call_id"] == "call_abc"
+        assert result[4]["role"] == "assistant"
+        assert result[4]["content"] == "The file contains: hello world"
+
+    def test_multiple_tool_results(self):
+        msg = ConversationMessage(
+            role="user",
+            content=[
+                ToolResultBlock(tool_use_id="c1", content="result1", is_error=False),
+                ToolResultBlock(tool_use_id="c2", content="result2", is_error=True),
+            ],
+        )
+        result = _convert_messages_to_openai([msg], None)
+        assert len(result) == 2
+        assert result[0]["tool_call_id"] == "c1"
+        assert result[1]["tool_call_id"] == "c2"


### PR DESCRIPTION
## Summary

- **Problem**: OpenHarness only supports Anthropic API format, making it unusable with popular providers like Alibaba DashScope, DeepSeek, OpenAI, GitHub Models, Groq, Ollama, etc.
- **Solution**: Add `OpenAICompatibleClient` that implements the existing `SupportsStreamingMessages` protocol, enabling any provider using the OpenAI `/v1/chat/completions` format as a drop-in replacement.

### Changes

**New files:**
- `src/openharness/api/openai_client.py` — OpenAI-compatible client with streaming, tool calling, retry logic, and phantom tool call filtering
- `tests/test_api/test_openai_client.py` — 11 unit tests for format conversion functions

**Modified files:**
- `pyproject.toml` — Added `openai>=1.0.0` dependency
- `src/openharness/api/__init__.py` — Export `OpenAICompatibleClient`
- `src/openharness/api/provider.py` — Detect DashScope/Qwen and GitHub Models providers
- `src/openharness/config/settings.py` — `api_format` field, `OPENAI_API_KEY` fallback, `OPENHARNESS_API_FORMAT` env var
- `src/openharness/cli.py` — `--api-format` CLI option
- `src/openharness/ui/runtime.py` — Client selection based on `api_format`
- `src/openharness/ui/app.py` — Pass through `api_format`
- `src/openharness/ui/backend_host.py` — Pass through `api_format`
- `CHANGELOG.md` — Added/Changed entries
- `README.md` — Updated provider compatibility section with OpenAI-format providers table and usage examples

### Usage

```bash
uv run oh --api-format openai \
  --base-url "https://dashscope.aliyuncs.com/compatible-mode/v1" \
  --api-key "sk-xxx" \
  --model "qwen3.5-flash"
```

### Design

The key abstraction is the `SupportsStreamingMessages` Protocol — the new client implements the same `stream_message()` interface, so the engine, tools, and UI layers require zero changes.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q` (128 passed + 11 new tests)
- [x] `cd frontend/terminal && npx tsc --noEmit`
- [x] Tested with Alibaba DashScope `qwen3.5-flash` — confirmed working

## Notes

- Tested providers: DashScope (qwen3.5-flash)
- Should work with any OpenAI-compatible provider (DeepSeek, Groq, Ollama, etc.) but not yet tested end-to-end with all of them