### PR TITLE
feat(frontend): render assistant markdown in React TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 - `CONTRIBUTING.md` with local setup, validation commands, and PR expectations.
 - `docs/SHOWCASE.md` with concrete OpenHarness usage patterns and demo commands.
 - GitHub issue templates and a pull request template.
+- React TUI assistant messages now render structured Markdown blocks, including headings, lists, code fences, blockquotes, links, and tables.
 
 ### Fixed
 
@@ -27,6 +28,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 - Memory search tokenizer handles Han characters for multilingual queries.
 - Fixed duplicate response in React TUI caused by double Enter key submission in the input handler.
 - Fixed concurrent permission modals overwriting each other in TUI default mode when the LLM returns multiple tool calls in one response; `_ask_permission` now serialises callers via an `asyncio.Lock` so each modal is shown and resolved before the next one is emitted.
+- Fixed React TUI Markdown tables to size columns from rendered cell text so inline formatting like code spans and bold text no longer breaks alignment.
 
 ### Changed
 

--- a/frontend/terminal/package-lock.json
+++ b/frontend/terminal/package-lock.json
@@ -8,7 +8,9 @@
       "dependencies": {
         "ink": "^5.1.0",
         "ink-text-input": "^6.0.0",
-        "react": "^18.3.1"
+        "marked": "^18.0.0",
+        "react": "^18.3.1",
+        "string-width": "^7.2.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
@@ -891,6 +893,18 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mimic-fn": {

--- a/frontend/terminal/package.json
+++ b/frontend/terminal/package.json
@@ -8,7 +8,9 @@
   "dependencies": {
     "ink": "^5.1.0",
     "ink-text-input": "^6.0.0",
-    "react": "^18.3.1"
+    "marked": "^18.0.0",
+    "react": "^18.3.1",
+    "string-width": "^7.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",

--- a/frontend/terminal/src/components/ConversationView.tsx
+++ b/frontend/terminal/src/components/ConversationView.tsx
@@ -3,6 +3,7 @@ import {Box, Text} from 'ink';
 
 import {useTheme} from '../theme/ThemeContext.js';
 import type {TranscriptItem} from '../types.js';
+import {MarkdownText} from './MarkdownText.js';
 import {ToolCallDisplay} from './ToolCallDisplay.js';
 import {WelcomeBanner} from './WelcomeBanner.js';
 
@@ -54,8 +55,10 @@ function MessageRow({item, theme}: {item: TranscriptItem; theme: ReturnType<type
 				<Box marginTop={1} marginBottom={0} flexDirection="column">
 					<Text>
 						<Text color={theme.colors.success} bold>{theme.icons.assistant}</Text>
-						<Text>{item.text}</Text>
 					</Text>
+					<Box marginLeft={2} flexDirection="column">
+						<MarkdownText content={item.text} />
+					</Box>
 				</Box>
 			);
 

--- a/frontend/terminal/src/components/MarkdownText.test.tsx
+++ b/frontend/terminal/src/components/MarkdownText.test.tsx
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {PassThrough} from 'node:stream';
+import React from 'react';
+import {render} from 'ink';
+
+import {ThemeProvider} from '../theme/ThemeContext.js';
+import {MarkdownText} from './MarkdownText.js';
+
+const stripAnsi = (value: string): string => value.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
+
+type InkTestStdout = PassThrough & {
+	isTTY: boolean;
+	columns: number;
+	rows: number;
+	cursorTo: () => boolean;
+	clearLine: () => boolean;
+	moveCursor: () => boolean;
+};
+
+function createTestStdout(): InkTestStdout {
+	return Object.assign(new PassThrough(), {
+		isTTY: true,
+		columns: 120,
+		rows: 40,
+		cursorTo: () => true,
+		clearLine: () => true,
+		moveCursor: () => true,
+	});
+}
+
+async function renderTableLines(content: string): Promise<string[]> {
+	const stdout = createTestStdout();
+
+	let output = '';
+	stdout.on('data', (chunk) => {
+		output += chunk.toString();
+	});
+
+	const instance = render(
+		<ThemeProvider initialTheme="default">
+			<MarkdownText content={content} />
+		</ThemeProvider>,
+		{stdout: stdout as unknown as NodeJS.WriteStream, debug: true, patchConsole: false},
+	);
+
+	await new Promise((resolve) => setTimeout(resolve, 80));
+	instance.unmount();
+	instance.cleanup();
+	await new Promise((resolve) => setTimeout(resolve, 20));
+
+	return stripAnsi(output)
+		.split('\n')
+		.filter((line) => /[┌├│└]/.test(line))
+		.slice(0, 5);
+}
+
+test('keeps table borders aligned when cells contain inline markdown', async () => {
+	const lines = await renderTableLines('| `aa` | bb |\n|------|----|\n| c | **ddd** |');
+
+	assert.equal(lines.length, 5);
+
+	const widths = lines.map((line) => [...line].length);
+	assert.ok(
+		widths.every((width) => width === widths[0]),
+		`Expected table lines to share a width, got ${JSON.stringify(
+			lines.map((line, index) => ({line, width: widths[index]})),
+		)}`,
+	);
+});

--- a/frontend/terminal/src/components/MarkdownText.test.tsx
+++ b/frontend/terminal/src/components/MarkdownText.test.tsx
@@ -8,6 +8,7 @@ import {ThemeProvider} from '../theme/ThemeContext.js';
 import {MarkdownText} from './MarkdownText.js';
 
 const stripAnsi = (value: string): string => value.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
+const nextLoopTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
 type InkTestStdout = PassThrough & {
 	isTTY: boolean;
@@ -29,7 +30,25 @@ function createTestStdout(): InkTestStdout {
 	});
 }
 
-async function renderTableLines(content: string): Promise<string[]> {
+async function waitForOutputToStabilize(getOutput: () => string): Promise<string> {
+	let previous = '';
+	let sawOutput = false;
+
+	for (let i = 0; i < 50; i++) {
+		await nextLoopTurn();
+		const current = getOutput();
+		sawOutput ||= current.length > 0;
+		if (sawOutput && current === previous) {
+			return current;
+		}
+
+		previous = current;
+	}
+
+	throw new Error(`Ink output did not stabilize: ${JSON.stringify(previous)}`);
+}
+
+async function renderMarkdownLines(content: string): Promise<string[]> {
 	const stdout = createTestStdout();
 
 	let output = '';
@@ -44,13 +63,20 @@ async function renderTableLines(content: string): Promise<string[]> {
 		{stdout: stdout as unknown as NodeJS.WriteStream, debug: true, patchConsole: false},
 	);
 
-	await new Promise((resolve) => setTimeout(resolve, 80));
+	const exitPromise = instance.waitUntilExit();
+	const stableOutput = await waitForOutputToStabilize(() => output);
 	instance.unmount();
+	await exitPromise;
+	await waitForOutputToStabilize(() => output);
 	instance.cleanup();
-	await new Promise((resolve) => setTimeout(resolve, 20));
 
-	return stripAnsi(output)
+	return stripAnsi(stableOutput)
 		.split('\n')
+		.filter(Boolean);
+}
+
+async function renderTableLines(content: string): Promise<string[]> {
+	return (await renderMarkdownLines(content))
 		.filter((line) => /[┌├│└]/.test(line))
 		.slice(0, 5);
 }
@@ -67,4 +93,27 @@ test('keeps table borders aligned when cells contain inline markdown', async () 
 			lines.map((line, index) => ({line, width: widths[index]})),
 		)}`,
 	);
+});
+
+test('renders unknown inline table tokens using the visible token text fallback', async () => {
+	const lines = await renderTableLines('| ![alt](https://example.com/img.png) | ok |\n|---|---|\n| x | y |');
+
+	assert.equal(lines.length, 5);
+	assert.match(lines[1] ?? '', /\balt\b/);
+	assert.doesNotMatch(lines[1] ?? '', /!\[alt\]/);
+
+	const widths = lines.map((line) => [...line].length);
+	assert.ok(
+		widths.every((width) => width === widths[0]),
+		`Expected fallback-token table lines to share a width, got ${JSON.stringify(
+			lines.map((line, index) => ({line, width: widths[index]})),
+		)}`,
+	);
+});
+
+test('preserves nested markdown structure inside blockquotes', async () => {
+	const lines = await renderMarkdownLines('> - first\n> - second');
+
+	assert.ok(lines.some((line) => line.includes('• first')), `Expected blockquote output to include a rendered bullet: ${JSON.stringify(lines)}`);
+	assert.ok(lines.some((line) => line.includes('• second')), `Expected blockquote output to include the second rendered bullet: ${JSON.stringify(lines)}`);
 });

--- a/frontend/terminal/src/components/MarkdownText.tsx
+++ b/frontend/terminal/src/components/MarkdownText.tsx
@@ -1,0 +1,306 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+import {lexer, type Token, type Tokens} from 'marked';
+import stringWidth from 'string-width';
+
+import {useTheme} from '../theme/ThemeContext.js';
+import type {ThemeConfig} from '../theme/builtinThemes.js';
+
+function getInlineDisplayText(tokens: Token[] | undefined): string {
+	if (!tokens || tokens.length === 0) {
+		return '';
+	}
+
+	return tokens.map((token) => {
+		switch (token.type) {
+			case 'text': {
+				const t = token as Tokens.Text;
+				return t.tokens && t.tokens.length > 0 ? getInlineDisplayText(t.tokens) : t.text;
+			}
+			case 'strong':
+			case 'em':
+			case 'del':
+				return getInlineDisplayText((token as Tokens.Strong | Tokens.Em | Tokens.Del).tokens);
+			case 'codespan':
+				return (token as Tokens.Codespan).text;
+			case 'link': {
+				const l = token as Tokens.Link;
+				return l.text || l.href;
+			}
+			case 'br':
+				return '\n';
+			case 'escape':
+				return (token as Tokens.Escape).text;
+			default:
+				if ('text' in token && typeof token.text === 'string') {
+					return token.text;
+				}
+				return token.raw;
+		}
+	}).join('');
+}
+
+function getTableCellDisplayText(cell: Tokens.TableCell): string {
+	const displayText = getInlineDisplayText(cell.tokens);
+	return displayText.length > 0 ? displayText : cell.text;
+}
+
+// ---------------------------------------------------------------------------
+// Inline token renderer — returns an array of <Text> elements
+// ---------------------------------------------------------------------------
+function renderInline(tokens: Token[] | undefined, theme: ThemeConfig): React.ReactNode {
+	if (!tokens || tokens.length === 0) {
+		return null;
+	}
+	return tokens.map((token, i) => {
+		switch (token.type) {
+			case 'text': {
+				const t = token as Tokens.Text;
+				// text tokens can themselves contain inline children (e.g. inside list items)
+				if (t.tokens && t.tokens.length > 0) {
+					return <React.Fragment key={i}>{renderInline(t.tokens, theme)}</React.Fragment>;
+				}
+				return <Text key={i}>{t.text}</Text>;
+			}
+			case 'strong': {
+				const s = token as Tokens.Strong;
+				return (
+					<Text key={i} bold>
+						{renderInline(s.tokens, theme)}
+					</Text>
+				);
+			}
+			case 'em': {
+				const e = token as Tokens.Em;
+				return (
+					<Text key={i} italic>
+						{renderInline(e.tokens, theme)}
+					</Text>
+				);
+			}
+			case 'del': {
+				const d = token as Tokens.Del;
+				return (
+					<Text key={i} strikethrough>
+						{renderInline(d.tokens, theme)}
+					</Text>
+				);
+			}
+			case 'codespan': {
+				const c = token as Tokens.Codespan;
+				return (
+					<Text key={i} color={theme.colors.accent}>
+						{c.text}
+					</Text>
+				);
+			}
+			case 'link': {
+				const l = token as Tokens.Link;
+				const label = l.text || l.href;
+				return (
+					<Text key={i} color={theme.colors.info}>
+						{label}
+					</Text>
+				);
+			}
+			case 'br':
+				return <Text key={i}>{'\n'}</Text>;
+			case 'escape': {
+				const es = token as Tokens.Escape;
+				return <Text key={i}>{es.text}</Text>;
+			}
+			default:
+				return <Text key={i}>{token.raw}</Text>;
+		}
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Block token renderer
+// ---------------------------------------------------------------------------
+function MarkdownBlock({
+	token,
+	theme,
+}: {
+	token: Token;
+	theme: ThemeConfig;
+}): React.JSX.Element | null {
+	switch (token.type) {
+		case 'heading': {
+			const h = token as Tokens.Heading;
+			const headingColors: string[] = [
+				theme.colors.primary,
+				theme.colors.secondary,
+				theme.colors.accent,
+				theme.colors.info,
+				theme.colors.muted,
+				theme.colors.muted,
+			];
+			const color = headingColors[h.depth - 1] ?? theme.colors.primary;
+			const isMajor = h.depth <= 2;
+			return (
+				<Box marginTop={1} flexDirection="column">
+					<Text color={color} bold={isMajor} underline={h.depth === 1}>
+						{renderInline(h.tokens, theme)}
+					</Text>
+					{h.depth === 1 ? <Text color={color} dimColor>{'━'.repeat(32)}</Text> : null}
+				</Box>
+			);
+		}
+
+		case 'paragraph': {
+			const p = token as Tokens.Paragraph;
+			return (
+				<Box marginTop={0} flexWrap="wrap">
+					<Text>{renderInline(p.tokens, theme)}</Text>
+				</Box>
+			);
+		}
+
+		case 'code': {
+			const c = token as Tokens.Code;
+			const lines = c.text.split('\n');
+			return (
+				<Box flexDirection="column" marginTop={1} marginLeft={2} borderStyle="round" paddingX={1} borderColor={theme.colors.muted}>
+					{c.lang ? (
+						<Text dimColor>{c.lang}</Text>
+					) : null}
+					{lines.map((line, i) => (
+						<Text key={i} color={theme.colors.accent}>
+							{line}
+						</Text>
+					))}
+				</Box>
+			);
+		}
+
+		case 'blockquote': {
+			const bq = token as Tokens.Blockquote;
+			return (
+				<Box flexDirection="column" marginTop={0} marginLeft={0}>
+					{bq.tokens.map((t, i) => (
+						<Box key={i} flexDirection="row">
+							<Text color={theme.colors.muted}>{'│ '}</Text>
+							<Box flexGrow={1}>
+								<Text dimColor>
+									{t.type === 'paragraph'
+										? renderInline((t as Tokens.Paragraph).tokens, theme)
+										: (t as Token).raw}
+								</Text>
+							</Box>
+						</Box>
+					))}
+				</Box>
+			);
+		}
+
+		case 'list': {
+			const l = token as Tokens.List;
+			return (
+				<Box flexDirection="column" marginTop={0} marginLeft={2}>
+					{l.items.map((item, i) => {
+						// For tight lists, item.tokens = [{type:'text', tokens:[...inline]}]
+						// For loose lists, item.tokens = [{type:'paragraph', tokens:[...inline]}]
+						const inlineTokens: Token[] = item.tokens.flatMap((t) =>
+							'tokens' in t && t.tokens ? (t.tokens as Token[]) : [],
+						);
+						const bullet = l.ordered ? `${(Number(l.start) || 1) + i}. ` : '• ';
+						return (
+							<Box key={i} flexDirection="row">
+								<Text color={theme.colors.primary}>{bullet}</Text>
+								<Box flexGrow={1}>
+									<Text>
+										{inlineTokens.length > 0
+											? renderInline(inlineTokens, theme)
+											: item.text}
+									</Text>
+								</Box>
+							</Box>
+						);
+					})}
+				</Box>
+			);
+		}
+
+		case 'hr':
+			return (
+				<Box marginTop={1}>
+					<Text dimColor>{'─'.repeat(48)}</Text>
+				</Box>
+			);
+
+		case 'space':
+			return null;
+
+		case 'table': {
+			const t = token as Tokens.Table;
+			const headerTexts = t.header.map(getTableCellDisplayText);
+			const rowTexts = t.rows.map((row) => row.map(getTableCellDisplayText));
+			// Use stringWidth for correct CJK / wide-char column widths
+			const colCount = t.header.length;
+			const colWidths: number[] = headerTexts.map((cellText) => stringWidth(cellText));
+			for (const row of rowTexts) {
+				for (let c = 0; c < colCount; c++) {
+					colWidths[c] = Math.max(colWidths[c] ?? 0, stringWidth(row[c] ?? ''));
+				}
+			}
+			const trailing = (cellText: string, c: number): string =>
+				' '.repeat(Math.max(0, (colWidths[c] ?? 0) - stringWidth(cellText)));
+			const top = '┌' + colWidths.map((w) => '─'.repeat(w + 2)).join('┬') + '┐';
+			const mid = '├' + colWidths.map((w) => '─'.repeat(w + 2)).join('┼') + '┤';
+			const bot = '└' + colWidths.map((w) => '─'.repeat(w + 2)).join('┴') + '┘';
+			return (
+				<Box flexDirection="column" marginTop={1} marginLeft={1}>
+					<Text color={theme.colors.muted}>{top}</Text>
+					<Text>
+						<Text color={theme.colors.muted}>{'│'}</Text>
+						{t.header.map((cell, c) => (
+							<React.Fragment key={c}>
+								<Text color={theme.colors.primary} bold>
+									{' '}{renderInline(cell.tokens, theme)}{trailing(headerTexts[c] ?? '', c)}{' '}
+								</Text>
+								<Text color={theme.colors.muted}>{'│'}</Text>
+							</React.Fragment>
+						))}
+					</Text>
+					<Text color={theme.colors.muted}>{mid}</Text>
+					{t.rows.map((row, i) => (
+						<Text key={i}>
+							<Text color={theme.colors.muted}>{'│'}</Text>
+							{row.map((cell, c) => (
+								<React.Fragment key={c}>
+									<Text>
+										{' '}{renderInline(cell.tokens, theme)}{trailing(rowTexts[i]?.[c] ?? '', c)}{' '}
+									</Text>
+									<Text color={theme.colors.muted}>{'│'}</Text>
+								</React.Fragment>
+							))}
+						</Text>
+					))}
+					<Text color={theme.colors.muted}>{bot}</Text>
+				</Box>
+			);
+		}
+
+		default:
+			if ((token as Token).raw) {
+				return <Text>{(token as Token).raw}</Text>;
+			}
+			return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+export function MarkdownText({content}: {content: string}): React.JSX.Element {
+	const {theme} = useTheme();
+	const tokens = lexer(content);
+	return (
+		<Box flexDirection="column">
+			{tokens.map((token, i) => (
+				<MarkdownBlock key={i} token={token} theme={theme} />
+			))}
+		</Box>
+	);
+}

--- a/frontend/terminal/src/components/MarkdownText.tsx
+++ b/frontend/terminal/src/components/MarkdownText.tsx
@@ -6,6 +6,14 @@ import stringWidth from 'string-width';
 import {useTheme} from '../theme/ThemeContext.js';
 import type {ThemeConfig} from '../theme/builtinThemes.js';
 
+function getInlineFallbackText(token: Token): string {
+	if ('text' in token && typeof token.text === 'string') {
+		return token.text;
+	}
+
+	return token.raw;
+}
+
 function getInlineDisplayText(tokens: Token[] | undefined): string {
 	if (!tokens || tokens.length === 0) {
 		return '';
@@ -32,10 +40,7 @@ function getInlineDisplayText(tokens: Token[] | undefined): string {
 			case 'escape':
 				return (token as Tokens.Escape).text;
 			default:
-				if ('text' in token && typeof token.text === 'string') {
-					return token.text;
-				}
-				return token.raw;
+				return getInlineFallbackText(token);
 		}
 	}).join('');
 }
@@ -110,9 +115,19 @@ function renderInline(tokens: Token[] | undefined, theme: ThemeConfig): React.Re
 				return <Text key={i}>{es.text}</Text>;
 			}
 			default:
-				return <Text key={i}>{token.raw}</Text>;
+				return <Text key={i}>{getInlineFallbackText(token)}</Text>;
 		}
 	});
+}
+
+function renderBlocks(tokens: Token[] | undefined, theme: ThemeConfig): React.ReactNode {
+	if (!tokens || tokens.length === 0) {
+		return null;
+	}
+
+	return tokens.map((token, i) => (
+		<MarkdownBlock key={i} token={token} theme={theme} />
+	));
 }
 
 // ---------------------------------------------------------------------------
@@ -181,12 +196,8 @@ function MarkdownBlock({
 					{bq.tokens.map((t, i) => (
 						<Box key={i} flexDirection="row">
 							<Text color={theme.colors.muted}>{'│ '}</Text>
-							<Box flexGrow={1}>
-								<Text dimColor>
-									{t.type === 'paragraph'
-										? renderInline((t as Tokens.Paragraph).tokens, theme)
-										: (t as Token).raw}
-								</Text>
+							<Box flexDirection="column" flexGrow={1}>
+								{renderBlocks([t], theme)}
 							</Box>
 						</Box>
 					))}
@@ -293,14 +304,12 @@ function MarkdownBlock({
 // ---------------------------------------------------------------------------
 // Public component
 // ---------------------------------------------------------------------------
-export function MarkdownText({content}: {content: string}): React.JSX.Element {
+export const MarkdownText = React.memo(function MarkdownText({content}: {content: string}): React.JSX.Element {
 	const {theme} = useTheme();
-	const tokens = lexer(content);
+	const tokens = React.useMemo(() => lexer(content), [content]);
 	return (
 		<Box flexDirection="column">
-			{tokens.map((token, i) => (
-				<MarkdownBlock key={i} token={token} theme={theme} />
-			))}
+			{renderBlocks(tokens, theme)}
 		</Box>
 	);
-}
+});


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  - React TUI assistant output was rendered as plain text, which dropped markdown structure and made tables hard to read.
  - When markdown tables contained inline formatting such as `` `code` `` or `**bold**`, column sizing could diverge from the visible cell text and leave borders misaligned.
- What changed?
  - Render assistant transcript rows with `MarkdownText` in `frontend/terminal/src/components/ConversationView.tsx`.
  - Add a reusable markdown renderer for the React TUI, including width-aware table rendering based on displayed cell content.
  - Add `marked` and `string-width` as frontend dependencies.
  - Add a regression test for markdown table alignment and a changelog entry for the user-visible improvement.

## Validation

- [x] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q` *(currently fails on an existing baseline test: `tests/test_auth/test_external.py::test_cli_codex_login_binds_without_switching`, which expects the Moonshot `base_url` in the current tree)*
- [x] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)
- [x] `cd frontend/terminal && node --test --import tsx src/components/MarkdownText.test.tsx`

## Notes

- Related issue: Closes #88
- Follow-up work: Investigate the existing `test_cli_codex_login_binds_without_switching` baseline failure separately if it still needs a repo-level fix.
