### PR TITLE
fix(tools): cap read_file line limit to 10

### DIFF
--- a/src/openharness/tools/file_read_tool.py
+++ b/src/openharness/tools/file_read_tool.py
@@ -14,7 +14,12 @@ class FileReadToolInput(BaseModel):
 
     path: str = Field(description="Path of the file to read")
     offset: int = Field(default=0, ge=0, description="Zero-based starting line")
-    limit: int = Field(default=200, ge=1, le=2000, description="Number of lines to return")
+    limit: int = Field(
+        default=10,
+        ge=1,
+        le=10,
+        description="Number of lines to return (max 10)",
+    )
 
 
 class FileReadTool(BaseTool):


### PR DESCRIPTION
Background: when agent loops are high and read_file gets called with large limits (e.g. 260 lines), sessions can become slow and feel stuck.

Change: hard-cap read_file 'limit' to max 10 lines (default 10) via tool schema.

Test: pytest -q (338 passed, 5 skipped, 1 xfailed).