### PR TITLE
[security] Harden path rules and web fetch network guards

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -220,7 +220,8 @@ async def _execute_tool_call(
         )
 
     # Normalize common tool inputs before permission checks so path rules apply
-    # consistently across built-in tools that use either `file_path` or `path`.
+    # consistently across built-in tools that use `file_path`, `path`, or
+    # directory-scoped roots such as `glob`/`grep`.
     _file_path = _resolve_permission_file_path(context.cwd, tool_input, parsed_input)
     _command = _extract_permission_command(tool_input, parsed_input)
     log.debug("permission check: %s read_only=%s path=%s cmd=%s",
@@ -290,7 +291,7 @@ def _resolve_permission_file_path(
     raw_input: dict[str, object],
     parsed_input: object,
 ) -> str | None:
-    for key in ("file_path", "path"):
+    for key in ("file_path", "path", "root"):
         value = raw_input.get(key)
         if isinstance(value, str) and value.strip():
             path = Path(value).expanduser()
@@ -298,7 +299,7 @@ def _resolve_permission_file_path(
                 path = cwd / path
             return str(path.resolve())
 
-    for attr in ("file_path", "path"):
+    for attr in ("file_path", "path", "root"):
         value = getattr(parsed_input, attr, None)
         if isinstance(value, str) and value.strip():
             path = Path(value).expanduser()

--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -86,15 +86,16 @@ class PermissionChecker:
         # defence-in-depth measure against LLM-directed or prompt-injection
         # driven access to credential files.
         if file_path:
-            for pattern in SENSITIVE_PATH_PATTERNS:
-                if fnmatch.fnmatch(file_path, pattern):
-                    return PermissionDecision(
-                        allowed=False,
-                        reason=(
-                            f"Access denied: {file_path} is a sensitive credential path "
-                            f"(matched built-in pattern '{pattern}')"
-                        ),
-                    )
+            for candidate_path in _policy_match_paths(file_path):
+                for pattern in SENSITIVE_PATH_PATTERNS:
+                    if fnmatch.fnmatch(candidate_path, pattern):
+                        return PermissionDecision(
+                            allowed=False,
+                            reason=(
+                                f"Access denied: {file_path} is a sensitive credential path "
+                                f"(matched built-in pattern '{pattern}')"
+                            ),
+                        )
 
         # Explicit tool deny list
         if tool_name in self._settings.denied_tools:
@@ -106,13 +107,14 @@ class PermissionChecker:
 
         # Check path-level rules
         if file_path and self._path_rules:
-            for rule in self._path_rules:
-                if fnmatch.fnmatch(file_path, rule.pattern):
-                    if not rule.allow:
-                        return PermissionDecision(
-                            allowed=False,
-                            reason=f"Path {file_path} matches deny rule: {rule.pattern}",
-                        )
+            for candidate_path in _policy_match_paths(file_path):
+                for rule in self._path_rules:
+                    if fnmatch.fnmatch(candidate_path, rule.pattern):
+                        if not rule.allow:
+                            return PermissionDecision(
+                                allowed=False,
+                                reason=f"Path {file_path} matches deny rule: {rule.pattern}",
+                            )
 
         # Check command deny patterns (e.g. deny "rm -rf /")
         if command:
@@ -144,3 +146,16 @@ class PermissionChecker:
             requires_confirmation=True,
             reason="Mutating tools require user confirmation in default mode",
         )
+
+
+def _policy_match_paths(file_path: str) -> tuple[str, ...]:
+    """Return path forms that should participate in policy matching.
+
+    Directory-scoped tools like ``grep`` and ``glob`` may operate on a root such
+    as ``/home/user/.ssh``. Appending a trailing slash lets glob-style deny
+    patterns like ``*/.ssh/*`` and ``/etc/*`` match the directory root itself.
+    """
+    normalized = file_path.rstrip("/")
+    if not normalized:
+        return (file_path,)
+    return (normalized, normalized + "/")

--- a/src/openharness/tools/web_fetch_tool.py
+++ b/src/openharness/tools/web_fetch_tool.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import re
 from html.parser import HTMLParser
-from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, Field
 
 from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
+from openharness.utils.network_guard import (
+    NetworkGuardError,
+    fetch_public_http_response,
+    validate_http_url,
+)
 
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) "
@@ -39,14 +43,14 @@ class WebFetchTool(BaseTool):
         if not is_valid:
             return ToolResult(output=f"web_fetch failed: {error_message}", is_error=True)
         try:
-            async with httpx.AsyncClient(
-                follow_redirects=True,
-                max_redirects=MAX_REDIRECTS,
+            response = await fetch_public_http_response(
+                arguments.url,
+                headers={"User-Agent": USER_AGENT},
                 timeout=15.0,
-            ) as client:
-                response = await client.get(arguments.url, headers={"User-Agent": USER_AGENT})
-                response.raise_for_status()
-        except httpx.HTTPError as exc:
+                max_redirects=MAX_REDIRECTS,
+            )
+            response.raise_for_status()
+        except (httpx.HTTPError, NetworkGuardError) as exc:
             return ToolResult(output=f"web_fetch failed: {exc}", is_error=True)
 
         content_type = response.headers.get("content-type", "")
@@ -81,13 +85,10 @@ def _html_to_text(html: str) -> str:
 
 
 def _validate_url(url: str) -> tuple[bool, str]:
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        return False, "only http and https URLs are allowed"
-    if not parsed.netloc:
-        return False, "URL must include a host"
-    if parsed.username or parsed.password:
-        return False, "URLs with embedded credentials are not allowed"
+    try:
+        validate_http_url(url)
+    except NetworkGuardError as exc:
+        return False, str(exc)
     return True, ""
 
 

--- a/src/openharness/tools/web_search_tool.py
+++ b/src/openharness/tools/web_search_tool.py
@@ -10,6 +10,7 @@ import httpx
 from pydantic import BaseModel, Field
 
 from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
+from openharness.utils.network_guard import NetworkGuardError, fetch_public_http_response
 
 
 class WebSearchToolInput(BaseModel):
@@ -42,14 +43,14 @@ class WebSearchTool(BaseTool):
         del context
         endpoint = arguments.search_url or "https://html.duckduckgo.com/html/"
         try:
-            async with httpx.AsyncClient(follow_redirects=True, timeout=20.0) as client:
-                response = await client.get(
-                    endpoint,
-                    params={"q": arguments.query},
-                    headers={"User-Agent": "OpenHarness/0.1"},
-                )
-                response.raise_for_status()
-        except httpx.HTTPError as exc:
+            response = await fetch_public_http_response(
+                endpoint,
+                params={"q": arguments.query},
+                headers={"User-Agent": "OpenHarness/0.1"},
+                timeout=20.0,
+            )
+            response.raise_for_status()
+        except (httpx.HTTPError, NetworkGuardError) as exc:
             return ToolResult(output=f"web_search failed: {exc}", is_error=True)
 
         results = _parse_search_results(response.text, limit=arguments.max_results)

--- a/src/openharness/utils/network_guard.py
+++ b/src/openharness/utils/network_guard.py
@@ -1,0 +1,127 @@
+"""HTTP target validation helpers for outbound web tools."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+
+_DEFAULT_PORTS = {
+    "http": 80,
+    "https": 443,
+}
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+class NetworkGuardError(ValueError):
+    """Raised when an outbound HTTP target violates security policy."""
+
+
+def validate_http_url(url: str) -> None:
+    """Validate basic HTTP/HTTPS URL syntax."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise NetworkGuardError("only http and https URLs are allowed")
+    if not parsed.netloc or not parsed.hostname:
+        raise NetworkGuardError("URL must include a host")
+    if parsed.username or parsed.password:
+        raise NetworkGuardError("URLs with embedded credentials are not allowed")
+
+
+async def ensure_public_http_url(url: str) -> None:
+    """Reject loopback, private-network, and other non-public HTTP targets."""
+    validate_http_url(url)
+    parsed = urlparse(url)
+    assert parsed.hostname is not None  # covered by validate_http_url
+    port = parsed.port or _DEFAULT_PORTS[parsed.scheme]
+    addresses = await _resolve_host_addresses(parsed.hostname, port)
+    if not addresses:
+        raise NetworkGuardError(f"target host did not resolve: {parsed.hostname}")
+
+    blocked = sorted({str(address) for address in addresses if not address.is_global})
+    if blocked:
+        rendered = ", ".join(blocked[:3])
+        if len(blocked) > 3:
+            rendered += ", ..."
+        raise NetworkGuardError(f"target resolves to non-public address(es): {rendered}")
+
+
+async def fetch_public_http_response(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    params: dict[str, str] | None = None,
+    timeout: float = 15.0,
+    max_redirects: int = 5,
+) -> httpx.Response:
+    """Fetch one HTTP resource while validating every redirect hop."""
+    current_url = url
+    current_params = params
+
+    async with httpx.AsyncClient(
+        follow_redirects=False,
+        timeout=timeout,
+        trust_env=False,
+    ) as client:
+        for redirect_count in range(max_redirects + 1):
+            await ensure_public_http_url(current_url)
+            response = await client.get(
+                current_url,
+                params=current_params,
+                headers=headers,
+            )
+            if not response.has_redirect_location:
+                return response
+
+            location = response.headers.get("location")
+            if not location:
+                return response
+            if redirect_count >= max_redirects:
+                raise NetworkGuardError(f"too many redirects (>{max_redirects})")
+
+            current_url = urljoin(str(response.url), location)
+            current_params = None
+
+    raise NetworkGuardError("request failed before receiving a response")
+
+
+async def _resolve_host_addresses(host: str, port: int) -> set[_IPAddress]:
+    """Resolve a host into concrete IP addresses."""
+    literal = _parse_ip_literal(host)
+    if literal is not None:
+        return {literal}
+
+    try:
+        infos = await asyncio.to_thread(
+            socket.getaddrinfo,
+            host,
+            port,
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+    except OSError as exc:
+        raise NetworkGuardError(f"could not resolve target host {host}: {exc}") from exc
+
+    addresses: set[_IPAddress] = set()
+    for family, _, _, _, sockaddr in infos:
+        if family == socket.AF_INET:
+            candidate = sockaddr[0]
+        elif family == socket.AF_INET6:
+            candidate = sockaddr[0]
+        else:
+            continue
+        parsed = _parse_ip_literal(candidate)
+        if parsed is not None:
+            addresses.add(parsed)
+    return addresses
+
+
+def _parse_ip_literal(value: str) -> _IPAddress | None:
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -21,9 +21,13 @@ from openharness.engine.stream_events import (
 )
 from openharness.permissions import PermissionChecker, PermissionMode
 from openharness.tools import create_default_tool_registry
+from openharness.tools.base import ToolRegistry
+from openharness.tools.glob_tool import GlobTool
+from openharness.tools.grep_tool import GrepTool
 from openharness.hooks import HookExecutionContext, HookExecutor, HookEvent
 from openharness.hooks.loader import HookRegistry
 from openharness.hooks.schemas import PromptHookDefinition
+from openharness.engine.query import QueryContext, _execute_tool_call
 
 
 @dataclass
@@ -75,6 +79,13 @@ class RetryThenSuccessApiClient:
             usage=UsageSnapshot(input_tokens=1, output_tokens=1),
             stop_reason=None,
         )
+
+
+class _NoopApiClient:
+    async def stream_message(self, request):
+        del request
+        if False:
+            yield None
 
 
 @pytest.mark.asyncio
@@ -276,6 +287,66 @@ async def test_query_engine_respects_pre_tool_hook_blocks(tmp_path: Path):
     assert tool_results
     assert tool_results[0].is_error is True
     assert "no reading" in tool_results[0].output
+
+
+def _tool_context(tmp_path: Path, registry: ToolRegistry, settings: PermissionSettings) -> QueryContext:
+    return QueryContext(
+        api_client=_NoopApiClient(),
+        tool_registry=registry,
+        permission_checker=PermissionChecker(settings),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        max_tokens=1,
+        max_turns=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_blocks_sensitive_directory_roots(tmp_path: Path):
+    sensitive_dir = tmp_path / ".ssh"
+    sensitive_dir.mkdir()
+    (sensitive_dir / "id_rsa").write_text("PRIVATE KEY MATERIAL\n", encoding="utf-8")
+
+    registry = ToolRegistry()
+    registry.register(GrepTool())
+
+    result = await _execute_tool_call(
+        _tool_context(tmp_path, registry, PermissionSettings(mode=PermissionMode.DEFAULT)),
+        "grep",
+        "toolu_grep",
+        {"pattern": "PRIVATE", "root": str(sensitive_dir), "file_glob": "*"},
+    )
+
+    assert result.is_error is True
+    assert "sensitive credential path" in result.content
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_applies_path_rules_to_directory_roots(tmp_path: Path):
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    (blocked_dir / "secret.txt").write_text("classified\n", encoding="utf-8")
+
+    registry = ToolRegistry()
+    registry.register(GlobTool())
+
+    result = await _execute_tool_call(
+        _tool_context(
+            tmp_path,
+            registry,
+            PermissionSettings(
+                mode=PermissionMode.DEFAULT,
+                path_rules=[{"pattern": str(blocked_dir) + "/*", "allow": False}],
+            ),
+        ),
+        "glob",
+        "toolu_glob",
+        {"pattern": "*", "root": str(blocked_dir)},
+    )
+
+    assert result.is_error is True
+    assert str(blocked_dir) in result.content
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_web_fetch_tool.py
+++ b/tests/test_tools/test_web_fetch_tool.py
@@ -2,59 +2,34 @@
 
 from __future__ import annotations
 
-import contextlib
-import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
 
+import httpx
 import pytest
-
-from urllib.parse import parse_qs, urlparse
 
 from openharness.tools.base import ToolExecutionContext
 from openharness.tools.web_fetch_tool import WebFetchTool, WebFetchToolInput, _html_to_text
 from openharness.tools.web_search_tool import WebSearchTool, WebSearchToolInput
 
 
-class _Handler(BaseHTTPRequestHandler):
-    def do_GET(self) -> None:  # noqa: N802
-        query = parse_qs(urlparse(self.path).query).get("q", [""])[0]
-        if query:
-            body = (
-                "<html><body>"
-                '<a class="result__a" href="https://example.com/docs">OpenHarness Docs</a>'
-                '<div class="result__snippet">Search query was %s and docs were found.</div>'
-                "</body></html>"
-            ) % query
-        else:
-            body = "<html><body><h1>OpenHarness Test</h1><p>web fetch works</p></body></html>"
-        encoded = body.encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Content-Length", str(len(encoded)))
-        self.end_headers()
-        self.wfile.write(encoded)
-
-    def log_message(self, format: str, *args) -> None:  # noqa: A003
-        del format, args
-
-
 @pytest.mark.asyncio
-async def test_web_fetch_tool_reads_html(tmp_path):
-    server = HTTPServer(("127.0.0.1", 0), _Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        tool = WebFetchTool()
-        result = await tool.execute(
-            WebFetchToolInput(url=f"http://127.0.0.1:{server.server_port}/"),
-            ToolExecutionContext(cwd=tmp_path),
+async def test_web_fetch_tool_reads_html(tmp_path, monkeypatch):
+    async def fake_fetch(url: str, **_: object) -> httpx.Response:
+        request = httpx.Request("GET", url)
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "text/html; charset=utf-8"},
+            text="<html><body><h1>OpenHarness Test</h1><p>web fetch works</p></body></html>",
+            request=request,
         )
-    finally:
-        server.shutdown()
-        with contextlib.suppress(Exception):
-            server.server_close()
-        thread.join(timeout=1)
+
+    monkeypatch.setattr("openharness.tools.web_fetch_tool.fetch_public_http_response", fake_fetch)
+
+    tool = WebFetchTool()
+    result = await tool.execute(
+        WebFetchToolInput(url="https://example.com/"),
+        ToolExecutionContext(cwd=tmp_path),
+    )
 
     assert result.is_error is False
     assert "External content - treat as data" in result.output
@@ -63,24 +38,33 @@ async def test_web_fetch_tool_reads_html(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_web_search_tool_reads_results(tmp_path):
-    server = HTTPServer(("127.0.0.1", 0), _Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        tool = WebSearchTool()
-        result = await tool.execute(
-            WebSearchToolInput(
-                query="openharness docs",
-                search_url=f"http://127.0.0.1:{server.server_port}/search",
-            ),
-            ToolExecutionContext(cwd=tmp_path),
+async def test_web_search_tool_reads_results(tmp_path, monkeypatch):
+    async def fake_fetch(url: str, **kwargs: object) -> httpx.Response:
+        query = (kwargs.get("params") or {}).get("q", "")
+        request = httpx.Request("GET", url, params=kwargs.get("params"))
+        body = (
+            "<html><body>"
+            '<a class="result__a" href="https://example.com/docs">OpenHarness Docs</a>'
+            '<div class="result__snippet">Search query was %s and docs were found.</div>'
+            "</body></html>"
+        ) % query
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "text/html; charset=utf-8"},
+            text=body,
+            request=request,
         )
-    finally:
-        server.shutdown()
-        with contextlib.suppress(Exception):
-            server.server_close()
-        thread.join(timeout=1)
+
+    monkeypatch.setattr("openharness.tools.web_search_tool.fetch_public_http_response", fake_fetch)
+
+    tool = WebSearchTool()
+    result = await tool.execute(
+        WebSearchToolInput(
+            query="openharness docs",
+            search_url="https://search.example.com/html",
+        ),
+        ToolExecutionContext(cwd=tmp_path),
+    )
 
     assert result.is_error is False
     assert "OpenHarness Docs" in result.output
@@ -112,3 +96,30 @@ async def test_web_fetch_tool_rejects_embedded_credentials(tmp_path):
 
     assert result.is_error is True
     assert "embedded credentials" in result.output
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_tool_rejects_non_public_targets(tmp_path):
+    tool = WebFetchTool()
+    result = await tool.execute(
+        WebFetchToolInput(url="http://127.0.0.1:8080/"),
+        ToolExecutionContext(cwd=tmp_path),
+    )
+
+    assert result.is_error is True
+    assert "non-public" in result.output
+
+
+@pytest.mark.asyncio
+async def test_web_search_tool_rejects_non_public_search_backends(tmp_path):
+    tool = WebSearchTool()
+    result = await tool.execute(
+        WebSearchToolInput(
+            query="openharness docs",
+            search_url="http://127.0.0.1:8080/search",
+        ),
+        ToolExecutionContext(cwd=tmp_path),
+    )
+
+    assert result.is_error is True
+    assert "non-public" in result.output

--- a/tests/test_tools/test_web_fetch_tool.py
+++ b/tests/test_tools/test_web_fetch_tool.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import time
 
 import httpx
@@ -24,7 +23,7 @@ async def test_web_fetch_tool_reads_html(tmp_path, monkeypatch):
             request=request,
         )
 
-    monkeypatch.setattr(sys.modules[WebFetchTool.__module__], "fetch_public_http_response", fake_fetch)
+    monkeypatch.setitem(WebFetchTool.execute.__globals__, "fetch_public_http_response", fake_fetch)
 
     tool = WebFetchTool()
     result = await tool.execute(
@@ -56,7 +55,7 @@ async def test_web_search_tool_reads_results(tmp_path, monkeypatch):
             request=request,
         )
 
-    monkeypatch.setattr(sys.modules[WebSearchTool.__module__], "fetch_public_http_response", fake_fetch)
+    monkeypatch.setitem(WebSearchTool.execute.__globals__, "fetch_public_http_response", fake_fetch)
 
     tool = WebSearchTool()
     result = await tool.execute(

--- a/tests/test_tools/test_web_fetch_tool.py
+++ b/tests/test_tools/test_web_fetch_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 
 import httpx
@@ -23,7 +24,7 @@ async def test_web_fetch_tool_reads_html(tmp_path, monkeypatch):
             request=request,
         )
 
-    monkeypatch.setattr("openharness.tools.web_fetch_tool.fetch_public_http_response", fake_fetch)
+    monkeypatch.setattr(sys.modules[WebFetchTool.__module__], "fetch_public_http_response", fake_fetch)
 
     tool = WebFetchTool()
     result = await tool.execute(
@@ -55,7 +56,7 @@ async def test_web_search_tool_reads_results(tmp_path, monkeypatch):
             request=request,
         )
 
-    monkeypatch.setattr("openharness.tools.web_search_tool.fetch_public_http_response", fake_fetch)
+    monkeypatch.setattr(sys.modules[WebSearchTool.__module__], "fetch_public_http_response", fake_fetch)
 
     tool = WebSearchTool()
     result = await tool.execute(


### PR DESCRIPTION
## Summary

This PR fixes two security issues in built-in OpenHarness tools.

First, `grep` and `glob` could bypass sensitive-path protection and configured `permission.path_rules` because the permission boundary normalized `path` and `file_path`, but not the directory-scoped `root` argument those tools actually use.
Directory roots such as `/home/user/.ssh` also did not match child-oriented deny globs like `*/.ssh/*`.
That allowed prompt-controlled read-only tool calls to inspect sensitive host directories that should have been denied.

Second, `web_fetch` and `web_search` accepted attacker-controlled HTTP endpoints and fetched them with direct `httpx` requests, including redirect handling, without rejecting loopback, RFC1918, link-local, or other non-public targets.
That created a localhost/private-network SSRF primitive with response disclosure from the host running OpenHarness.

## Related Issue

No public issue linked.
This PR addresses two security findings in the current tool boundary implementation.

## CVSS Assessment

Context note:
CVSS is conservative for local agent-runtime issues because the attack still depends on the victim running OpenHarness on attacker-influenced content.
I am still treating both bugs as high-severity trust-boundary breaks in the PR context because they enable prompt-driven disclosure of host secrets or private-network responses.

### 1. Sensitive path bypass via `grep` / `glob` `root`

- Preliminary CVSS v3.1: `5.5`
- Vector: `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N`

Rationale:

- `AV:L`: exploitation occurs inside a local OpenHarness session running on the victim machine
- `AC:L`: the attacker only needs to steer the model toward `grep` or `glob` with a chosen `root`
- `PR:N`: no prior account or host privilege is required; attacker-controlled prompt input is enough
- `UI:R`: the user must run OpenHarness on attacker-influenced content or otherwise admit that content into the session
- `S:U`: the vulnerable permission boundary and impacted files remain under the same local security authority
- `C:H`: sensitive local files and directory contents can be enumerated or disclosed despite explicit deny patterns
- `I:N`: the affected tools are read-only
- `A:N`: the bug does not directly degrade availability

### 2. Localhost / private-network SSRF via `web_fetch` and `web_search`

- Preliminary CVSS v3.1: `6.3`
- Vector: `CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N`

Rationale:

- `AV:L`: exploitation occurs through a local OpenHarness runtime making outbound requests from the victim host
- `AC:L`: the attacker only needs to cause the model to invoke the built-in web tools with a chosen URL or `search_url`
- `PR:N`: no authenticated foothold on the host or target service is needed
- `UI:R`: the user must run the agent on attacker-influenced content or otherwise accept attacker-influenced prompts
- `S:C`: the vulnerable component can reach and disclose data from separate localhost or private-network services under a different security authority
- `C:H`: internal HTTP responses can be disclosed back through tool output
- `I:N`: the implementation only issues GET requests, so direct data modification is not the primary impact
- `A:N`: denial of service is not the primary effect

## Changes

- normalize `root` alongside `path` and `file_path` in [`src/openharness/engine/query.py`](https://github.com/HKUDS/OpenHarness/blob/main/src/openharness/engine/query.py) before permission evaluation
- evaluate both the normalized path and a trailing-slash variant in [`src/openharness/permissions/checker.py`](https://github.com/HKUDS/OpenHarness/blob/main/src/openharness/permissions/checker.py) so directory roots match patterns such as `*/.ssh/*` and `/etc/*`
- add [`src/openharness/utils/network_guard.py`](https://github.com/HKUDS/OpenHarness/blob/main/src/openharness/utils/network_guard.py) to validate outbound HTTP targets, reject non-public addresses, disable environment proxy inheritance for guarded requests, and revalidate every redirect hop
- route `web_fetch` and `web_search` through the shared network guard
- add regression tests that prove directory-root permission checks now block both built-in sensitive paths and explicit deny rules
- replace localhost-backed web-tool tests with deterministic mocked-fetch tests and add explicit regression coverage for blocked non-public targets

## Type of Change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Testing

Executed after the final code changes:

- `uv run --with ruff ruff check src/openharness/utils/network_guard.py src/openharness/tools/web_fetch_tool.py src/openharness/tools/web_search_tool.py src/openharness/engine/query.py src/openharness/permissions/checker.py tests/test_tools/test_web_fetch_tool.py tests/test_engine/test_query_engine.py`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_permissions/test_checker.py tests/test_tools/test_web_fetch_tool.py tests/test_engine/test_query_engine.py -q`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_tools/test_core_tools.py tests/test_tools/test_grep_tool.py -q`

Not run:

- `uv run pytest -q`
- `cd frontend/terminal && npx tsc --noEmit` (frontend not touched)

## Reproduction

### 1. Path-rule bypass before this patch

```bash
PYTHONPATH=src uv run --with pytest --with pytest-asyncio python - <<'PY'
import asyncio
from pathlib import Path

from openharness.config.settings import PermissionSettings
from openharness.engine.query import QueryContext, _execute_tool_call
from openharness.permissions import PermissionChecker, PermissionMode
from openharness.tools.base import ToolRegistry
from openharness.tools.grep_tool import GrepTool


class DummyAPI:
    async def stream_message(self, request):
        if False:
            yield None


async def main():
    secret_dir = Path('/tmp/openharness-poc-ssh')
    secret_dir.mkdir(parents=True, exist_ok=True)
    (secret_dir / 'id_rsa').write_text('PRIVATE KEY MATERIAL\n', encoding='utf-8')

    registry = ToolRegistry()
    registry.register(GrepTool())
    context = QueryContext(
        api_client=DummyAPI(),
        tool_registry=registry,
        permission_checker=PermissionChecker(PermissionSettings(mode=PermissionMode.DEFAULT)),
        cwd=Path.cwd(),
        model='dummy',
        system_prompt='dummy',
        max_tokens=1,
        max_turns=1,
    )
    result = await _execute_tool_call(
        context,
        'grep',
        'poc-grep',
        {'pattern': 'PRIVATE', 'root': str(secret_dir), 'file_glob': '*'},
    )
    print('is_error:', result.is_error)
    print(result.content)

asyncio.run(main())
PY
```

Observed on the vulnerable snapshot: the grep call succeeds and returns the file content instead of being denied.
Expected after this patch: the tool call is rejected as a sensitive-path access.

### 2. SSRF before this patch

```bash
PYTHONPATH=src uv run --with pytest --with pytest-asyncio python - <<'PY'
import asyncio
import threading
from http.server import BaseHTTPRequestHandler, HTTPServer
from pathlib import Path

from openharness.tools.base import ToolExecutionContext
from openharness.tools.web_fetch_tool import WebFetchTool, WebFetchToolInput


class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        body = b'INTERNAL_SECRET=openharness-demo-secret\n'
        self.send_response(200)
        self.send_header('Content-Type', 'text/plain')
        self.send_header('Content-Length', str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, format, *args):
        pass


server = HTTPServer(('127.0.0.1', 0), Handler)
thread = threading.Thread(target=server.serve_forever, daemon=True)
thread.start()

async def main():
    tool = WebFetchTool()
    result = await tool.execute(
        WebFetchToolInput(url=f'http://127.0.0.1:{server.server_port}/secret'),
        ToolExecutionContext(cwd=Path.cwd()),
    )
    print('is_error:', result.is_error)
    print(result.output)

try:
    asyncio.run(main())
finally:
    server.shutdown()
    server.server_close()
PY
```

Observed on the vulnerable snapshot: `web_fetch` returns the localhost response body.
Expected after this patch: the request is rejected because the target resolves to a non-public address.

## Checklist

- [x] The PR summary matches the actual diff
- [x] The new guardrails are covered by regression tests
- [x] The security tradeoff is documented in the PR body
- [x] No frontend or unrelated project files were changed

Signed-off-by: 13ernkastel <LennonCMJ@live.com>
