### PR TITLE
fix: show friendly error on missing API key instead of traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
-- Show a clear error message and exit cleanly when no API key is configured, instead of crashing with a raw `ValueError` traceback.
 - Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.
 - Memory scanner now parses YAML frontmatter (`name`, `description`, `type`) instead of returning raw `---` as description.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Show a clear error message and exit cleanly when no API key is configured, instead of crashing with a raw `ValueError` traceback.
 - Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.
 - Memory scanner now parses YAML frontmatter (`name`, `description`, `type`) instead of returning raw `---` as description.

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -131,16 +132,27 @@ async def build_runtime(
         from openharness.api.copilot_client import COPILOT_DEFAULT_MODEL
         copilot_model = settings.model if settings.model != "claude-sonnet-4-20250514" else COPILOT_DEFAULT_MODEL
         resolved_api_client = CopilotClient(model=copilot_model)
-    elif settings.api_format == "openai":
-        resolved_api_client = OpenAICompatibleClient(
-            api_key=settings.resolve_api_key(),
-            base_url=settings.base_url,
-        )
     else:
-        resolved_api_client = AnthropicApiClient(
-            api_key=settings.resolve_api_key(),
-            base_url=settings.base_url,
-        )
+        try:
+            resolved_key = settings.resolve_api_key()
+        except ValueError:
+            print(
+                "Error: No API key configured.\n"
+                "  Run `oh auth login` to set up authentication, or set the\n"
+                "  ANTHROPIC_API_KEY (or OPENAI_API_KEY) environment variable.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        if settings.api_format == "openai":
+            resolved_api_client = OpenAICompatibleClient(
+                api_key=resolved_key,
+                base_url=settings.base_url,
+            )
+        else:
+            resolved_api_client = AnthropicApiClient(
+                api_key=resolved_key,
+                base_url=settings.base_url,
+            )
     mcp_manager = McpClientManager(load_mcp_server_configs(settings, plugins))
     await mcp_manager.connect_all()
     tool_registry = create_default_tool_registry(mcp_manager)

--- a/tests/test_ui/test_runtime_api_key.py
+++ b/tests/test_ui/test_runtime_api_key.py
@@ -1,0 +1,27 @@
+"""Tests for build_runtime behaviour when no API key is configured."""
+
+from __future__ import annotations
+
+import pytest
+
+from openharness.ui.runtime import build_runtime
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_exits_cleanly_when_api_key_missing(monkeypatch):
+    """build_runtime should raise SystemExit(1) — not ValueError — when no API key is set."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit, match="1"):
+        await build_runtime()
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_exits_cleanly_for_openai_format(monkeypatch):
+    """Same check for the openai api_format path."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit, match="1"):
+        await build_runtime(api_format="openai")


### PR DESCRIPTION
## Summary

- When no API key is configured (no env var, no `settings.json`), `build_runtime` now catches the `ValueError` from `resolve_api_key()` and prints a clear message to stderr before exiting with code 1.
- Previously, users saw a raw `ValueError` traceback — confusing for new users who haven't configured authentication yet.
- Adds two tests verifying the clean exit for both the default (Anthropic) and `openai` format paths.

**Before:**
```
Traceback (most recent call last):
  ...
ValueError: No API key found. Set ANTHROPIC_API_KEY ...
```

**After:**
```
Error: No API key configured.
  Run `oh auth login` to set up authentication, or set the
  ANTHROPIC_API_KEY (or OPENAI_API_KEY) environment variable.
```

## Test plan

- [x] `uv run pytest tests/test_ui/test_runtime_api_key.py -v` — 2 new tests pass
- [x] `uv run pytest -q` — full suite passes (402 passed, 6 skipped, 1 xfailed)
- [x] `uv run ruff check src tests scripts` — all checks passed
- [ ] Manual: unset `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`, run `oh` — should see the friendly message and exit code 1