### PR TITLE
fix(backend-host): add missing cwd field to BackendHostConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- `BackendHostConfig` was missing the `cwd` field, causing `AttributeError: 'BackendHostConfig' object has no attribute 'cwd'` on startup when `oh` was run after the runtime refactor that added `cwd` support to `build_runtime`.
 - Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.
 - Memory scanner now parses YAML frontmatter (`name`, `description`, `type`) instead of returning raw `---` as description.

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -51,6 +51,7 @@ class BackendHostConfig:
     api_format: str | None = None
     active_profile: str | None = None
     api_client: SupportsStreamingMessages | None = None
+    cwd: str | None = None
     restore_messages: list[dict] | None = None
     enforce_max_turns: bool = True
     permission_mode: str | None = None
@@ -742,6 +743,7 @@ async def run_backend_host(
             api_format=api_format,
             active_profile=active_profile,
             api_client=api_client,
+            cwd=cwd,
             restore_messages=restore_messages,
             enforce_max_turns=enforce_max_turns,
             permission_mode=permission_mode,


### PR DESCRIPTION
Fixes #78
Fixes #79

## Summary

Commit `a6a4c3d` added `cwd=self._config.cwd` to the `build_runtime()` call inside `ReactBackendHost.run()` but omitted the field from the config dataclass and forgot to wire it through in `run_backend_host()`. This caused an `AttributeError` on every `oh` startup, making the app completely unusable.

**Changes:**
- Add `cwd: str | None = None` to `BackendHostConfig`
- Pass `cwd=cwd` when constructing `BackendHostConfig` in `run_backend_host()`

## Validation

- [x] `uv run ruff check src tests scripts` — All checks passed
- [x] `uv run pytest -q` — 521 passed, 8 pre-existing failures unrelated to this change
- [x] `oh` starts successfully after fix
- [ ] Frontend not touched

## Notes

- Related issues: #78 #79
- Root cause introduced by `a6a4c3d`