### PR TITLE
[security]fix path rule enforcement for file tools

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -188,9 +188,10 @@ async def _execute_tool_call(
             is_error=True,
         )
 
-    # Extract file_path and command for path-level permission checks
-    _file_path = str(tool_input.get("file_path", "")) or None
-    _command = str(tool_input.get("command", "")) or None
+    # Normalize common tool inputs before permission checks so path rules apply
+    # consistently across built-in tools that use either `file_path` or `path`.
+    _file_path = _resolve_permission_file_path(context.cwd, tool_input, parsed_input)
+    _command = _extract_permission_command(tool_input, parsed_input)
     decision = context.permission_checker.evaluate(
         tool_name,
         is_read_only=tool.is_read_only(parsed_input),
@@ -241,3 +242,42 @@ async def _execute_tool_call(
             },
         )
     return tool_result
+
+
+def _resolve_permission_file_path(
+    cwd: Path,
+    raw_input: dict[str, object],
+    parsed_input: object,
+) -> str | None:
+    for key in ("file_path", "path"):
+        value = raw_input.get(key)
+        if isinstance(value, str) and value.strip():
+            path = Path(value).expanduser()
+            if not path.is_absolute():
+                path = cwd / path
+            return str(path.resolve())
+
+    for attr in ("file_path", "path"):
+        value = getattr(parsed_input, attr, None)
+        if isinstance(value, str) and value.strip():
+            path = Path(value).expanduser()
+            if not path.is_absolute():
+                path = cwd / path
+            return str(path.resolve())
+
+    return None
+
+
+def _extract_permission_command(
+    raw_input: dict[str, object],
+    parsed_input: object,
+) -> str | None:
+    value = raw_input.get("command")
+    if isinstance(value, str) and value.strip():
+        return value
+
+    value = getattr(parsed_input, "command", None)
+    if isinstance(value, str) and value.strip():
+        return value
+
+    return None

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -18,7 +18,7 @@ from openharness.engine.stream_events import (
     ToolExecutionCompleted,
     ToolExecutionStarted,
 )
-from openharness.permissions import PermissionChecker
+from openharness.permissions import PermissionChecker, PermissionMode
 from openharness.tools import create_default_tool_registry
 from openharness.hooks import HookExecutionContext, HookExecutor, HookEvent
 from openharness.hooks.loader import HookRegistry
@@ -249,3 +249,107 @@ async def test_query_engine_executes_ask_user_tool(tmp_path: Path):
     assert tool_results[0].output == "green"
     assert isinstance(events[-1], AssistantTurnComplete)
     assert events[-1].message.text == "Picked green."
+
+
+@pytest.mark.asyncio
+async def test_query_engine_applies_path_rules_to_relative_read_file_targets(tmp_path: Path):
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    secret = blocked_dir / "secret.txt"
+    secret.write_text("top-secret\n", encoding="utf-8")
+
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_blocked_read",
+                                name="read_file",
+                                input={"path": "blocked/secret.txt", "offset": 0, "limit": 1},
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="blocked")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(
+            PermissionSettings(
+                mode=PermissionMode.DEFAULT,
+                path_rules=[{"pattern": str((blocked_dir / "*").resolve()), "allow": False}],
+            )
+        ),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+    )
+
+    events = [event async for event in engine.submit_message("read blocked file")]
+
+    tool_results = [event for event in events if isinstance(event, ToolExecutionCompleted)]
+    assert tool_results
+    assert tool_results[0].is_error is True
+    assert "matches deny rule" in tool_results[0].output
+
+
+@pytest.mark.asyncio
+async def test_query_engine_applies_path_rules_to_write_file_targets_in_full_auto(tmp_path: Path):
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    target = blocked_dir / "output.txt"
+
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_blocked_write",
+                                name="write_file",
+                                input={"path": "blocked/output.txt", "content": "poc"},
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="blocked")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(
+            PermissionSettings(
+                mode=PermissionMode.FULL_AUTO,
+                path_rules=[{"pattern": str((blocked_dir / "*").resolve()), "allow": False}],
+            )
+        ),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+    )
+
+    events = [event async for event in engine.submit_message("write blocked file")]
+
+    tool_results = [event for event in events if isinstance(event, ToolExecutionCompleted)]
+    assert tool_results
+    assert tool_results[0].is_error is True
+    assert "matches deny rule" in tool_results[0].output
+    assert target.exists() is False


### PR DESCRIPTION
## Summary
This PR fixes a security-sensitive permission enforcement gap in built-in file tools. The query runner only forwarded `file_path` into the permission layer, while several core file tools use `path`, which meant configured `permission.path_rules` could be bypassed for those calls. In practice, that allowed blocked reads in default mode and blocked writes in `full_auto`; this patch normalizes the effective target path before evaluation and adds regression coverage for both cases.

## Related Issue
No linked public issue. This PR addresses a local file-access boundary failure in the documented `permission.path_rules` control.

## Changes
- Normalize permission-time file path extraction in `src/openharness/engine/query.py` so built-in tools using either `file_path` or `path` are evaluated consistently.
- Resolve relative paths against the session `cwd` before applying deny rules, so permission decisions are made against the real absolute target path.
- Add regression tests covering the two security-relevant cases from validation:
  - a blocked `read_file` call in default mode
  - a blocked `write_file` call in `full_auto`
- Preserve the documented behavior in `README.md` by making implementation and security expectations match again.

## Security Context
The root cause was an argument-name mismatch in the permission boundary. `PermissionChecker` supports path-level rules, but the query runner only passed `file_path` into that layer. Several core file tools instead use `path`, so the real filesystem target never reached permission evaluation.

That mismatch had direct security impact:
- `read_file` is treated as read-only, so the bypass allowed reads from denied paths in default mode
- `write_file` and similar mutating tools could reach denied paths once the session was in `full_auto`

## Steps to Reproduce
1. Check out vulnerable snapshot `7f7081b8a5f8bcd9dde26094aa470f20bd02098c`.
2. From the repository root, run a local PoC with `PYTHONPATH=src uv run python`.
3. Configure `PermissionChecker(mode=PermissionMode.DEFAULT, path_rules=[{"pattern": "/etc/*", "allow": False}])`.
4. Invoke `_execute_tool_call(..., "read_file", {"path": "/etc/hosts", "offset": 0, "limit": 1})`.
5. Expected result: the call is denied because the path matches the configured rule.
6. Actual result on the vulnerable snapshot: the call succeeds and returns file content from `/etc/hosts`.
7. Configure `PermissionChecker(mode=PermissionMode.FULL_AUTO, path_rules=[{"pattern": "/tmp/*", "allow": False}])`.
8. Invoke `_execute_tool_call(..., "write_file", {"path": "/tmp/openharness-path-rule-bypass.txt", "content": "poc"})`.
9. Expected result: the call is denied because the path matches the configured rule.
10. Actual result on the vulnerable snapshot: the marker file is created successfully under `/tmp/`.

## Security Impact
- Confidentiality: attacker-influenced tool use can read arbitrary local text files outside the intended repository boundary, including configuration, secrets, shell history, SSH material, or adjacent credentials available to the runtime user.
- Integrity: denied host paths can be created or overwritten in `full_auto`, allowing tampering with local project state or other writable host files outside the intended repository scope.
- Availability: overwrite-based disruption is possible, but this is not the primary effect.

## CVSS / CWE
- Severity: `High`
- CVSS v3.1: `7.8`
- Vector: `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L`
- CWE: `CWE-284: Improper Access Control`

## Testing
- [x] `uv run --extra dev ruff check src/openharness/engine/query.py tests/test_engine/test_query_engine.py`
- [x] `PYTHONPATH=src uv run --extra dev pytest tests/test_engine/test_query_engine.py tests/test_permissions/test_checker.py`
- [ ] Full project test suite was not run for this targeted fix.

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Checklist

### General

- [x] The summary and change list match the actual diff.
- [x] No secrets, API keys, or credentials were committed.

### Code Changes

- [x] Tests were added for the changed behavior.
- [x] The fix is limited to permission enforcement and regression coverage.
- [x] The documented `permission.path_rules` behavior now matches the implementation for these built-in file-tool inputs.

### Doc Changes

- [x] No user-facing doc changes were needed because the intended behavior was already documented.
- [ ] `SECURITY.md` is still missing and should be added in a follow-up by maintainers.

## Maintainer Note
The repository does not appear to publish a `SECURITY.md` file or another documented private disclosure path today. Adding `SECURITY.md` with a reporting contact or policy would make future security reports easier to handle privately.

---
Signed-off-by: 13ernkastel <LennonCMJ@live.com>
