### PR TITLE
fix(ui): show effective runtime model in header

### DIFF
--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 from openharness.api.client import SupportsStreamingMessages
 from openharness.auth.manager import AuthManager
-from openharness.config.settings import CLAUDE_MODEL_ALIAS_OPTIONS, display_model_setting
+from openharness.config.settings import CLAUDE_MODEL_ALIAS_OPTIONS, resolve_model_setting
 from openharness.bridge import get_bridge_manager
 from openharness.themes import list_themes
 from openharness.engine.stream_events import (
@@ -389,7 +389,7 @@ class ReactBackendHost:
         settings = self._bundle.current_settings()
         state = self._bundle.app_state.get()
         _, active_profile = settings.resolve_profile()
-        current_model = display_model_setting(active_profile)
+        current_model = settings.model
 
         if command == "provider":
             statuses = AuthManager(settings).get_profile_statuses()
@@ -598,12 +598,14 @@ class ReactBackendHost:
             ]
         provider_name = provider.lower()
         if provider_name in {"anthropic", "anthropic_claude"}:
+            resolved_current = resolve_model_setting(current_model, provider_name)
             return [
                 {
                     "value": value,
                     "label": label,
                     "description": description,
-                    "active": value == current_model,
+                    "active": value == current_model
+                    or resolve_model_setting(value, provider_name) == resolved_current,
                 }
                 for value, label, description in CLAUDE_MODEL_ALIAS_OPTIONS
             ]

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -16,7 +16,6 @@ from openharness.api.provider import auth_status, detect_provider
 from openharness.bridge import get_bridge_manager
 from openharness.commands import CommandContext, CommandResult, create_default_command_registry
 from openharness.config import get_config_file_path, load_settings
-from openharness.config.settings import display_model_setting
 from openharness.engine import QueryEngine
 from openharness.engine.messages import ConversationMessage, ToolResultBlock, ToolUseBlock
 from openharness.engine.query import MaxTurnsExceeded
@@ -205,11 +204,12 @@ async def build_runtime(
     await mcp_manager.connect_all()
     tool_registry = create_default_tool_registry(mcp_manager)
     provider = detect_provider(settings)
-    _, active_profile = settings.resolve_profile()
     bridge_manager = get_bridge_manager()
     app_state = AppStateStore(
         AppState(
-            model=display_model_setting(active_profile),
+            # Show the effective runtime model (after CLI/env/profile merges),
+            # not profile.last_model which may be stale.
+            model=settings.model,
             permission_mode=settings.permission.mode.value,
             theme=settings.theme,
             cwd=cwd,
@@ -387,9 +387,8 @@ def sync_app_state(bundle: RuntimeBundle) -> None:
     if bundle.enforce_max_turns:
         bundle.engine.set_max_turns(settings.max_turns)
     provider = detect_provider(settings)
-    _, active_profile = settings.resolve_profile()
     bundle.app_state.set(
-        model=display_model_setting(active_profile),
+        model=settings.model,
         permission_mode=settings.permission.mode.value,
         theme=settings.theme,
         cwd=bundle.cwd,

--- a/tests/test_ui/test_react_backend.py
+++ b/tests/test_ui/test_react_backend.py
@@ -244,6 +244,33 @@ async def test_backend_host_command_does_not_reset_cli_overrides(tmp_path, monke
 
 
 @pytest.mark.asyncio
+async def test_backend_host_uses_effective_model_from_env_override(tmp_path, monkeypatch):
+    """Regression: header model should reflect effective env override, not stale profile last_model."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("OPENHARNESS_MODEL", "minimax-m1")
+
+    host = ReactBackendHost(BackendHostConfig(api_client=StaticApiClient("unused")))
+    host._bundle = await build_runtime(api_client=StaticApiClient("unused"))
+    events = []
+
+    async def _emit(event):
+        events.append(event)
+
+    host._emit = _emit  # type: ignore[method-assign]
+    await start_runtime(host._bundle)
+    try:
+        assert host._bundle.app_state.get().model == "minimax-m1"
+
+        # Exercise sync_app_state through a slash command refresh path.
+        await host._process_line("/fast show")
+        assert host._bundle.app_state.get().model == "minimax-m1"
+    finally:
+        await close_runtime(host._bundle)
+
+
+@pytest.mark.asyncio
 async def test_build_runtime_leaves_interactive_sessions_unbounded_by_default(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))


### PR DESCRIPTION
## Summary
- use effective runtime model (`settings.model`) when initializing and syncing app state
- keep model selector highlighting correct for Anthropic aliases by comparing resolved model IDs
- add regression test for env-only model override (`OPENHARNESS_MODEL`)

## Why
When only environment variables override model/provider (for example MiniMax OpenAI-compatible usage), the runtime header showed stale `active_profile.last_model` (often Claude) instead of the real running model.

## Validation
- `uv run ruff check src/openharness/ui/runtime.py src/openharness/ui/backend_host.py tests/test_ui/test_react_backend.py`
- `uv run pytest -q tests/test_ui/test_react_backend.py tests/test_ui/test_runtime_api_key.py tests/test_ui/test_react_launcher.py tests/test_ui/test_modes.py`
