### PR TITLE
fix(tui): keep busy spinner active throughout agent turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- React TUI spinner now stays visible throughout the entire agent turn: `assistant_complete` no longer resets `busy` state prematurely, and `tool_started` explicitly sets `busy=true` so the status bar remains active even when tool calls follow an assistant message. `line_complete` is the sole signal that ends the turn and clears the spinner.
+
 - `BackendHostConfig` was missing the `cwd` field, causing `AttributeError: 'BackendHostConfig' object has no attribute 'cwd'` on startup when `oh` was run after the runtime refactor that added `cwd` support to `build_runtime`.
 - Shell-escape `$ARGUMENTS` substitution in command hooks to prevent shell injection from payload values containing metacharacters like `$(...)` or backticks.
 - Swarm `_READ_ONLY_TOOLS` now uses actual registered tool names (snake_case) instead of PascalCase, fixing read-only auto-approval in `handle_permission_request`.

--- a/frontend/terminal/src/hooks/useBackendSession.ts
+++ b/frontend/terminal/src/hooks/useBackendSession.ts
@@ -264,13 +264,13 @@ export function useBackendSession(config: FrontendConfig, onExit: (code?: number
 			const text = event.message ?? assistantBufferRef.current;
 			setTranscript((items) => [...items, {role: 'assistant', text}]);
 			clearAssistantDelta();
-			setBusy(false);
+			// Do NOT reset busy here: tool calls may follow this event.
+			// busy is reset by line_complete (the true end-of-turn signal).
 			setBusyLabel(undefined);
 			return;
 		}
 		if (event.type === 'line_complete') {
-			// If the line ended without an assistant_complete (e.g. errors), make sure we
-			// don't leave stale streaming text on screen.
+			// Final end-of-turn: clear everything, stop spinner.
 			clearAssistantDelta();
 			setBusy(false);
 			setBusyLabel(undefined);
@@ -278,7 +278,10 @@ export function useBackendSession(config: FrontendConfig, onExit: (code?: number
 		}
 		if ((event.type === 'tool_started' || event.type === 'tool_completed') && event.item) {
 			if (event.type === 'tool_started') {
-				setBusyLabel(event.tool_name ? `Running ${event.tool_name}...` : 'Running...');
+				setBusy(true);
+				setBusyLabel(`Running ${event.tool_name ?? 'tool'}...`);
+			} else {
+				setBusyLabel('Processing...');
 			}
 			const enrichedItem: TranscriptItem = {
 				...event.item,


### PR DESCRIPTION
Fixes #115

## Problem

The React TUI spinner disappears prematurely during multi-tool agent turns because:
- `assistant_complete` incorrectly called `setBusy(false)`, but tool calls may follow this event in the same turn.
- `tool_started` never called `setBusy(true)`, so the spinner would stay hidden if `busy` was already `false`.

## Change

- Remove `setBusy(false)` from `assistant_complete` handler — `line_complete` is the only true end-of-turn signal.
- Add `setBusy(true)` to `tool_started` handler so the spinner re-activates for each tool call.
- Show `'Processing...'` label on `tool_completed` instead of clearing the label immediately.
- Clarify inline comments to document the intended event-flow contract.

## Verification

1. `cd frontend/terminal && npx tsc --noEmit` — passes with no errors.
2. Run `oh` and ask a question that triggers multiple tool calls; the spinner stays visible continuously until the full response is rendered.