### PR TITLE
fix(config): strip ANSI escape sequences from model names

### DIFF
--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,21 @@ from pydantic import BaseModel, Field
 from openharness.hooks.schemas import HookDefinition
 from openharness.mcp.types import McpServerConfig
 from openharness.permissions.modes import PermissionMode
+
+
+# ANSI escape sequence pattern
+_ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi_escape_sequences(text: str) -> str:
+    """Remove ANSI escape sequences from text.
+
+    This is used to clean environment variables that may contain terminal
+    formatting codes (e.g., '[1m' for bold) which can corrupt API requests.
+    """
+    if not text:
+        return text
+    return _ANSI_ESCAPE_PATTERN.sub("", text)
 
 
 class PathRuleConfig(BaseModel):
@@ -651,6 +667,9 @@ class Settings(BaseModel):
     def merge_cli_overrides(self, **overrides: Any) -> Settings:
         """Return a new Settings with CLI overrides applied (non-None values only)."""
         updates = {k: v for k, v in overrides.items() if v is not None}
+        # Strip ANSI escape sequences from model name if present
+        if "model" in updates and isinstance(updates["model"], str):
+            updates["model"] = strip_ansi_escape_sequences(updates["model"])
         merged = self.model_copy(update=updates)
         if not updates:
             return merged
@@ -668,7 +687,9 @@ def _apply_env_overrides(settings: Settings) -> Settings:
     updates: dict[str, Any] = {}
     model = os.environ.get("ANTHROPIC_MODEL") or os.environ.get("OPENHARNESS_MODEL")
     if model:
-        updates["model"] = model
+        # Strip ANSI escape sequences that may be present if the environment
+        # variable was set with terminal formatting (e.g., bold text)
+        updates["model"] = strip_ansi_escape_sequences(model)
 
     base_url = (
         os.environ.get("ANTHROPIC_BASE_URL")

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -15,6 +15,8 @@ from openharness.config.settings import (
     load_settings,
     normalize_anthropic_model_name,
     save_settings,
+    strip_ansi_escape_sequences,
+    _apply_env_overrides,
 )
 
 
@@ -416,3 +418,44 @@ def test_normalize_anthropic_model_name_matches_hermes_behavior():
         assert s.sandbox.network.allowed_domains == ["github.com"]
         assert s.sandbox.filesystem.allow_write == [".", "/tmp"]
         assert s.sandbox.filesystem.deny_write == [".env"]
+
+
+class TestAnsiEscapeSequences:
+    """Tests for ANSI escape sequence handling in settings."""
+
+    def test_strip_ansi_escape_sequences(self):
+        """Test that ANSI escape sequences are properly stripped."""
+        # Normal model name should pass through unchanged
+        assert strip_ansi_escape_sequences("claude-opus-4-6") == "claude-opus-4-6"
+        # Bold formatting should be stripped
+        assert strip_ansi_escape_sequences("\x1b[1mclaude-opus-4-6\x1b[0m") == "claude-opus-4-6"
+        # Green + bold formatting should be stripped
+        assert strip_ansi_escape_sequences("\x1b[32m\x1b[1mclaude-opus-4-6\x1b[0m") == "claude-opus-4-6"
+        # Only bold prefix
+        assert strip_ansi_escape_sequences("\x1b[1mclaude-opus-4-6") == "claude-opus-4-6"
+        # Only reset suffix
+        assert strip_ansi_escape_sequences("claude-opus-4-6\x1b[0m") == "claude-opus-4-6"
+        # Empty string should return empty string
+        assert strip_ansi_escape_sequences("") == ""
+        # None should return None
+        assert strip_ansi_escape_sequences(None) is None
+
+    def test_env_override_strips_ansi_from_model(self, monkeypatch):
+        """Test that ANSI escape sequences are stripped from ANTHROPIC_MODEL env var."""
+        monkeypatch.setenv("ANTHROPIC_MODEL", "\x1b[1mclaude-opus-4-6\x1b[0m")
+        s = Settings()
+        updated = _apply_env_overrides(s)
+        assert updated.model == "claude-opus-4-6"
+
+    def test_env_override_strips_ansi_from_openharness_model(self, monkeypatch):
+        """Test that ANSI escape sequences are stripped from OPENHARNESS_MODEL env var."""
+        monkeypatch.setenv("OPENHARNESS_MODEL", "\x1b[32mclaude-sonnet-4-6\x1b[0m")
+        s = Settings()
+        updated = _apply_env_overrides(s)
+        assert updated.model == "claude-sonnet-4-6"
+
+    def test_merge_cli_overrides_strips_ansi_from_model(self):
+        """Test that ANSI escape sequences are stripped from CLI model override."""
+        s = Settings()
+        updated = s.merge_cli_overrides(model="\x1b[1mclaude-opus-4-6\x1b[0m")
+        assert updated.model == "claude-opus-4-6"


### PR DESCRIPTION
## Summary

This PR fixes an issue where ANSI escape sequences in the `ANTHROPIC_MODEL` or `OPENHARNESS_MODEL` environment variables would cause API requests to fail with 404 errors.

## Problem

When users set the model environment variable in a terminal with formatting (e.g., bold text), ANSI escape sequences like `\x1b[1m` (bold) and `\x1b[0m` (reset) can be inadvertently included. This results in the API receiving an invalid model name like `claude-opus-4-6[1m]` instead of `claude-opus-4-6`.

Fixes #113

## Changes

- **Added `strip_ansi_escape_sequences()` helper function** in `settings.py` to remove ANSI escape codes from text
- **Updated `_apply_env_overrides()`** to strip ANSI sequences from model environment variables
- **Updated `merge_cli_overrides()`** to strip ANSI sequences from CLI `--model` argument
- **Added comprehensive tests** in `TestAnsiEscapeSequences` test class

## Testing

```bash
# Test with ANSI escape sequences
export ANTHROPIC_MODEL=$'\x1b[1mclaude-opus-4-6\x1b[0m'
uv run oh
# API requests now work correctly with clean model name
```

## Checklist

- [x] Added helper function with docstring
- [x] Applied sanitization to environment variable overrides
- [x] Applied sanitization to CLI argument overrides
- [x] Added unit tests for the new functionality
- [x] All existing tests pass