### PR TITLE
Fix shell injection in command hook $ARGUMENTS substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Memory scanner now parses YAML frontmatter (`name`, `description`, `type`) instead of returning raw `---` as description.
 - Memory search matches against body content in addition to metadata, with metadata weighted higher for relevance.
 - Memory search tokenizer handles Han characters for multilingual queries.

--- a/src/openharness/hooks/executor.py
+++ b/src/openharness/hooks/executor.py
@@ -6,6 +6,7 @@ import asyncio
 import fnmatch
 import json
 import os
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -70,7 +71,7 @@ class HookExecutor:
         event: HookEvent,
         payload: dict[str, Any],
     ) -> HookResult:
-        command = _inject_arguments(hook.command, payload)
+        command = _inject_arguments(hook.command, payload, shell_escape=True)
         try:
             process = await create_shell_subprocess(
                 command,
@@ -207,8 +208,13 @@ def _matches_hook(hook: HookDefinition, payload: dict[str, Any]) -> bool:
     return fnmatch.fnmatch(subject, matcher)
 
 
-def _inject_arguments(template: str, payload: dict[str, Any]) -> str:
-    return template.replace("$ARGUMENTS", json.dumps(payload, ensure_ascii=True))
+def _inject_arguments(
+    template: str, payload: dict[str, Any], *, shell_escape: bool = False
+) -> str:
+    serialized = json.dumps(payload, ensure_ascii=True)
+    if shell_escape:
+        serialized = shlex.quote(serialized)
+    return template.replace("$ARGUMENTS", serialized)
 
 
 def _parse_hook_json(text: str) -> dict[str, Any]:

--- a/tests/test_hooks/test_executor.py
+++ b/tests/test_hooks/test_executor.py
@@ -10,6 +10,7 @@ from openharness.api.client import ApiMessageCompleteEvent
 from openharness.api.usage import UsageSnapshot
 from openharness.engine.messages import ConversationMessage, TextBlock
 from openharness.hooks import HookEvent, HookExecutionContext, HookExecutor
+from openharness.hooks.executor import _inject_arguments
 from openharness.hooks.loader import HookRegistry
 from openharness.hooks.schemas import CommandHookDefinition, PromptHookDefinition
 
@@ -70,3 +71,51 @@ async def test_prompt_hook_can_block(tmp_path: Path):
 
     assert result.blocked is True
     assert result.reason == "blocked by policy"
+
+
+# ---------------------------------------------------------------------------
+# _inject_arguments shell escaping
+# ---------------------------------------------------------------------------
+
+
+def test_inject_arguments_no_escape_by_default():
+    payload = {"command": "$(whoami)"}
+    result = _inject_arguments("echo $ARGUMENTS", payload)
+    # Without shell_escape, the raw JSON is substituted
+    assert result == 'echo {"command": "$(whoami)"}'
+
+
+def test_inject_arguments_shell_escape_wraps_in_single_quotes():
+    payload = {"command": "$(whoami)"}
+    result = _inject_arguments("echo $ARGUMENTS", payload, shell_escape=True)
+    # With shell_escape, shlex.quote wraps the JSON in single quotes
+    # so bash treats it as a literal string
+    assert result.startswith("echo '")
+    assert "$(whoami)" in result
+
+
+@pytest.mark.asyncio
+async def test_command_hook_escapes_shell_metacharacters(tmp_path: Path):
+    """$ARGUMENTS in command hooks must be shell-escaped to prevent injection."""
+    registry = HookRegistry()
+    registry.register(
+        HookEvent.PRE_TOOL_USE,
+        CommandHookDefinition(command="echo $ARGUMENTS"),
+    )
+    executor = HookExecutor(
+        registry,
+        HookExecutionContext(
+            cwd=tmp_path,
+            api_client=FakeApiClient('{"ok": true}'),
+            default_model="claude-test",
+        ),
+    )
+
+    # $(echo INJECTED) would execute as a subshell if not properly escaped
+    payload = {"tool_name": "test", "input": "$(echo INJECTED)"}
+    result = await executor.execute(HookEvent.PRE_TOOL_USE, payload)
+
+    output = result.results[0].output
+    # With proper escaping, the literal $(echo INJECTED) must survive.
+    # Without escaping, bash expands the subshell and the $() wrapper is gone.
+    assert "$(echo INJECTED)" in output


### PR DESCRIPTION
## Summary

- `_inject_arguments` replaced `$ARGUMENTS` with `json.dumps(payload)` directly into shell command strings passed to `bash -lc`. JSON encoding does **not** neutralize shell metacharacters — `$(...)`, backticks, and `$((expr))` inside double-quoted strings are still expanded by bash.
- A hook command like `echo $ARGUMENTS` with payload `{"command": "$(whoami)"}` would execute the `whoami` subshell.
- Added `shlex.quote()` around the serialized JSON when substituting into command hooks, wrapping it in single quotes so bash treats the entire payload as a literal string.
- Prompt/agent hooks are unaffected — they pass the substituted string to the LLM API, not a shell.

## Changes

| File | Change |
|------|--------|
| `src/openharness/hooks/executor.py` | Import `shlex`; add `shell_escape` kwarg to `_inject_arguments`; pass `shell_escape=True` from `_run_command_hook` |
| `tests/test_hooks/test_executor.py` | 3 new tests: unit tests for `_inject_arguments` with/without escaping, integration test proving `$(echo INJECTED)` survives as a literal |
| `CHANGELOG.md` | Entry under `[Unreleased] > Fixed` |

## How I verified it

```
$ python3 -m pytest tests/test_hooks/test_executor.py -v
5 passed in 1.08s

$ python3 -m ruff check src/openharness/hooks/executor.py tests/test_hooks/test_executor.py
All checks passed!
```

The integration test `test_command_hook_escapes_shell_metacharacters` is a proof-of-exploit: it sends `$(echo INJECTED)` inside a payload to a command hook using `echo $ARGUMENTS`. Before this fix, bash expands the subshell and the `$()` wrapper disappears from the output. After this fix, the literal `$(echo INJECTED)` survives intact.

## Note on existing mitigation

The `OPENHARNESS_HOOK_PAYLOAD` environment variable (already set at executor.py:83) passes the same payload safely via the process environment and is not subject to shell expansion. Hook authors who read `$OPENHARNESS_HOOK_PAYLOAD` instead of relying on `$ARGUMENTS` inline substitution are unaffected. This fix closes the gap for the inline path.

## Test plan

- [x] 2 unit tests verify `_inject_arguments` escaping behavior (with and without `shell_escape`)
- [x] 1 integration test proves shell metacharacters are not expanded in command hooks
- [x] 2 existing tests continue to pass (command hook execution, prompt hook blocking)
- [x] `ruff check` passes on changed files
- [ ] CI runs green on Python 3.10 and 3.11