### PR TITLE
Fix _READ_ONLY_TOOLS using wrong tool names in swarm permission sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.
 - Memory scanner now parses YAML frontmatter (`name`, `description`, `type`) instead of returning raw `---` as description.
 - Memory search matches against body content in addition to metadata, with metadata weighted higher for relevance.
 - Memory search tokenizer handles Han characters for multilingual queries.

--- a/src/openharness/swarm/permission_sync.py
+++ b/src/openharness/swarm/permission_sync.py
@@ -75,15 +75,15 @@ def _get_teammate_color() -> str | None:
 
 _READ_ONLY_TOOLS: frozenset[str] = frozenset(
     {
-        "Read",
-        "Glob",
-        "Grep",
-        "WebFetch",
-        "WebSearch",
-        "TaskGet",
-        "TaskList",
-        "TaskOutput",
-        "CronList",
+        "read_file",
+        "glob",
+        "grep",
+        "web_fetch",
+        "web_search",
+        "task_get",
+        "task_list",
+        "task_output",
+        "cron_list",
     }
 )
 

--- a/tests/test_swarm/test_permission_sync.py
+++ b/tests/test_swarm/test_permission_sync.py
@@ -25,13 +25,13 @@ from openharness.swarm.permission_sync import (
 
 @pytest.mark.parametrize(
     "tool_name",
-    ["Read", "Glob", "Grep", "WebFetch", "WebSearch", "TaskGet", "TaskList", "CronList"],
+    ["read_file", "glob", "grep", "web_fetch", "web_search", "task_get", "task_list", "cron_list"],
 )
 def test_is_read_only_true_for_safe_tools(tool_name):
     assert _is_read_only(tool_name) is True
 
 
-@pytest.mark.parametrize("tool_name", ["Bash", "Edit", "Write", "TaskCreate"])
+@pytest.mark.parametrize("tool_name", ["bash", "edit_file", "write_file", "task_create"])
 def test_is_read_only_false_for_write_tools(tool_name):
     assert _is_read_only(tool_name) is False
 
@@ -120,7 +120,7 @@ async def test_send_permission_response_writes_to_worker(tmp_path, monkeypatch):
 
 
 async def test_handle_read_only_tool_auto_approved():
-    req = create_permission_request("Read", "tu-1", {"file_path": "/tmp/f.py"})
+    req = create_permission_request("read_file", "tu-1", {"file_path": "/tmp/f.py"})
     checker = MagicMock()
     resp = await handle_permission_request(req, checker)
     assert resp.allowed is True


### PR DESCRIPTION
## Summary

- `_READ_ONLY_TOOLS` in `permission_sync.py` used PascalCase names (`"Read"`, `"Glob"`, `"WebFetch"`, etc.) carried over from the TypeScript original, but the Python tool registry registers tools with snake_case names (`"read_file"`, `"glob"`, `"web_fetch"`, etc.)
- This meant `_is_read_only()` never matched any tool, so `handle_permission_request()` never auto-approved read-only operations — every swarm tool call required explicit leader permission evaluation, even for safe read-only tools like file reads and greps
- Updated `_READ_ONLY_TOOLS` to use the actual registered tool names and aligned the test parametrizations accordingly

## Changes

| File | Change |
|------|--------|
| `src/openharness/swarm/permission_sync.py` | Updated 9 tool names in `_READ_ONLY_TOOLS` from PascalCase to actual registered snake_case names |
| `tests/test_swarm/test_permission_sync.py` | Updated test parametrizations to use actual tool names (both read-only and write-tool cases) |
| `CHANGELOG.md` | Added entry under `[Unreleased] > Fixed` |

## How I verified it

```
$ python3 -m pytest tests/test_swarm/test_permission_sync.py -v
23 passed in 0.74s

$ python3 -m ruff check src/openharness/swarm/permission_sync.py tests/test_swarm/test_permission_sync.py
All checks passed!
```

## Test plan

- [x] All 23 existing `test_permission_sync.py` tests pass with updated tool names
- [x] `ruff check` passes on changed files
- [ ] CI runs green on Python 3.10 and 3.11