### PR TITLE
fix(permissions): warn and skip path rules with invalid pattern fields

### DIFF
--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import fnmatch
+import logging
 from dataclasses import dataclass
 
 from openharness.config.settings import PermissionSettings
 from openharness.permissions.modes import PermissionMode
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -36,8 +39,13 @@ class PermissionChecker:
         for rule in getattr(settings, "path_rules", []):
             pattern = getattr(rule, "pattern", None) or (rule.get("pattern") if isinstance(rule, dict) else None)
             allow = getattr(rule, "allow", True) if not isinstance(rule, dict) else rule.get("allow", True)
-            if pattern:
-                self._path_rules.append(PathRule(pattern=pattern, allow=allow))
+            if isinstance(pattern, str) and pattern.strip():
+                self._path_rules.append(PathRule(pattern=pattern.strip(), allow=allow))
+            else:
+                log.warning(
+                    "Skipping path rule with missing, empty, or non-string 'pattern' field: %r",
+                    rule,
+                )
 
     def evaluate(
         self,

--- a/tests/test_permissions/test_checker.py
+++ b/tests/test_permissions/test_checker.py
@@ -1,6 +1,10 @@
 """Tests for permission decisions."""
 
-from openharness.config.settings import PermissionSettings
+import logging
+
+import pytest
+
+from openharness.config.settings import PathRuleConfig, PermissionSettings
 from openharness.permissions import PermissionChecker, PermissionMode
 
 
@@ -29,3 +33,83 @@ def test_full_auto_allows_mutating_tools():
     checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
     decision = checker.evaluate("bash", is_read_only=False)
     assert decision.allowed is True
+
+
+# --- path_rules parsing tests ---
+
+
+def _settings_with_rules(*rules) -> PermissionSettings:
+    """Build a PermissionSettings with the given path_rule objects bypassing validation."""
+    return PermissionSettings.model_construct(
+        mode=PermissionMode.FULL_AUTO,
+        allowed_tools=[],
+        denied_tools=[],
+        denied_commands=[],
+        path_rules=list(rules),
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_rule",
+    [
+        PathRuleConfig.model_construct(allow=False),                  # pattern attribute missing
+        PathRuleConfig.model_construct(pattern="", allow=False),      # pattern empty string
+        PathRuleConfig.model_construct(pattern="   ", allow=False),   # pattern whitespace-only
+        PathRuleConfig.model_construct(pattern=42, allow=False),      # pattern non-string
+        PathRuleConfig.model_construct(pattern=None, allow=False),    # pattern None
+    ],
+    ids=["missing", "empty", "whitespace-only", "non-string", "none"],
+)
+def test_invalid_pattern_rule_is_skipped_and_warns(bad_rule, caplog):
+    """Rules with missing, empty, or non-string patterns are skipped with a warning."""
+    settings = _settings_with_rules(bad_rule)
+    with caplog.at_level(logging.WARNING, logger="openharness.permissions.checker"):
+        checker = PermissionChecker(settings)
+
+    assert checker._path_rules == []
+    assert "Skipping path rule" in caplog.text
+
+
+def test_valid_deny_rule_blocks_matching_path():
+    """A valid deny rule prevents access to a matching file path."""
+    rule = PathRuleConfig(pattern="/etc/*", allow=False)
+    settings = _settings_with_rules(rule)
+    checker = PermissionChecker(settings)
+
+    decision = checker.evaluate("read_file", is_read_only=True, file_path="/etc/passwd")
+    assert decision.allowed is False
+    assert "/etc/passwd" in decision.reason
+
+
+def test_valid_deny_rule_does_not_block_non_matching_path():
+    """A deny rule does not affect paths that don't match the pattern."""
+    rule = PathRuleConfig(pattern="/etc/*", allow=False)
+    settings = _settings_with_rules(rule)
+    checker = PermissionChecker(settings)
+
+    decision = checker.evaluate("read_file", is_read_only=True, file_path="/home/user/file.txt")
+    assert decision.allowed is True
+
+
+def test_valid_allow_rule_is_added():
+    """A rule with allow=True is accepted and stored without warnings."""
+    rule = PathRuleConfig(pattern="/data/*", allow=True)
+    settings = _settings_with_rules(rule)
+    checker = PermissionChecker(settings)
+
+    assert len(checker._path_rules) == 1
+    assert checker._path_rules[0].pattern == "/data/*"
+    assert checker._path_rules[0].allow is True
+
+
+def test_pattern_with_surrounding_whitespace_is_stripped():
+    """A pattern with leading/trailing whitespace is accepted with whitespace stripped."""
+    rule = PathRuleConfig.model_construct(pattern="  /etc/*  ", allow=False)
+    settings = _settings_with_rules(rule)
+    checker = PermissionChecker(settings)
+
+    assert len(checker._path_rules) == 1
+    assert checker._path_rules[0].pattern == "/etc/*"
+
+    decision = checker.evaluate("read_file", is_read_only=True, file_path="/etc/passwd")
+    assert decision.allowed is False


### PR DESCRIPTION
## Summary
- **What problem does this PR solve?**
  Two silent failure modes existed in `PermissionChecker` path rule parsing:
  1. A rule with an empty or whitespace-only `pattern` was accepted by Pydantic (valid `str`)
     and silently stored, later matching nothing with no indication of misconfiguration.
  2. A rule with a non-string `pattern` constructed programmatically (e.g. via `model_construct()`)
     would be stored and cause `fnmatch.fnmatch` to raise a `TypeError` at evaluation time.

- **What changed?**
  - Pattern validation tightened: only a non-empty `str` (after `strip()`) is accepted
  - Invalid rules now emit a `log.warning()` instead of being silently dropped or stored
  - Whitespace is stripped from valid patterns before storing
  - Regression tests added covering empty, whitespace-only, `None`, non-string, and
    padded-whitespace pattern cases

## Validation
- [ ] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes
- Related issue: none
- Follow-up work: none — note that typos in `settings.json` keys (e.g. `"patern"` instead
  of `"pattern"`) are already caught by Pydantic at load time and do not require handling here