### PR TITLE
fix: windows下， uv run oh 启动后，新cmd一闪而过，无法看见具体的错误信息

### DIFF
--- a/frontend/terminal/src/hooks/useBackendSession.ts
+++ b/frontend/terminal/src/hooks/useBackendSession.ts
@@ -72,10 +72,14 @@ export function useBackendSession(config: FrontendConfig, onExit: (code?: number
 
 	useEffect(() => {
 		const [command, ...args] = config.backend_command;
+		const useDetachedGroup = process.platform !== 'win32';
 		const child = spawn(command, args, {
 			stdio: ['pipe', 'pipe', 'inherit'],
 			env: process.env,
-			detached: true,
+			// On Windows, a detached child gets its own console window and can
+			// flash open/closed. Keep detached groups for POSIX only.
+			detached: useDetachedGroup,
+			windowsHide: true,
 		});
 		childRef.current = child;
 
@@ -98,10 +102,13 @@ export function useBackendSession(config: FrontendConfig, onExit: (code?: number
 		// Ensure child processes are killed on parent exit (prevents stale processes)
 		const killChild = (): void => {
 			if (!child.killed) {
-				// Kill process group to ensure Python backend and its children all die
+				// Kill the whole process group on POSIX. On Windows, terminate the
+				// direct child to avoid relying on negative PIDs.
 				try {
-					if (child.pid) {
+					if (useDetachedGroup && child.pid) {
 						process.kill(-child.pid, 'SIGTERM');
+					} else {
+						child.kill('SIGTERM');
 					}
 				} catch {
 					child.kill('SIGTERM');


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
Windows下，uv run oh 启动后 新cmd一闪而过
![001](https://github.com/user-attachments/assets/028a494d-a510-406f-b390-111971d4b050)

- What changed?
frontend/terminal/src/hooks/useBackendSession.ts
对windows不使用新的弹窗，直接在之前的弹窗显示具体的错误提示
![002](https://github.com/user-attachments/assets/c0b41bd8-27c1-44ff-8cc7-31f80ed5cbfa)

## Validation

- [ ] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue:
- Follow-up work:
