### PR TITLE
fix(auth): cache keyring probe and rename misleading encrypt/decrypt

### DIFF
--- a/src/openharness/auth/__init__.py
+++ b/src/openharness/auth/__init__.py
@@ -6,10 +6,10 @@ from openharness.auth.storage import (
     clear_provider_credentials,
     decrypt,
     encrypt,
-    load_external_binding,
     load_credential,
-    store_external_binding,
+    load_external_binding,
     store_credential,
+    store_external_binding,
 )
 
 __all__ = [
@@ -22,6 +22,8 @@ __all__ = [
     "store_external_binding",
     "load_external_binding",
     "clear_provider_credentials",
+    # Deprecated — use _obfuscate/_deobfuscate directly if needed.
+    # Kept for backward compatibility; will be removed in a future version.
     "encrypt",
     "decrypt",
 ]

--- a/src/openharness/auth/storage.py
+++ b/src/openharness/auth/storage.py
@@ -1,7 +1,16 @@
-"""Secure credential storage for OpenHarness.
+"""Credential storage for OpenHarness.
 
 Default backend: ~/.openharness/credentials.json with mode 600.
-Optional backend: system keyring (if the `keyring` package is installed).
+Optional backend: system keyring (if the `keyring` package is installed
+and a usable backend is present).
+
+Security model
+--------------
+When no keyring backend is available (common in containers, CI, and WSL),
+credentials are stored as **plain-text JSON** protected only by POSIX file
+permissions (mode 600).  The ``_obfuscate`` / ``_deobfuscate`` helpers in
+this module are a lightweight XOR round-trip used elsewhere for non-secret
+data; they are **not** encryption and must not be used to protect secrets.
 """
 
 from __future__ import annotations
@@ -66,13 +75,34 @@ def _save_creds_file(data: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _keyring_available() -> bool:
-    try:
-        import keyring  # noqa: F401
+_keyring_checked: bool = False
+_keyring_usable: bool = False
 
-        return True
+
+def _keyring_available() -> bool:
+    """Return True when a usable system keyring backend is present.
+
+    The check is cached after the first call so the "Keyring load failed"
+    warning is emitted at most once per process.
+    """
+    global _keyring_checked, _keyring_usable  # noqa: PLW0603
+    if _keyring_checked:
+        return _keyring_usable
+    _keyring_checked = True
+    try:
+        import keyring
+
+        # Probe the backend — merely importing keyring is not enough because
+        # the package may be installed without a functioning backend (e.g. on
+        # headless Linux / WSL / containers).
+        keyring.get_password(_KEYRING_SERVICE, "__probe__")
+        _keyring_usable = True
     except ImportError:
-        return False
+        _keyring_usable = False
+    except Exception as exc:
+        log.info("System keyring unavailable, using file backend: %s", exc)
+        _keyring_usable = False
+    return _keyring_usable
 
 
 def _keyring_key(provider: str, key: str) -> str:
@@ -189,21 +219,25 @@ def load_external_binding(provider: str) -> ExternalAuthBinding | None:
 
 
 # ---------------------------------------------------------------------------
-# Encrypt/decrypt helpers (lightweight XOR obfuscation, not true encryption)
+# Obfuscation helpers (XOR round-trip — NOT encryption)
+# ---------------------------------------------------------------------------
+# These exist for lightweight obfuscation of non-secret data (e.g. session
+# tokens where the goal is to prevent casual reading, not resist attack).
+# Do NOT use for API keys or passwords — those belong in the keyring or in
+# the plain-text file protected by POSIX permissions.
 # ---------------------------------------------------------------------------
 
 
 def _obfuscation_key() -> bytes:
     """Return a per-user obfuscation key derived from the home directory path."""
     seed = str(Path.home()).encode() + b"openharness-v1"
-    # Simple repeating key stretched to 32 bytes via SHA-256 for determinism.
     import hashlib
 
     return hashlib.sha256(seed).digest()
 
 
-def encrypt(plaintext: str) -> str:
-    """Lightly obfuscate *plaintext* (base64-encoded XOR).  Not cryptographic."""
+def _obfuscate(plaintext: str) -> str:
+    """Lightly obfuscate *plaintext* (base64-encoded XOR).  **Not cryptographic.**"""
     import base64
 
     key = _obfuscation_key()
@@ -212,11 +246,16 @@ def encrypt(plaintext: str) -> str:
     return base64.urlsafe_b64encode(xored).decode("ascii")
 
 
-def decrypt(ciphertext: str) -> str:
-    """Reverse of :func:`encrypt`."""
+def _deobfuscate(ciphertext: str) -> str:
+    """Reverse of :func:`_obfuscate`."""
     import base64
 
     key = _obfuscation_key()
     data = base64.urlsafe_b64decode(ciphertext.encode("ascii"))
     xored = bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
     return xored.decode("utf-8")
+
+
+# Backward compatibility — deprecated, will be removed in a future version.
+encrypt = _obfuscate
+decrypt = _deobfuscate


### PR DESCRIPTION
## Problem

### 1. Keyring warning spam floods stderr

On systems without a desktop keyring backend (WSL, containers, CI, headless Linux), every single credential operation calls `_keyring_available()` → imports `keyring` → tries to use it → fails → logs a warning. A single `oh setup gemini` produces **22 identical warnings** that drown out the actual output:

```
$ oh setup gemini
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Google Gemini requires Gemini API key.
Enter API key for Google Gemini:
```

That is the **full, unedited output** of a single command. Every `store_credential` / `load_credential` / `clear_provider_credentials` call independently probes the keyring, fails, and prints. This affects every user on WSL, headless Linux, containers, and CI — the most common non-macOS environments.

`oh auth login gemini` produces a similar wall:

```
$ oh auth login gemini
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Keyring load failed, falling back to file: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details.
Enter your Google Gemini API key:
```

### 2. `encrypt`/`decrypt` are XOR obfuscation, not encryption

`encrypt()` and `decrypt()` in `auth.storage` are XOR with a key deterministically derived from `Path.home()` — trivially reversible by anyone with filesystem access. Naming them `encrypt`/`decrypt` and exporting them in `__all__` misleads callers (and auditors) into thinking credentials have cryptographic protection. They are not called anywhere in the codebase today, but the public API surface invites misuse.

## Fix

### Keyring caching
- `_keyring_available()` now probes the backend **once** on first call, caches the result in a module-level flag, and returns the cached value on subsequent calls
- The probe does an actual `keyring.get_password()` round-trip instead of just checking the import — this catches the common case where `keyring` is installed as a transitive dep but no backend is configured
- On failure, logs a single `INFO`-level message instead of a `WARNING` per call

### Rename obfuscation helpers
- `encrypt` → `_obfuscate` (private)
- `decrypt` → `_deobfuscate` (private)
- Module docstring updated to document the actual security model (file permissions, not crypto)
- `encrypt`/`decrypt` kept as deprecated aliases for backward compatibility
- `__init__.py` exports annotated as deprecated

## Test plan

- [x] `ruff check src tests scripts` passes
- [x] Full test suite passes (573 passed, 6 skipped, 1 xfailed — identical to main)
- [x] `_obfuscate` / `_deobfuscate` round-trip verified
- [x] Deprecated `encrypt` / `decrypt` aliases still work (point to same functions)
- [x] Keyring probe runs only once per process (verified via module-level cache)