### PR TITLE
fix(ohmo): align user profile docs with user.md path

### DIFF
--- a/ohmo/workspace.py
+++ b/ohmo/workspace.py
@@ -48,7 +48,7 @@ Sound like a capable companion with taste, not a corporate support bot.
 ## Continuity
 
 Your continuity lives in this workspace:
-- `USER.md` tells you who the user is.
+- `user.md` tells you who the user is.
 - `memory/` holds durable notes and recurring context.
 - `state.json` and session history tell you what has been happening recently.
 
@@ -57,7 +57,7 @@ Read these files. Update them when something should persist.
 If you materially change this file, tell the user. It is your soul.
 """
 
-USER_TEMPLATE = """# USER.md - About Your Human
+USER_TEMPLATE = """# user.md - About Your Human
 
 Learn the person you are helping. Keep this useful, respectful, and current.
 
@@ -137,7 +137,7 @@ enough to become useful.
 
 3. Make the workspace real.
    - Update `IDENTITY.md`
-   - Update `USER.md`
+   - Update `user.md`
    - If something durable matters, write it into `memory/`
 
 ## Style


### PR DESCRIPTION
## Summary

- **What problem does this PR solve?**  
  Ohmo’s code and CLI use `get_user_path()` → **`user.md`**, while workspace bootstrap prompts (`SOUL.md`, `USER` template, `BOOTSTRAP.md`) referred to **`USER.md`**. On case-sensitive filesystems (e.g. Linux), agents following the prompts can create a separate **`USER.md`**, diverging from the canonical file the app reads.

- **What changed?**  
  Aligned all in-repo template text in `ohmo/workspace.py` to **`user.md`** (SOUL continuity line, USER template title, BOOTSTRAP checklist) so prompts match the implementation and reduce wrong-path writes.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q`
- [x] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched) — **N/A** (no frontend changes)

## Notes

- **Related issue:** *(none filed; can link if you open one)*  
- **Follow-up:** Existing `~/.ohmo/soul.md` / `BOOTSTRAP.md` copies are not auto-migrated; users may manually replace `USER.md` with `user.md` in wording if they rely on old text.