### PR TITLE
fix: TUI confirmation dialog not accepting input on WSL/Windows

### DIFF
--- a/frontend/terminal/src/index.tsx
+++ b/frontend/terminal/src/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {render} from 'ink';
+import fs from 'node:fs';
+import tty from 'node:tty';
 
 import {App} from './App.js';
 import type {FrontendConfig} from './types.js';
@@ -20,4 +22,27 @@ process.on('SIGTERM', () => {
 	process.exit(143);
 });
 
-render(<App config={config} />);
+// On WSL / Windows the process-spawning chain (npm exec → tsx → node) can
+// lose the TTY on stdin, which prevents Ink's useInput from enabling raw mode.
+// When that happens, open /dev/tty directly to get a real TTY stream.
+let stdinStream: NodeJS.ReadStream & {fd: 0} = process.stdin;
+let ttyFd: number | undefined;
+
+if (!process.stdin.isTTY) {
+	try {
+		ttyFd = fs.openSync('/dev/tty', 'r');
+		const ttyStream = new tty.ReadStream(ttyFd);
+		// Cast is safe — tty.ReadStream is a full readable TTY stream
+		stdinStream = ttyStream as unknown as NodeJS.ReadStream & {fd: 0};
+	} catch {
+		// /dev/tty unavailable (e.g. non-interactive CI) — fall back to process.stdin
+	}
+}
+
+process.on('exit', () => {
+	if (ttyFd !== undefined) {
+		try { fs.closeSync(ttyFd); } catch { /* ignore */ }
+	}
+});
+
+render(<App config={config} />, {stdin: stdinStream});

--- a/src/openharness/ui/react_launcher.py
+++ b/src/openharness/ui/react_launcher.py
@@ -24,6 +24,38 @@ def _resolve_npm() -> str:
     return shutil.which("npm") or "npm"
 
 
+def _resolve_tsx(frontend_dir: Path) -> tuple[str, ...]:
+    """Resolve the tsx command to invoke directly, bypassing ``npm exec``.
+
+    On Windows / WSL the ``npm exec -- tsx`` wrapper chain often spawns
+    intermediate ``cmd.exe`` / shell processes that break TTY stdin
+    inheritance.  Calling the ``tsx`` binary directly preserves the TTY so
+    that Ink's ``useInput`` (which requires raw-mode stdin) keeps working.
+
+    Returns a tuple of command parts, e.g. ``("path/to/tsx",)`` or
+    ``("npm", "exec", "--", "tsx")`` as last-resort fallback.
+    """
+    # 1. Prefer the locally-installed binary
+    bin_dir = frontend_dir / "node_modules" / ".bin"
+    if sys.platform == "win32":
+        for name in ("tsx.cmd", "tsx.ps1", "tsx"):
+            candidate = bin_dir / name
+            if candidate.exists():
+                return (str(candidate),)
+    else:
+        candidate = bin_dir / "tsx"
+        if candidate.exists():
+            return (str(candidate),)
+
+    # 2. Fall back to a globally-installed tsx
+    global_tsx = shutil.which("tsx")
+    if global_tsx:
+        return (global_tsx,)
+
+    # 3. Last resort — go through npm exec (may break TTY on Windows/WSL)
+    return (_resolve_npm(), "exec", "--", "tsx")
+
+
 def get_frontend_dir() -> Path:
     """Return the React terminal frontend directory.
 
@@ -121,11 +153,9 @@ async def launch_react_tui(
             "theme": _resolve_theme(),
         }
     )
+    tsx_cmd = _resolve_tsx(frontend_dir)
     process = await asyncio.create_subprocess_exec(
-        npm,
-        "exec",
-        "--",
-        "tsx",
+        *tsx_cmd,
         "src/index.tsx",
         cwd=str(frontend_dir),
         env=env,


### PR DESCRIPTION
Fixes #37

The permission dialog (`[y] Allow / [n] Deny`) renders fine but ignores all keyboard input on WSL2, Git Bash, PowerShell, and CMD.

### What was wrong

`npm exec -- tsx` spawns intermediate shell processes that break TTY stdin inheritance. Once `process.stdin.isTTY` becomes false, Ink's `useInput` can't enable raw mode — so keypresses never arrive.

### What I changed

- **`react_launcher.py`** — call the `tsx` binary directly from `node_modules/.bin/` instead of going through `npm exec`, cutting out the middleman that loses the TTY.
- **`index.tsx`** — if stdin still isn't a TTY, try opening `/dev/tty` as a fallback. Gracefully falls back to `process.stdin` if that's not available either (e.g. CI).

### Testing

- `tsc --noEmit` passes
- All existing UI tests pass
- Fallback logic verified: no crash when `/dev/tty` is unavailable