### PR TITLE
fix: Support max_completion_tokens for newer models

### DIFF
--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -36,6 +36,21 @@ log = logging.getLogger(__name__)
 MAX_RETRIES = 3
 BASE_DELAY = 1.0
 MAX_DELAY = 30.0
+_MAX_COMPLETION_TOKEN_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _token_limit_param_for_model(model: str, max_tokens: int) -> dict[str, int]:
+    """Return the correct token limit field for the target OpenAI model.
+
+    GPT-5 and the current reasoning-model families reject ``max_tokens`` and
+    require ``max_completion_tokens`` instead.
+    """
+    normalized = model.strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    if normalized.startswith(_MAX_COMPLETION_TOKEN_MODEL_PREFIXES):
+        return {"max_completion_tokens": max_tokens}
+    return {"max_tokens": max_tokens}
 
 
 def _convert_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -221,10 +236,10 @@ class OpenAICompatibleClient:
         params: dict[str, Any] = {
             "model": request.model,
             "messages": openai_messages,
-            "max_tokens": request.max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        params.update(_token_limit_param_for_model(request.model, request.max_tokens))
         if openai_tools:
             params["tools"] = openai_tools
             # Some providers (Kimi) error on empty reasoning_content in

--- a/tests/test_api/test_openai_client.py
+++ b/tests/test_api/test_openai_client.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from openharness.api.client import ApiMessageRequest
 from openharness.api.openai_client import (
+    OpenAICompatibleClient,
     _convert_messages_to_openai,
     _convert_tools_to_openai,
+    _token_limit_param_for_model,
 )
 from openharness.engine.messages import (
     ConversationMessage,
@@ -167,3 +172,83 @@ class TestConvertMessagesToOpenai:
         assert len(result) == 2
         assert result[0]["tool_call_id"] == "c1"
         assert result[1]["tool_call_id"] == "c2"
+
+
+class TestTokenLimitParams:
+    def test_gpt5_uses_max_completion_tokens(self):
+        assert _token_limit_param_for_model("gpt-5.4", 4096) == {"max_completion_tokens": 4096}
+
+    def test_legacy_chat_models_keep_max_tokens(self):
+        assert _token_limit_param_for_model("gpt-4o", 4096) == {"max_tokens": 4096}
+
+
+class _FakeUsage:
+    prompt_tokens = 11
+    completion_tokens = 7
+
+
+class _FakeChunk:
+    def __init__(self) -> None:
+        self.choices = []
+        self.usage = _FakeUsage()
+
+
+class _FakeCompletions:
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, object] | None = None
+
+    async def create(self, **kwargs):
+        self.last_kwargs = kwargs
+
+        async def _stream():
+            yield _FakeChunk()
+
+        return _stream()
+
+
+class _FakeChat:
+    def __init__(self) -> None:
+        self.completions = _FakeCompletions()
+
+
+class _FakeOpenAIClient:
+    def __init__(self) -> None:
+        self.chat = _FakeChat()
+
+
+class TestStreamMessageTokenParams:
+    @pytest.mark.asyncio
+    async def test_gpt5_stream_uses_max_completion_tokens(self):
+        client = OpenAICompatibleClient(api_key="test-key")
+        fake_sdk = _FakeOpenAIClient()
+        client._client = fake_sdk
+
+        request = ApiMessageRequest(
+            model="gpt-5.4",
+            messages=[ConversationMessage.from_user_text("Explain the codebase")],
+        )
+
+        events = [event async for event in client.stream_message(request)]
+
+        assert events
+        assert fake_sdk.chat.completions.last_kwargs is not None
+        assert "max_completion_tokens" in fake_sdk.chat.completions.last_kwargs
+        assert "max_tokens" not in fake_sdk.chat.completions.last_kwargs
+
+    @pytest.mark.asyncio
+    async def test_gpt4o_stream_keeps_max_tokens(self):
+        client = OpenAICompatibleClient(api_key="test-key")
+        fake_sdk = _FakeOpenAIClient()
+        client._client = fake_sdk
+
+        request = ApiMessageRequest(
+            model="gpt-4o",
+            messages=[ConversationMessage.from_user_text("Explain the codebase")],
+        )
+
+        events = [event async for event in client.stream_message(request)]
+
+        assert events
+        assert fake_sdk.chat.completions.last_kwargs is not None
+        assert "max_tokens" in fake_sdk.chat.completions.last_kwargs
+        assert "max_completion_tokens" not in fake_sdk.chat.completions.last_kwargs


### PR DESCRIPTION
Add _token_limit_param_for_model to map max_tokens vs max_completion_tokens for models that require the latter (e.g. gpt-5 and reasoning-model families).

## Summary

## What problem does this PR solve?
chatgpt 5.4 and reasoning models use max_completion_tokens instead of max_tokens in payload
##  What changed?
added a few helpers to delegate

## Validation

- [X] `uv run ruff check src tests scripts`
- [X] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

