### PR TITLE
fix(mcp): handle disconnected server in call_tool and read_resource

### DIFF
--- a/src/openharness/mcp/__init__.py
+++ b/src/openharness/mcp/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from openharness.mcp.client import McpClientManager
+    from openharness.mcp.client import McpClientManager, McpServerNotConnectedError
     from openharness.mcp.types import (
         McpConnectionStatus,
         McpHttpServerConfig,
@@ -20,6 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = [
     "McpClientManager",
     "McpConnectionStatus",
+    "McpServerNotConnectedError",
     "McpHttpServerConfig",
     "McpJsonConfig",
     "McpResourceInfo",
@@ -36,6 +37,10 @@ def __getattr__(name: str):
         from openharness.mcp.client import McpClientManager
 
         return McpClientManager
+    if name == "McpServerNotConnectedError":
+        from openharness.mcp.client import McpServerNotConnectedError
+
+        return McpServerNotConnectedError
     if name == "load_mcp_server_configs":
         from openharness.mcp.config import load_mcp_server_configs
 

--- a/src/openharness/mcp/client.py
+++ b/src/openharness/mcp/client.py
@@ -17,6 +17,10 @@ from openharness.mcp.types import (
 )
 
 
+class McpServerNotConnectedError(Exception):
+    """Raised when an MCP server is not connected or its session has been lost."""
+
+
 class McpClientManager:
     """Manage MCP connections and expose tools/resources."""
 
@@ -91,8 +95,19 @@ class McpClientManager:
 
     async def call_tool(self, server_name: str, tool_name: str, arguments: dict[str, Any]) -> str:
         """Invoke one MCP tool and stringify the result."""
-        session = self._sessions[server_name]
-        result: CallToolResult = await session.call_tool(tool_name, arguments)
+        session = self._sessions.get(server_name)
+        if session is None:
+            status = self._statuses.get(server_name)
+            detail = status.detail if status else "unknown server"
+            raise McpServerNotConnectedError(
+                f"MCP server '{server_name}' is not connected: {detail}"
+            )
+        try:
+            result: CallToolResult = await session.call_tool(tool_name, arguments)
+        except Exception as exc:
+            raise McpServerNotConnectedError(
+                f"MCP server '{server_name}' call failed: {exc}"
+            ) from exc
         parts: list[str] = []
         for item in result.content:
             if getattr(item, "type", None) == "text":
@@ -107,8 +122,19 @@ class McpClientManager:
 
     async def read_resource(self, server_name: str, uri: str) -> str:
         """Read one MCP resource and stringify the response."""
-        session = self._sessions[server_name]
-        result: ReadResourceResult = await session.read_resource(uri)
+        session = self._sessions.get(server_name)
+        if session is None:
+            status = self._statuses.get(server_name)
+            detail = status.detail if status else "unknown server"
+            raise McpServerNotConnectedError(
+                f"MCP server '{server_name}' is not connected: {detail}"
+            )
+        try:
+            result: ReadResourceResult = await session.read_resource(uri)
+        except Exception as exc:
+            raise McpServerNotConnectedError(
+                f"MCP server '{server_name}' resource read failed: {exc}"
+            ) from exc
         parts: list[str] = []
         for item in result.contents:
             text = getattr(item, "text", None)

--- a/src/openharness/tools/mcp_tool.py
+++ b/src/openharness/tools/mcp_tool.py
@@ -6,7 +6,7 @@ import re
 
 from pydantic import BaseModel, Field, create_model
 
-from openharness.mcp.client import McpClientManager
+from openharness.mcp.client import McpClientManager, McpServerNotConnectedError
 from openharness.mcp.types import McpToolInfo
 from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
 
@@ -25,11 +25,14 @@ class McpToolAdapter(BaseTool):
 
     async def execute(self, arguments: BaseModel, context: ToolExecutionContext) -> ToolResult:
         del context
-        output = await self._manager.call_tool(
-            self._tool_info.server_name,
-            self._tool_info.name,
-            arguments.model_dump(mode="json"),
-        )
+        try:
+            output = await self._manager.call_tool(
+                self._tool_info.server_name,
+                self._tool_info.name,
+                arguments.model_dump(mode="json"),
+            )
+        except McpServerNotConnectedError as exc:
+            return ToolResult(output=str(exc), is_error=True)
         return ToolResult(output=output)
 
 

--- a/src/openharness/tools/read_mcp_resource_tool.py
+++ b/src/openharness/tools/read_mcp_resource_tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-from openharness.mcp.client import McpClientManager
+from openharness.mcp.client import McpClientManager, McpServerNotConnectedError
 from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
 
 
@@ -31,5 +31,8 @@ class ReadMcpResourceTool(BaseTool):
 
     async def execute(self, arguments: ReadMcpResourceToolInput, context: ToolExecutionContext) -> ToolResult:
         del context
-        output = await self._manager.read_resource(arguments.server, arguments.uri)
+        try:
+            output = await self._manager.read_resource(arguments.server, arguments.uri)
+        except McpServerNotConnectedError as exc:
+            return ToolResult(output=str(exc), is_error=True)
         return ToolResult(output=output)

--- a/tests/test_mcp/test_client_errors.py
+++ b/tests/test_mcp/test_client_errors.py
@@ -1,0 +1,111 @@
+"""Tests for MCP client error handling on disconnected servers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openharness.mcp.client import McpClientManager, McpServerNotConnectedError
+from openharness.mcp.types import McpConnectionStatus, McpStdioServerConfig, McpToolInfo
+from openharness.tools.base import ToolExecutionContext
+from openharness.tools.mcp_tool import McpToolAdapter
+from openharness.tools.read_mcp_resource_tool import ReadMcpResourceTool
+
+
+# --- McpClientManager.call_tool ---
+
+
+@pytest.mark.asyncio
+async def test_call_tool_raises_when_server_never_connected():
+    manager = McpClientManager({})
+    with pytest.raises(McpServerNotConnectedError, match="not connected"):
+        await manager.call_tool("missing", "some_tool", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_raises_when_server_failed_to_connect():
+    config = McpStdioServerConfig(command="false", args=[])
+    manager = McpClientManager({"bad": config})
+    manager._statuses["bad"] = McpConnectionStatus(
+        name="bad", state="failed", detail="Connection refused",
+    )
+    with pytest.raises(McpServerNotConnectedError, match="Connection refused"):
+        await manager.call_tool("bad", "tool", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_raises_when_session_errors():
+    manager = McpClientManager({})
+    mock_session = AsyncMock()
+    mock_session.call_tool.side_effect = RuntimeError("transport closed")
+    manager._sessions["flaky"] = mock_session
+
+    with pytest.raises(McpServerNotConnectedError, match="transport closed"):
+        await manager.call_tool("flaky", "tool", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_includes_unknown_server_detail_for_unconfigured():
+    """When the server name is not even in _statuses, detail says 'unknown server'."""
+    manager = McpClientManager({})
+    with pytest.raises(McpServerNotConnectedError, match="unknown server"):
+        await manager.call_tool("ghost", "tool", {})
+
+
+# --- McpClientManager.read_resource ---
+
+
+@pytest.mark.asyncio
+async def test_read_resource_raises_when_server_never_connected():
+    manager = McpClientManager({})
+    with pytest.raises(McpServerNotConnectedError, match="not connected"):
+        await manager.read_resource("missing", "res://data")
+
+
+@pytest.mark.asyncio
+async def test_read_resource_raises_when_session_errors():
+    manager = McpClientManager({})
+    mock_session = AsyncMock()
+    mock_session.read_resource.side_effect = OSError("broken pipe")
+    manager._sessions["flaky"] = mock_session
+
+    with pytest.raises(McpServerNotConnectedError, match="broken pipe"):
+        await manager.read_resource("flaky", "res://data")
+
+
+# --- McpToolAdapter catches error and returns ToolResult(is_error=True) ---
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_adapter_returns_error_result_on_disconnected_server():
+    manager = McpClientManager({})
+    tool_info = McpToolInfo(
+        server_name="gone",
+        name="hello",
+        description="test",
+        input_schema={"type": "object", "properties": {"x": {"type": "string"}}},
+    )
+    adapter = McpToolAdapter(manager, tool_info)
+    result = await adapter.execute(
+        adapter.input_model.model_validate({"x": "1"}),
+        ToolExecutionContext(cwd=Path(".")),
+    )
+    assert result.is_error is True
+    assert "not connected" in result.output
+
+
+# --- ReadMcpResourceTool catches error and returns ToolResult(is_error=True) ---
+
+
+@pytest.mark.asyncio
+async def test_read_mcp_resource_tool_returns_error_result_on_disconnected_server():
+    manager = McpClientManager({})
+    tool = ReadMcpResourceTool(manager)
+    result = await tool.execute(
+        tool.input_model.model_validate({"server": "gone", "uri": "res://x"}),
+        ToolExecutionContext(cwd=Path(".")),
+    )
+    assert result.is_error is True
+    assert "not connected" in result.output


### PR DESCRIPTION
## Problem

`McpClientManager.call_tool()` and `read_resource()` access `self._sessions[server_name]` directly with no guard. If an MCP server failed to connect, disconnected mid-session, or was cleared by `close()`/`reconnect_all()`, this raises a raw `KeyError` that crashes the tool call and can end the entire conversation turn.

## Change

- Replace bare `self._sessions[server_name]` dict access with `.get()` and raise a descriptive `McpServerNotConnectedError` that includes the server's failure detail from `_statuses`.
- Wrap `session.call_tool()` / `session.read_resource()` in try/except to catch transport-level errors (broken pipe, closed connection) and surface them as the same exception type.
- `McpToolAdapter` and `ReadMcpResourceTool` now catch `McpServerNotConnectedError` and return `ToolResult(is_error=True)` so the model receives a clean error message instead of an unhandled crash.
- Export `McpServerNotConnectedError` from the `mcp` package `__init__.py`.

## Files changed

| File | What |
|------|------|
| `src/openharness/mcp/client.py` | Add `McpServerNotConnectedError`; guard both methods |
| `src/openharness/mcp/__init__.py` | Export the new exception |
| `src/openharness/tools/mcp_tool.py` | Catch error, return `ToolResult(is_error=True)` |
| `src/openharness/tools/read_mcp_resource_tool.py` | Catch error, return `ToolResult(is_error=True)` |
| `tests/test_mcp/test_client_errors.py` | 8 new tests |

## Verification

```
uv run ruff check src tests scripts   # All checks passed
uv run pytest -q                       # 465 passed, 6 skipped, 1 xfailed
```

All existing tests continue to pass, including the real stdio MCP integration test.