### PR TITLE
fix(grep): raise asyncio stream limit and catch ValueError on long lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 - Fixed duplicate response in React TUI caused by double Enter key submission in the input handler.
 - Fixed concurrent permission modals overwriting each other in TUI default mode when the LLM returns multiple tool calls in one response; `_ask_permission` now serialises callers via an `asyncio.Lock` so each modal is shown and resolved before the next one is emitted.
 - Fixed React TUI Markdown tables to size columns from rendered cell text so inline formatting like code spans and bold text no longer breaks alignment.
+- Fixed grep tool crashing with `ValueError` / `LimitOverrunError` when ripgrep outputs a line longer than 64 KB (e.g. minified assets or lock files). The asyncio subprocess stream limit is now 8 MB and oversized lines are skipped rather than terminating the session.
 
 ### Changed
 

--- a/src/openharness/tools/grep_tool.py
+++ b/src/openharness/tools/grep_tool.py
@@ -183,6 +183,7 @@ async def _rg_grep(
         cwd=str(root),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        limit=8 * 1024 * 1024,  # 8 MB per line — avoids LimitOverrunError on long lines
     )
 
     matches: list[str] = []
@@ -239,6 +240,7 @@ async def _rg_grep_file(
         cwd=str(path.parent),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        limit=8 * 1024 * 1024,  # 8 MB per line — avoids LimitOverrunError on long lines
     )
 
     matches: list[str] = []
@@ -282,7 +284,11 @@ async def _collect_rg_matches(
 ) -> None:
     assert process.stdout is not None
     while len(matches) < limit:
-        raw = await process.stdout.readline()
+        try:
+            raw = await process.stdout.readline()
+        except ValueError:
+            # Line exceeded the stream buffer limit; skip it and continue.
+            continue
         if not raw:
             break
         line = raw.decode("utf-8", errors="replace").rstrip("\n")
@@ -300,7 +306,11 @@ async def _collect_rg_file_matches(
 ) -> None:
     assert process.stdout is not None
     while len(matches) < limit:
-        raw = await process.stdout.readline()
+        try:
+            raw = await process.stdout.readline()
+        except ValueError:
+            # Line exceeded the stream buffer limit; skip it and continue.
+            continue
         if not raw:
             break
         line = raw.decode("utf-8", errors="replace").rstrip("\n")


### PR DESCRIPTION
## Summary

**Problem:** The grep tool crashes the session with an unhandled `ValueError` when ripgrep outputs a line longer than asyncio's default `StreamReader` limit (64 KB). This happens on minified JS/CSS files, lock files, and any generated asset with very long lines.

**Root cause:** `asyncio.create_subprocess_exec` uses a 64 KB per-line buffer. When `rg` hits a longer line, `readline()` raises `LimitOverrunError`, which is re-raised as `ValueError` and propagates unhandled all the way to the REPL.

**Fix — two-layer defence in `grep_tool.py`:**
1. Pass `limit=8*1024*1024` to `asyncio.create_subprocess_exec` so lines up to 8 MB are handled transparently (covers the vast majority of real-world long lines).
2. Catch `ValueError` inside `_collect_rg_matches` and `_collect_rg_file_matches` as a safety net: any line that somehow exceeds even 8 MB is silently skipped rather than terminating the session.

Both `_rg_grep` (directory search) and `_rg_grep_file` (single-file search) are fixed.

## Validation

- [x] `uv run ruff check src tests scripts` — all checks passed
- [x] `uv run pytest -q` — passed
- [ ] `cd frontend/terminal && npx tsc --noEmit` — not applicable (backend-only change)

## Notes

- Related issue: #108
- Follow-up work: none