### PR TITLE
Add built-in sensitive path protection to PermissionChecker

### DIFF
--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -11,6 +11,31 @@ from openharness.permissions.modes import PermissionMode
 
 log = logging.getLogger(__name__)
 
+# Paths that are always denied regardless of permission mode or user config.
+# These protect high-value credential and key material from LLM-directed access
+# (including via prompt injection).  Patterns use fnmatch syntax and are matched
+# against the fully-resolved absolute path produced by the query engine.
+SENSITIVE_PATH_PATTERNS: tuple[str, ...] = (
+    # SSH keys and config
+    "*/.ssh/*",
+    # AWS credentials
+    "*/.aws/credentials",
+    "*/.aws/config",
+    # GCP credentials
+    "*/.config/gcloud/*",
+    # Azure credentials
+    "*/.azure/*",
+    # GPG keys
+    "*/.gnupg/*",
+    # Docker credentials
+    "*/.docker/config.json",
+    # Kubernetes credentials
+    "*/.kube/config",
+    # OpenHarness own credential stores
+    "*/.openharness/credentials.json",
+    "*/.openharness/copilot_auth.json",
+)
+
 
 @dataclass(frozen=True)
 class PermissionDecision:
@@ -56,6 +81,21 @@ class PermissionChecker:
         command: str | None = None,
     ) -> PermissionDecision:
         """Return whether the tool may run immediately."""
+        # Built-in sensitive path protection — always active, cannot be
+        # overridden by user settings or permission mode.  This is a
+        # defence-in-depth measure against LLM-directed or prompt-injection
+        # driven access to credential files.
+        if file_path:
+            for pattern in SENSITIVE_PATH_PATTERNS:
+                if fnmatch.fnmatch(file_path, pattern):
+                    return PermissionDecision(
+                        allowed=False,
+                        reason=(
+                            f"Access denied: {file_path} is a sensitive credential path "
+                            f"(matched built-in pattern '{pattern}')"
+                        ),
+                    )
+
         # Explicit tool deny list
         if tool_name in self._settings.denied_tools:
             return PermissionDecision(allowed=False, reason=f"{tool_name} is explicitly denied")

--- a/tests/test_permissions/test_checker.py
+++ b/tests/test_permissions/test_checker.py
@@ -6,6 +6,7 @@ import pytest
 
 from openharness.config.settings import PathRuleConfig, PermissionSettings
 from openharness.permissions import PermissionChecker, PermissionMode
+from openharness.permissions.checker import SENSITIVE_PATH_PATTERNS
 
 
 def test_default_mode_allows_read_only():
@@ -113,3 +114,104 @@ def test_pattern_with_surrounding_whitespace_is_stripped():
 
     decision = checker.evaluate("read_file", is_read_only=True, file_path="/etc/passwd")
     assert decision.allowed is False
+
+
+# --- built-in sensitive path protection tests ---
+
+
+class TestSensitivePathProtection:
+    """Built-in sensitive path patterns must block access in every permission mode."""
+
+    @pytest.mark.parametrize(
+        "mode",
+        [PermissionMode.FULL_AUTO, PermissionMode.DEFAULT, PermissionMode.PLAN],
+        ids=["full_auto", "default", "plan"],
+    )
+    def test_ssh_key_blocked_in_all_modes(self, mode):
+        checker = PermissionChecker(PermissionSettings(mode=mode))
+        decision = checker.evaluate(
+            "read_file", is_read_only=True, file_path="/home/user/.ssh/id_rsa"
+        )
+        assert decision.allowed is False
+        assert ".ssh" in decision.reason
+
+    def test_full_auto_blocks_sensitive_paths(self):
+        """FULL_AUTO normally allows everything, but sensitive paths are still denied."""
+        checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
+        for path in (
+            "/home/user/.ssh/id_ed25519",
+            "/home/user/.aws/credentials",
+            "/home/user/.config/gcloud/application_default_credentials.json",
+            "/home/user/.gnupg/private-keys-v1.d/key.key",
+            "/home/user/.azure/accessTokens.json",
+            "/home/user/.docker/config.json",
+            "/home/user/.kube/config",
+            "/home/user/.openharness/credentials.json",
+            "/home/user/.openharness/copilot_auth.json",
+        ):
+            decision = checker.evaluate("read_file", is_read_only=True, file_path=path)
+            assert decision.allowed is False, f"Expected {path} to be denied"
+
+    def test_sensitive_path_blocks_write_tools(self):
+        """Sensitive path protection applies to write operations too."""
+        checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
+        decision = checker.evaluate(
+            "write_file", is_read_only=False, file_path="/home/user/.ssh/authorized_keys"
+        )
+        assert decision.allowed is False
+
+    def test_allowed_tools_does_not_bypass_sensitive_paths(self):
+        """Even if read_file is explicitly allowed, sensitive paths are still denied."""
+        checker = PermissionChecker(
+            PermissionSettings(
+                mode=PermissionMode.FULL_AUTO,
+                allowed_tools=["read_file"],
+            )
+        )
+        decision = checker.evaluate(
+            "read_file", is_read_only=True, file_path="/home/user/.ssh/id_rsa"
+        )
+        assert decision.allowed is False
+
+    def test_non_sensitive_paths_unaffected(self):
+        """Normal project files are not blocked by sensitive path protection."""
+        checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
+        for path in (
+            "/home/user/project/src/main.py",
+            "/home/user/.bashrc",
+            "/home/user/.config/nvim/init.lua",
+            "/tmp/scratch.txt",
+        ):
+            decision = checker.evaluate("read_file", is_read_only=True, file_path=path)
+            assert decision.allowed is True, f"Expected {path} to be allowed"
+
+    def test_no_file_path_skips_sensitive_check(self):
+        """Tools without a file path (e.g. bash) are not affected."""
+        checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
+        decision = checker.evaluate("bash", is_read_only=False, command="echo hello")
+        assert decision.allowed is True
+
+    @pytest.mark.parametrize(
+        "pattern",
+        SENSITIVE_PATH_PATTERNS,
+        ids=[p.split("/")[-1] or p.split("/")[-2] for p in SENSITIVE_PATH_PATTERNS],
+    )
+    def test_every_builtin_pattern_has_coverage(self, pattern):
+        """Verify every pattern in SENSITIVE_PATH_PATTERNS actually blocks something."""
+        # Build a concrete path that should match the pattern
+        example_paths = {
+            "*/.ssh/*": "/home/u/.ssh/id_rsa",
+            "*/.aws/credentials": "/home/u/.aws/credentials",
+            "*/.aws/config": "/home/u/.aws/config",
+            "*/.config/gcloud/*": "/home/u/.config/gcloud/creds.json",
+            "*/.azure/*": "/home/u/.azure/tokens.json",
+            "*/.gnupg/*": "/home/u/.gnupg/secring.gpg",
+            "*/.docker/config.json": "/home/u/.docker/config.json",
+            "*/.kube/config": "/home/u/.kube/config",
+            "*/.openharness/credentials.json": "/home/u/.openharness/credentials.json",
+            "*/.openharness/copilot_auth.json": "/home/u/.openharness/copilot_auth.json",
+        }
+        test_path = example_paths[pattern]
+        checker = PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO))
+        decision = checker.evaluate("read_file", is_read_only=True, file_path=test_path)
+        assert decision.allowed is False, f"Pattern {pattern!r} did not block {test_path}"


### PR DESCRIPTION
## Summary

File tools (`read_file`, `write_file`, `edit_file`, `notebook_edit`) resolve paths via `Path.expanduser().resolve()` but the permission layer has no default deny rules for credential files. In `FULL_AUTO` mode — or when no `path_rules` are configured — the LLM can be directed (including via prompt injection) to access `~/.ssh/id_rsa`, `~/.aws/credentials`, `~/.kube/config`, and similar targets.

This PR adds a `SENSITIVE_PATH_PATTERNS` tuple to `PermissionChecker` that is always evaluated **before** any other permission logic, including `FULL_AUTO` allow-all, explicit `allowed_tools`, and user-configured `path_rules`. The patterns cover:

- **SSH** — `*/.ssh/*`
- **AWS** — `*/.aws/credentials`, `*/.aws/config`
- **GCP** — `*/.config/gcloud/*`
- **Azure** — `*/.azure/*`
- **GPG** — `*/.gnupg/*`
- **Docker** — `*/.docker/config.json`
- **Kubernetes** — `*/.kube/config`
- **OpenHarness** — `*/.openharness/credentials.json`, `*/.openharness/copilot_auth.json`

Patterns use `fnmatch` syntax (already used by the existing path rule infrastructure) and are matched against the fully-resolved absolute path produced by the query engine, so they work cross-platform.

## Design decisions

- **Placement before all other checks**: Even `allowed_tools` cannot bypass this protection. This is intentional — a user who adds `read_file` to `allowed_tools` wants to skip confirmation prompts, not expose credential files.
- **Defence in depth**: The existing `path_rules` mechanism still works — users can add their own deny rules for additional paths. The built-in patterns are a safety net, not a replacement.
- **Constant tuple, not settings**: The patterns are hardcoded in the checker module rather than coming from `PermissionSettings`. This prevents accidental removal via settings.json edits.

## Test plan

18 new tests added to `tests/test_permissions/test_checker.py`:

- [x] Sensitive paths blocked in all 3 permission modes (`FULL_AUTO`, `DEFAULT`, `PLAN`)
- [x] All 9 categories of sensitive paths blocked (SSH, AWS, GCP, Azure, GPG, Docker, K8s, OH credentials, OH copilot auth)
- [x] Write operations blocked, not just reads
- [x] `allowed_tools` does not bypass protection
- [x] Normal project files (`.py`, `.bashrc`, `/tmp/*`) are unaffected
- [x] Tools without a `file_path` (e.g. `bash`) unaffected
- [x] Parametrized test ensures every pattern in the tuple actually matches a concrete path

All 458 existing tests still pass. `ruff check` clean.