### PR TITLE
plugins, themes: add docstrings and debug logging to loader utilities

### DIFF
--- a/src/openharness/plugins/loader.py
+++ b/src/openharness/plugins/loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from openharness.config.paths import get_config_dir
@@ -10,6 +11,8 @@ from openharness.plugins.schemas import PluginManifest
 from openharness.plugins.types import LoadedPlugin
 from openharness.skills.loader import _parse_skill_markdown
 from openharness.skills.types import SkillDefinition
+
+logger = logging.getLogger(__name__)
 
 
 def get_user_plugins_dir() -> Path:
@@ -67,7 +70,8 @@ def load_plugin(path: Path, enabled_plugins: dict[str, bool]) -> LoadedPlugin | 
         return None
     try:
         manifest = PluginManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
-    except Exception:
+    except Exception as exc:
+        logger.debug("Failed to load plugin manifest from %s: %s", manifest_path, exc)
         return None
     enabled = enabled_plugins.get(manifest.name, manifest.enabled_by_default)
 
@@ -107,6 +111,14 @@ def load_plugin(path: Path, enabled_plugins: dict[str, bool]) -> LoadedPlugin | 
 
 
 def _load_plugin_skills(path: Path) -> list[SkillDefinition]:
+    """Load skill definitions from markdown files in a directory.
+
+    Args:
+        path: Directory containing ``.md`` skill files.
+
+    Returns:
+        List of parsed ``SkillDefinition`` objects, or empty list if path doesn't exist.
+    """
     if not path.exists():
         return []
     skills: list[SkillDefinition] = []
@@ -126,6 +138,14 @@ def _load_plugin_skills(path: Path) -> list[SkillDefinition]:
 
 
 def _load_plugin_hooks(path: Path) -> dict[str, list]:
+    """Load hooks from a flat hooks.json file.
+
+    Args:
+        path: Path to a hooks JSON file.
+
+    Returns:
+        Dictionary mapping event names to lists of hook definition objects.
+    """
     if not path.exists():
         return {}
     from openharness.hooks.schemas import (
@@ -185,6 +205,14 @@ def _load_plugin_hooks_structured(path: Path, plugin_root: Path) -> dict[str, li
 
 
 def _load_plugin_mcp(path: Path) -> dict[str, object]:
+    """Load MCP server configuration from a JSON file.
+
+    Args:
+        path: Path to an MCP config file (e.g. ``.mcp.json``).
+
+    Returns:
+        Dictionary mapping server names to their configuration objects.
+    """
     if not path.exists():
         return {}
     from openharness.mcp.types import McpJsonConfig

--- a/src/openharness/themes/loader.py
+++ b/src/openharness/themes/loader.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from openharness.themes.builtin import BUILTIN_THEMES
 from openharness.themes.schema import ThemeConfig
+
+logger = logging.getLogger(__name__)
 
 
 def get_custom_themes_dir() -> Path:
@@ -24,8 +27,8 @@ def load_custom_themes() -> dict[str, ThemeConfig]:
             data = json.loads(path.read_text(encoding="utf-8"))
             theme = ThemeConfig.model_validate(data)
             themes[theme.name] = theme
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Skipping invalid theme file %s: %s", path, exc)
     return themes
 
 


### PR DESCRIPTION
## Problem
Three private functions in `plugins/loader.py` (`_load_plugin_skills`,
`_load_plugin_hooks`, `_load_plugin_mcp`) had no docstrings.

Two `except Exception` blocks — one in `load_plugin` and one in
`load_custom_themes` — silently swallowed errors with no log output,
making it impossible to diagnose why a plugin or theme failed to load.

## Changes
- Added docstrings to the three undocumented private functions
- Replaced bare `except Exception` with `except Exception as exc` +
  `logger.debug(...)`, consistent with the project's established
  `logging.getLogger(__name__)` pattern

## Verification
- `uv run ruff check src/openharness/plugins/loader.py src/openharness/themes/loader.py` — clean
- `uv run pytest -q` — all tests pass
- No functional changes; purely observability and documentation improvements
