### PR TITLE
feat(tui): pair tool-call and tool-result rows for cleaner transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 - Fixed duplicate response in React TUI caused by double Enter key submission in the input handler.
 - Fixed concurrent permission modals overwriting each other in TUI default mode when the LLM returns multiple tool calls in one response; `_ask_permission` now serialises callers via an `asyncio.Lock` so each modal is shown and resolved before the next one is emitted.
 - Fixed React TUI Markdown tables to size columns from rendered cell text so inline formatting like code spans and bold text no longer breaks alignment.
+- Fixed grep tool crashing with `ValueError` / `LimitOverrunError` when ripgrep outputs a line longer than 64 KB (e.g. minified assets or lock files). The asyncio subprocess stream limit is now 8 MB and oversized lines are skipped rather than terminating the session.
+
+### Changed
+
+- React TUI now groups consecutive `tool` + `tool_result` transcript rows into a single compound row: success shows the result line count inline (e.g. `→ 24L`), errors show a red icon and up to 5 lines of error detail beneath the tool row. Standalone successful tool results are suppressed to reduce transcript noise; standalone errors are still surfaced.
 
 ### Changed
 

--- a/frontend/terminal/src/components/ConversationView.tsx
+++ b/frontend/terminal/src/components/ConversationView.tsx
@@ -6,6 +6,26 @@ import {MarkdownText} from './MarkdownText.js';
 import {ToolCallDisplay} from './ToolCallDisplay.js';
 import {WelcomeBanner} from './WelcomeBanner.js';
 
+type ToolPair = readonly [TranscriptItem, TranscriptItem];
+type GroupedItem = TranscriptItem | ToolPair;
+
+function groupToolPairs(items: TranscriptItem[]): GroupedItem[] {
+	const result: GroupedItem[] = [];
+	let i = 0;
+	while (i < items.length) {
+		const cur = items[i];
+		const next = items[i + 1];
+		if (cur.role === 'tool' && next?.role === 'tool_result') {
+			result.push([cur, next] as const);
+			i += 2;
+		} else {
+			result.push(cur);
+			i++;
+		}
+	}
+	return result;
+}
+
 export function ConversationView({
 	items,
 	assistantBuffer,
@@ -18,14 +38,19 @@ export function ConversationView({
 	const {theme} = useTheme();
 	// Show the most recent items that fit the viewport
 	const visible = items.slice(-40);
+	const grouped = groupToolPairs(visible);
 
 	return (
 		<Box flexDirection="column" flexGrow={1}>
 			{showWelcome && items.length === 0 ? <WelcomeBanner /> : null}
 
-			{visible.map((item, index) => (
-				<MessageRow key={index} item={item} theme={theme} />
-			))}
+			{grouped.map((group, index) => {
+				if (Array.isArray(group)) {
+					const [toolItem, resultItem] = group as [TranscriptItem, TranscriptItem];
+					return <ToolCallDisplay key={index} item={toolItem} resultItem={resultItem} />;
+				}
+				return <MessageRow key={index} item={group as TranscriptItem} theme={theme} />;
+			})}
 
 			{assistantBuffer ? (
 				<Box marginTop={1} marginBottom={0} flexDirection="column">

--- a/frontend/terminal/src/components/ToolCallDisplay.tsx
+++ b/frontend/terminal/src/components/ToolCallDisplay.tsx
@@ -4,34 +4,60 @@ import {Box, Text} from 'ink';
 import {useTheme} from '../theme/ThemeContext.js';
 import type {TranscriptItem} from '../types.js';
 
-export function ToolCallDisplay({item}: {item: TranscriptItem}): React.JSX.Element {
+export function ToolCallDisplay({item, resultItem}: {item: TranscriptItem; resultItem?: TranscriptItem}): React.JSX.Element {
 	const {theme} = useTheme();
 
 	if (item.role === 'tool') {
 		const toolName = item.tool_name ?? 'tool';
 		const summary = summarizeInput(toolName, item.tool_input, item.text);
+
+		let statusNode: React.ReactNode = null;
+		let errorLines: string[] | null = null;
+
+		if (resultItem) {
+			if (resultItem.is_error) {
+				statusNode = <Text color={theme.colors.error}> {theme.icons.error.trim()}</Text>;
+				const lines = resultItem.text.split('\n').filter((l) => l.trim());
+				const maxErrLines = 5;
+				errorLines = lines.length > maxErrLines
+					? [...lines.slice(0, maxErrLines), `... (${lines.length - maxErrLines} more lines)`]
+					: lines;
+			} else {
+				const lineCount = resultItem.text.split('\n').filter((l) => l.trim()).length;
+				const resultLabel = lineCount > 0 ? `${lineCount}L` : theme.icons.success.trim();
+				statusNode = <Text dimColor> → {resultLabel}</Text>;
+			}
+		}
+
 		return (
 			<Box marginLeft={2} flexDirection="column">
 				<Text>
 					<Text color={theme.colors.accent} bold>{theme.icons.tool}</Text>
 					<Text color={theme.colors.accent} bold>{toolName}</Text>
 					<Text dimColor> {summary}</Text>
+					{statusNode}
 				</Text>
+				{errorLines?.map((line, i) => (
+					<Box key={i} marginLeft={4}>
+						<Text color={theme.colors.error}>{line}</Text>
+					</Box>
+				))}
 			</Box>
 		);
 	}
 
+	// Standalone tool_result (unpaired — should be rare). Hide successes; surface errors.
 	if (item.role === 'tool_result') {
-		const lines = item.text.split('\n');
-		const maxLines = 12;
+		if (!item.is_error) {
+			return <></>;
+		}
+		const lines = item.text.split('\n').filter((l) => l.trim());
+		const maxLines = 5;
 		const display = lines.length > maxLines ? [...lines.slice(0, maxLines), `... (${lines.length - maxLines} more lines)`] : lines;
-		const color = item.is_error ? theme.colors.error : undefined;
 		return (
 			<Box marginLeft={4} flexDirection="column">
 				{display.map((line, i) => (
-					<Text key={i} color={color} dimColor={!item.is_error}>
-						{line}
-					</Text>
+					<Text key={i} color={theme.colors.error}>{line}</Text>
 				))}
 			</Box>
 		);


### PR DESCRIPTION
## Summary

**Problem:** Tool calls and their results are rendered as independent rows in the React TUI. This causes two issues:
1. Every successful tool result dumps up to 12 lines of raw text into the transcript, making long agent runs very noisy.
2. There is no at-a-glance signal showing whether a tool call succeeded or failed — users must scroll to the separate result row to find out.

**Change:** Group consecutive `tool` + `tool_result` transcript items into a single compound row.

### `ConversationView.tsx`
- New `groupToolPairs()` helper groups adjacent `tool` / `tool_result` items into tuples before rendering.
- The render loop dispatches pairs to `<ToolCallDisplay>` and solo items to the existing `<MessageRow>`.

### `ToolCallDisplay.tsx`
- Accepts a new optional `resultItem` prop.
- **Success**: shows result line count inline (e.g. `→ 24L`).
- **Error**: shows a red error icon inline and expands up to 5 lines of error detail beneath the tool row.
- Standalone successful `tool_result` rows are suppressed (return empty fragment) to eliminate transcript noise.
- Standalone `tool_result` errors are still rendered so failures are never silently swallowed.

## Validation

- [x] `uv run ruff check src tests scripts` — all checks passed (backend unchanged)
- [x] `uv run pytest -q` — passed
- [x] `cd frontend/terminal && npx tsc --noEmit` — passed

## Notes

- Related issue: #109
- Follow-up work: none