### PR TITLE
fix(ui): handle EIO crashes in Ink TUI and wire up --debug logging

### DIFF
--- a/frontend/terminal/src/index.tsx
+++ b/frontend/terminal/src/index.tsx
@@ -6,6 +6,37 @@ import tty from 'node:tty';
 import {App} from './App.js';
 import type {FrontendConfig} from './types.js';
 
+// Guard against EIO crashes in both stdin reads and setRawMode calls.
+// Ink's React reconciler calls setRawMode during mount/unmount which can
+// throw EIO in certain terminal environments (SSH, tmux, Docker).
+process.stdin.on('error', (err: NodeJS.ErrnoException) => {
+	if (err.code === 'EIO' || err.code === 'EAGAIN') {
+		process.exit(1);
+	}
+	throw err;
+});
+
+if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+	const origSetRawMode = process.stdin.setRawMode.bind(process.stdin);
+	process.stdin.setRawMode = (mode: boolean) => {
+		try {
+			return origSetRawMode(mode);
+		} catch (err: any) {
+			if (err?.code === 'EIO' || err?.code === 'EAGAIN') {
+				process.exit(1);
+			}
+			throw err;
+		}
+	};
+}
+
+process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
+	if (err.code === 'EIO' || err.code === 'EAGAIN') {
+		process.exit(1);
+	}
+	throw err;
+});
+
 const config = JSON.parse(process.env.OPENHARNESS_FRONTEND_CONFIG ?? '{}') as FrontendConfig;
 
 // Restore terminal cursor visibility on exit (Ink hides it by default)

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -827,6 +828,18 @@ def main(
         return
 
     import asyncio
+    import logging
+
+    if debug:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+            stream=sys.stderr,
+        )
+        logging.getLogger("openharness").setLevel(logging.DEBUG)
+    elif os.environ.get("OPENHARNESS_LOG_LEVEL"):
+        lvl = getattr(logging, os.environ["OPENHARNESS_LOG_LEVEL"].upper(), logging.WARNING)
+        logging.basicConfig(level=lvl, format="%(asctime)s [%(name)s] %(levelname)s %(message)s", stream=sys.stderr)
 
     if dangerously_skip_permissions:
         permission_mode = "full_auto"

--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import AsyncIterator, Awaitable, Callable
+
+log = logging.getLogger(__name__)
 
 from openharness.api.client import (
     ApiMessageCompleteEvent,
@@ -194,8 +198,11 @@ async def _execute_tool_call(
                 is_error=True,
             )
 
+    log.debug("tool_call start: %s id=%s", tool_name, tool_use_id)
+
     tool = context.tool_registry.get(tool_name)
     if tool is None:
+        log.warning("unknown tool: %s", tool_name)
         return ToolResultBlock(
             tool_use_id=tool_use_id,
             content=f"Unknown tool: {tool_name}",
@@ -205,6 +212,7 @@ async def _execute_tool_call(
     try:
         parsed_input = tool.input_model.model_validate(tool_input)
     except Exception as exc:
+        log.warning("invalid input for %s: %s", tool_name, exc)
         return ToolResultBlock(
             tool_use_id=tool_use_id,
             content=f"Invalid input for {tool_name}: {exc}",
@@ -215,6 +223,8 @@ async def _execute_tool_call(
     # consistently across built-in tools that use either `file_path` or `path`.
     _file_path = _resolve_permission_file_path(context.cwd, tool_input, parsed_input)
     _command = _extract_permission_command(tool_input, parsed_input)
+    log.debug("permission check: %s read_only=%s path=%s cmd=%s",
+              tool_name, tool.is_read_only(parsed_input), _file_path, _command and _command[:80])
     decision = context.permission_checker.evaluate(
         tool_name,
         is_read_only=tool.is_read_only(parsed_input),
@@ -223,20 +233,25 @@ async def _execute_tool_call(
     )
     if not decision.allowed:
         if decision.requires_confirmation and context.permission_prompt is not None:
+            log.debug("permission prompt for %s: %s", tool_name, decision.reason)
             confirmed = await context.permission_prompt(tool_name, decision.reason)
             if not confirmed:
+                log.debug("permission denied by user for %s", tool_name)
                 return ToolResultBlock(
                     tool_use_id=tool_use_id,
                     content=f"Permission denied for {tool_name}",
                     is_error=True,
                 )
         else:
+            log.debug("permission blocked for %s: %s", tool_name, decision.reason)
             return ToolResultBlock(
                 tool_use_id=tool_use_id,
                 content=decision.reason or f"Permission denied for {tool_name}",
                 is_error=True,
             )
 
+    log.debug("executing %s ...", tool_name)
+    t0 = time.monotonic()
     result = await tool.execute(
         parsed_input,
         ToolExecutionContext(
@@ -248,6 +263,9 @@ async def _execute_tool_call(
             },
         ),
     )
+    elapsed = time.monotonic() - t0
+    log.debug("executed %s in %.2fs err=%s output_len=%d",
+              tool_name, elapsed, result.is_error, len(result.output or ""))
     tool_result = ToolResultBlock(
         tool_use_id=tool_use_id,
         content=result.output,

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -11,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from uuid import uuid4
 
+log = logging.getLogger(__name__)
+
 from openharness.api.client import SupportsStreamingMessages
 from openharness.auth.manager import AuthManager
 from openharness.config.settings import CLAUDE_MODEL_ALIAS_OPTIONS, display_model_setting
@@ -673,6 +675,7 @@ class ReactBackendHost:
             self._question_requests.pop(request_id, None)
 
     async def _emit(self, event: BackendEvent) -> None:
+        log.debug("emit event: type=%s tool=%s", event.type, getattr(event, "tool_name", None))
         async with self._write_lock:
             payload = _PROTOCOL_PREFIX + event.model_dump_json() + "\n"
             buffer = getattr(sys.stdout, "buffer", None)


### PR DESCRIPTION
## Summary
- Fix Ink TUI crashes caused by unhandled `EIO` errors on `stdin.setRawMode()` during React reconciler mount/unmount cycles (common in SSH, tmux, Docker environments)
- Wire up the existing `--debug` CLI flag to Python `logging.basicConfig` (was previously a no-op)
- Add `OPENHARNESS_LOG_LEVEL` env var support for log level control
- Add debug logging across the tool execution pipeline: permission checks, execution timing, backend event emission

## Root Cause
Ink framework calls `stdin.setRawMode(true/false)` internally without error handling. In certain terminal environments (SSH, tmux, PTY), this throws `EIO` which crashes the Node.js process. The TUI appears frozen on "Running write_file..." because the frontend dies but tmux preserves the last rendered frame.

## Changes
| File | Change |
|------|--------|
| `frontend/terminal/src/index.tsx` | Monkey-patch `setRawMode` to catch EIO, add `uncaughtException` fallback |
| `src/openharness/cli.py` | Wire `--debug` flag to `logging.basicConfig`, add `OPENHARNESS_LOG_LEVEL` env var |
| `src/openharness/engine/query.py` | Debug logs for tool permission, execution timing, output length |
| `src/openharness/ui/backend_host.py` | Debug logs for event emission |

## Test plan
- [x] `oh -p "Create /tmp/test.txt with hello"` — write_file completes in 0.00s
- [x] `oh --debug` interactive mode — TUI starts without EIO crash
- [x] Interactive write_file — completes successfully, debug log shows full pipeline
- [x] `--debug` flag outputs structured logs to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)