### PR TITLE
fix: regenerate system prompt on checkpoint restore

### DIFF
--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -1346,7 +1346,7 @@ def main(
                 model=session_data.get("model") or model,
                 backend_only=backend_only,
                 base_url=base_url,
-                system_prompt=session_data.get("system_prompt") or system_prompt,
+                system_prompt=system_prompt,
                 api_key=api_key,
                 restore_messages=session_data.get("messages"),
                 restore_tool_metadata=session_data.get("tool_metadata"),


### PR DESCRIPTION
- Don't restore saved system_prompt from checkpoint
- Let runtime regenerate it with current environment info
- Fixes cross-platform checkpoint migration issue

## Summary

- What problem does this PR solve?
  When restoring a checkpoint/session, the system prompt is restored from the saved snapshot instead of being regenerated with current environment information.

- What changed?
  Modified `src/openharness/cli.py:1349` to not restore the saved `system_prompt` from checkpoint. The runtime will now regenerate it with current environment info when `system_prompt=None`.

## Validation

- [ ] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue: #103 
- Follow-up work:
