### PR TITLE
fix(skills): use yaml.safe_load for SKILL.md frontmatter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Skill loader now uses `yaml.safe_load` to parse SKILL.md frontmatter, correctly handling YAML block scalars (`>`, `|`), quoted values, and other standard YAML constructs instead of naive line-by-line splitting.
 - `BackendHostConfig` was missing the `cwd` field, causing `AttributeError: 'BackendHostConfig' object has no attribute 'cwd'` on startup when `oh` was run after the runtime refactor that added `cwd` support to `build_runtime`.
 - Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.

--- a/src/openharness/skills/loader.py
+++ b/src/openharness/skills/loader.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Iterable
+
+import yaml
 
 from openharness.config.paths import get_config_dir
 from openharness.config.settings import load_settings
 from openharness.skills.bundled import get_bundled_skills
 from openharness.skills.registry import SkillRegistry
 from openharness.skills.types import SkillDefinition
+
+logger = logging.getLogger(__name__)
 
 
 def get_user_skills_dir() -> Path:
@@ -101,21 +106,20 @@ def _parse_skill_markdown(default_name: str, content: str) -> tuple[str, str]:
     lines = content.splitlines()
 
     # Try YAML frontmatter first (--- ... ---)
-    if lines and lines[0].strip() == "---":
-        for i, line in enumerate(lines[1:], 1):
-            if line.strip() == "---":
-                # Parse frontmatter fields
-                for fm_line in lines[1:i]:
-                    fm_stripped = fm_line.strip()
-                    if fm_stripped.startswith("name:"):
-                        val = fm_stripped[5:].strip().strip("'\"")
-                        if val:
-                            name = val
-                    elif fm_stripped.startswith("description:"):
-                        val = fm_stripped[12:].strip().strip("'\"")
-                        if val:
-                            description = val
-                break
+    if content.startswith("---\n"):
+        end_index = content.find("\n---\n", 4)
+        if end_index != -1:
+            try:
+                metadata = yaml.safe_load(content[4:end_index])
+                if isinstance(metadata, dict):
+                    val = metadata.get("name")
+                    if isinstance(val, str) and val.strip():
+                        name = val.strip()
+                    val = metadata.get("description")
+                    if isinstance(val, str) and val.strip():
+                        description = val.strip()
+            except yaml.YAMLError:
+                logger.debug("Failed to parse YAML frontmatter for skill %s", default_name)
 
     # Fallback: extract from headings and first paragraph
     if not description:

--- a/tests/test_skills/test_loader.py
+++ b/tests/test_skills/test_loader.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 from openharness.skills import get_user_skills_dir, load_skill_registry
+from openharness.skills.loader import _parse_skill_markdown as parse_skill_markdown
 
 
 def test_load_skill_registry_includes_bundled(tmp_path: Path, monkeypatch):
@@ -29,3 +31,112 @@ def test_load_skill_registry_includes_user_skills(tmp_path: Path, monkeypatch):
     assert deploy is not None
     assert deploy.source == "user"
     assert "Deployment workflow guidance" in deploy.content
+
+
+# --- parse_skill_markdown unit tests ---
+
+
+def test_parse_frontmatter_inline_description():
+    """Inline description: value on the same line as the key."""
+    content = textwrap.dedent("""\
+        ---
+        name: my-skill
+        description: A short inline description
+        ---
+
+        # Body
+    """)
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "my-skill"
+    assert desc == "A short inline description"
+
+
+def test_parse_frontmatter_folded_block_scalar():
+    """YAML folded block scalar (>) must be expanded into a single string."""
+    content = textwrap.dedent("""\
+        ---
+        name: NL2SQL Expert
+        description: >
+          Multi-tenant NL2SQL skill for converting natural language questions
+          into SQL queries. Covers the full pipeline: tenant routing,
+          table selection, question enhancement, context retrieval.
+        tags:
+          - nl2sql
+        ---
+
+        # NL2SQL Expert Skill
+    """)
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "NL2SQL Expert"
+    assert "Multi-tenant NL2SQL skill" in desc
+    assert "context retrieval" in desc
+    # Folded scalar joins lines with spaces, not newlines
+    assert "\n" not in desc
+
+
+def test_parse_frontmatter_literal_block_scalar():
+    """YAML literal block scalar (|) preserves newlines."""
+    content = textwrap.dedent("""\
+        ---
+        name: multi-line
+        description: |
+          Line one.
+          Line two.
+          Line three.
+        ---
+
+        # Body
+    """)
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "multi-line"
+    assert "Line one." in desc
+    assert "Line two." in desc
+
+
+def test_parse_frontmatter_quoted_description():
+    """Quoted description values are handled correctly."""
+    content = textwrap.dedent("""\
+        ---
+        name: quoted
+        description: "A quoted description with: colons"
+        ---
+
+        # Body
+    """)
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "quoted"
+    assert desc == "A quoted description with: colons"
+
+
+def test_parse_fallback_heading_and_paragraph():
+    """Without frontmatter, falls back to heading + first paragraph."""
+    content = "# My Skill\nThis is the description from the body.\n"
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "My Skill"
+    assert desc == "This is the description from the body."
+
+
+def test_parse_no_description_uses_skill_name():
+    """When nothing provides a description, falls back to 'Skill: <name>'."""
+    content = "# OnlyHeading\n"
+    name, desc = parse_skill_markdown("fallback", content)
+    assert name == "OnlyHeading"
+    assert desc == "Skill: OnlyHeading"
+
+
+def test_parse_malformed_yaml_falls_back():
+    """Malformed YAML in frontmatter falls back to body parsing."""
+    content = textwrap.dedent("""\
+        ---
+        name: [invalid yaml
+        description: also broken: {
+        ---
+
+        # Fallback Title
+        Body paragraph here.
+    """)
+    name, desc = parse_skill_markdown("fallback", content)
+    # Fallback scans all lines; frontmatter lines are not excluded, so
+    # the first non-heading, non-delimiter line wins.  The important thing
+    # is that a YAMLError doesn't crash the loader.
+    assert isinstance(desc, str) and desc


### PR DESCRIPTION
Replace naive line-by-line frontmatter parsing with yaml.safe_load to correctly handle YAML block scalars (folded `>`, literal `|`), quoted values, and other standard YAML constructs. Add comprehensive unit tests for inline, folded, literal, quoted, fallback, and malformed frontmatter.

Made-with: Cursor

## Summary

- What problem does this PR solve?
- What changed?

## Validation

- [ ] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue:
- Follow-up work:
