### PR TITLE
feat(providers): add built-in Google Gemini provider profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- Built-in `gemini` provider profile so `oh setup` offers Google Gemini as a first-class provider choice, with `gemini_api_key` auth source and `gemini-2.5-flash` as the default model.
 - `diagnose` skill: trace agent run failures and regressions using structured evidence from run artifacts.
 - OpenAI-compatible API client (`--api-format openai`) supporting any provider that implements the OpenAI `/v1/chat/completions` format, including Alibaba DashScope, DeepSeek, GitHub Models, Groq, Together AI, Ollama, and more.
 - `OPENHARNESS_API_FORMAT` environment variable for selecting the API format.

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Any provider implementing the OpenAI `/v1/chat/completions` style API works:
 | **DeepSeek** | `https://api.deepseek.com` | `deepseek-chat`, `deepseek-reasoner` |
 | **GitHub Models** | `https://models.inference.ai.azure.com` | `gpt-4o`, `Meta-Llama-3.1-405B-Instruct` |
 | **SiliconFlow** | `https://api.siliconflow.cn/v1` | `deepseek-ai/DeepSeek-V3` |
+| **Google Gemini** | `https://generativelanguage.googleapis.com/v1beta/openai` | `gemini-2.5-flash`, `gemini-2.5-pro` |
 | **Groq** | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` |
 | **Ollama (local)** | `http://localhost:11434/v1` | any local model |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,6 +104,7 @@ oh setup
 - DeepSeek
 - GitHub Models
 - SiliconFlow
+- Google Gemini
 - Groq
 - Ollama
 - 其他 OpenAI-compatible endpoint

--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -35,6 +35,7 @@ _KNOWN_PROVIDERS = [
     "bedrock",
     "vertex",
     "moonshot",
+    "gemini",
 ]
 
 _AUTH_SOURCES = [
@@ -47,6 +48,7 @@ _AUTH_SOURCES = [
     "bedrock_api_key",
     "vertex_api_key",
     "moonshot_api_key",
+    "gemini_api_key",
 ]
 
 _PROFILE_BY_PROVIDER = {
@@ -56,6 +58,7 @@ _PROFILE_BY_PROVIDER = {
     "openai_codex": "codex",
     "copilot": "copilot",
     "moonshot": "moonshot",
+    "gemini": "gemini",
 }
 
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -271,6 +271,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "bedrock": "AWS Bedrock",
     "vertex": "Google Vertex AI",
     "moonshot": "Moonshot (Kimi)",
+    "gemini": "Google Gemini",
 }
 
 _AUTH_SOURCE_LABELS: dict[str, str] = {
@@ -283,6 +284,7 @@ _AUTH_SOURCE_LABELS: dict[str, str] = {
     "bedrock_api_key": "Bedrock credentials",
     "vertex_api_key": "Vertex credentials",
     "moonshot_api_key": "Moonshot API key",
+    "gemini_api_key": "Gemini API key",
 }
 
 
@@ -724,7 +726,7 @@ def _login_provider(provider: str) -> None:
         _bind_external_provider(provider)
         return
 
-    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot"):
+    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini"):
         label = _PROVIDER_LABELS.get(provider, provider)
         flow = ApiKeyFlow(provider=provider, prompt_text=f"Enter your {label} API key")
         try:

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -189,6 +189,14 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             default_model="kimi-k2.5",
             base_url="https://api.moonshot.cn/v1",
         ),
+        "gemini": ProviderProfile(
+            label="Google Gemini",
+            provider="gemini",
+            api_format="openai",
+            auth_source="gemini_api_key",
+            default_model="gemini-2.5-flash",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        ),
     }
 
 
@@ -275,6 +283,7 @@ def auth_source_provider_name(auth_source: str) -> str:
         "bedrock_api_key": "bedrock",
         "vertex_api_key": "vertex",
         "moonshot_api_key": "moonshot",
+        "gemini_api_key": "gemini",
     }
     return mapping.get(auth_source, auth_source)
 
@@ -312,6 +321,8 @@ def default_auth_source_for_provider(provider: str, api_format: str | None = Non
         return "vertex_api_key"
     if provider == "moonshot":
         return "moonshot_api_key"
+    if provider == "gemini":
+        return "gemini_api_key"
     if provider == "openai" or api_format == "openai":
         return "openai_api_key"
     return "anthropic_api_key"


### PR DESCRIPTION
## Summary

Addresses #90 — adds Google Gemini as a first-class provider in `oh setup`.

The `ProviderSpec` for Gemini already exists in `api/registry.py` and the model picker in `backend_host.py` already suggests `gemini-2.5-pro` / `gemini-2.5-flash`. However, there is no built-in provider profile, so `oh setup` never offers Gemini and users must manually create a custom profile. This PR closes that gap by wiring the profile, auth-source mappings, and CLI login flow.

### Changes

- **`config/settings.py`** — add `"gemini"` entry to `default_provider_profiles()` (api_format=`openai`, auth_source=`gemini_api_key`, default_model=`gemini-2.5-flash`, base_url from AI Studio OpenAI-compat endpoint); register `gemini_api_key` in `auth_source_provider_name()` and `default_auth_source_for_provider()`
- **`auth/manager.py`** — add `"gemini"` to `_KNOWN_PROVIDERS`, `"gemini_api_key"` to `_AUTH_SOURCES`, and `"gemini": "gemini"` to `_PROFILE_BY_PROVIDER`
- **`cli.py`** — add `"gemini": "Google Gemini"` to `_PROVIDER_LABELS` and `_AUTH_SOURCE_LABELS`; include `"gemini"` in the `oh auth login` API-key flow condition
- **`README.md`** / **`README.zh-CN.md`** — add Gemini row to the OpenAI-Compatible provider table
- **`CHANGELOG.md`** — add entry under `[Unreleased] > Added`

### After this PR

```bash
oh setup gemini          # guided setup: enter Gemini API key from AI Studio
oh auth login gemini     # or set the key directly
oh -p "Hello"            # uses gemini-2.5-flash by default
```

Users can obtain a free API key from [Google AI Studio](https://aistudio.google.com/apikey).

## Test plan

- [x] `ruff check src tests scripts` passes
- [x] Full test suite passes (573 passed, 6 skipped, 1 xfailed — no regressions)
- [x] Verify `oh setup` lists "Google Gemini" as a provider choice
- [x] Verify `oh auth login gemini` prompts for the API key and stores it
- [x] Verify `oh -p "Hello"` works with a valid Gemini API key