### PR TITLE
feat: add native support for Moonshot (Kimi) provider

### DIFF
--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -34,6 +34,7 @@ _KNOWN_PROVIDERS = [
     "dashscope",
     "bedrock",
     "vertex",
+    "moonshot",
 ]
 
 _AUTH_SOURCES = [
@@ -45,6 +46,7 @@ _AUTH_SOURCES = [
     "dashscope_api_key",
     "bedrock_api_key",
     "vertex_api_key",
+    "moonshot_api_key",
 ]
 
 _PROFILE_BY_PROVIDER = {
@@ -53,6 +55,7 @@ _PROFILE_BY_PROVIDER = {
     "openai": "openai-compatible",
     "openai_codex": "codex",
     "copilot": "copilot",
+    "moonshot": "moonshot",
 }
 
 
@@ -225,6 +228,14 @@ class AuthManager:
                     configured = True
                     source = "env"
                 elif load_credential("dashscope", "api_key"):
+                    configured = True
+                    source = "file"
+
+            elif provider == "moonshot":
+                if os.environ.get("MOONSHOT_API_KEY"):
+                    configured = True
+                    source = "env"
+                elif load_credential("moonshot", "api_key"):
                     configured = True
                     source = "file"
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -269,6 +269,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "dashscope": "Alibaba DashScope",
     "bedrock": "AWS Bedrock",
     "vertex": "Google Vertex AI",
+    "moonshot": "Moonshot (Kimi)",
 }
 
 _AUTH_SOURCE_LABELS: dict[str, str] = {
@@ -280,6 +281,7 @@ _AUTH_SOURCE_LABELS: dict[str, str] = {
     "dashscope_api_key": "DashScope API key",
     "bedrock_api_key": "Bedrock credentials",
     "vertex_api_key": "Vertex credentials",
+    "moonshot_api_key": "Moonshot API key",
 }
 
 
@@ -721,7 +723,7 @@ def _login_provider(provider: str) -> None:
         _bind_external_provider(provider)
         return
 
-    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex"):
+    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot"):
         label = _PROVIDER_LABELS.get(provider, provider)
         flow = ApiKeyFlow(provider=provider, prompt_text=f"Enter your {label} API key")
         try:
@@ -803,7 +805,7 @@ def auth_login(
     """Interactively authenticate with a provider.
 
     Run without arguments to choose a provider from a menu.
-    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex.
+    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot.
     """
     if provider is None:
         print("Select a provider to authenticate:", flush=True)

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -181,6 +181,13 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             auth_source="copilot_oauth",
             default_model="gpt-5.4",
         ),
+        "moonshot": ProviderProfile(
+            label="Moonshot (Kimi)",
+            provider="moonshot",
+            api_format="openai",
+            auth_source="moonshot_api_key",
+            default_model="kimi-k2.5",
+        ),
     }
 
 
@@ -266,6 +273,7 @@ def auth_source_provider_name(auth_source: str) -> str:
         "dashscope_api_key": "dashscope",
         "bedrock_api_key": "bedrock",
         "vertex_api_key": "vertex",
+        "moonshot_api_key": "moonshot",
     }
     return mapping.get(auth_source, auth_source)
 
@@ -301,6 +309,8 @@ def default_auth_source_for_provider(provider: str, api_format: str | None = Non
         return "bedrock_api_key"
     if provider == "vertex":
         return "vertex_api_key"
+    if provider == "moonshot":
+        return "moonshot_api_key"
     if provider == "openai" or api_format == "openai":
         return "openai_api_key"
     return "anthropic_api_key"
@@ -604,6 +614,7 @@ class Settings(BaseModel):
             "anthropic_api_key": "ANTHROPIC_API_KEY",
             "openai_api_key": "OPENAI_API_KEY",
             "dashscope_api_key": "DASHSCOPE_API_KEY",
+            "moonshot_api_key": "MOONSHOT_API_KEY",
         }.get(auth_source)
         if env_var:
             env_value = os.environ.get(env_var, "")


### PR DESCRIPTION
## Summary

- What problem does this PR solve?

Currently, Moonshot (Kimi) is not natively supported as a named provider in the interactive CLI login menu or auth manager. Users had to manually configure it as a generic OpenAI-compatible provider.

- What changed?

- Added moonshot to _KNOWN_PROVIDERS and _AUTH_SOURCES in src/openharness/auth/manager.py .
- Added Moonshot (Kimi) to the interactive login menu and auth source labels in src/openharness/cli.py .
- Added a built-in provider profile for moonshot in src/openharness/config/settings.py defaulting to the kimi-k2.5 model.
- Mapped the MOONSHOT_API_KEY environment variable for automatic detection.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q`
- [x] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue:
- Follow-up work:
