### PR TITLE
fix: harden gateway slash command security

### DIFF
--- a/ohmo/cli.py
+++ b/ohmo/cli.py
@@ -306,6 +306,22 @@ def _run_gateway_config_wizard(workspace: str | Path) -> GatewayConfig:
         "Send tool hints to channels?",
         default=existing.send_tool_hints,
     )
+    allow_remote_admin_commands = _confirm_prompt(
+        "Allow explicitly listed administrative slash commands from remote channels?",
+        default=existing.allow_remote_admin_commands,
+    )
+    default_allowlist = ", ".join(existing.allowed_remote_admin_commands)
+    allowed_remote_admin_commands: list[str] = []
+    if allow_remote_admin_commands:
+        allowlist_raw = _text_prompt(
+            "Allowed remote admin commands (comma-separated, e.g. permissions, plan)",
+            default=default_allowlist,
+        )
+        allowed_remote_admin_commands = [
+            item.strip().lstrip("/")
+            for item in allowlist_raw.split(",")
+            if item.strip()
+        ]
     config = existing.model_copy(
         update={
             "provider_profile": provider_profile,
@@ -313,6 +329,8 @@ def _run_gateway_config_wizard(workspace: str | Path) -> GatewayConfig:
             "channel_configs": channel_configs,
             "send_progress": send_progress,
             "send_tool_hints": send_tool_hints,
+            "allow_remote_admin_commands": allow_remote_admin_commands,
+            "allowed_remote_admin_commands": allowed_remote_admin_commands,
         }
     )
     save_gateway_config(config, workspace)
@@ -328,6 +346,13 @@ def _print_gateway_config_summary(config: GatewayConfig) -> None:
         )
     else:
         print(f"Configured provider_profile={config.provider_profile}; no channels enabled yet.")
+    if config.allow_remote_admin_commands and config.allowed_remote_admin_commands:
+        print(
+            "Remote admin opt-in enabled for: "
+            + ", ".join(f"/{name}" for name in config.allowed_remote_admin_commands)
+        )
+    else:
+        print("Remote admin commands remain local-only.")
 
 
 def _maybe_restart_gateway(*, cwd: str | Path, workspace: str | Path) -> None:

--- a/ohmo/gateway/models.py
+++ b/ohmo/gateway/models.py
@@ -15,6 +15,8 @@ class GatewayConfig(BaseModel):
     send_tool_hints: bool = True
     permission_mode: str = "default"
     sandbox_enabled: bool = False
+    allow_remote_admin_commands: bool = False
+    allowed_remote_admin_commands: list[str] = Field(default_factory=list)
     log_level: str = "INFO"
     channel_configs: dict[str, dict] = Field(default_factory=dict)
 

--- a/ohmo/gateway/runtime.py
+++ b/ohmo/gateway/runtime.py
@@ -27,6 +27,7 @@ from openharness.engine.stream_events import (
 from openharness.prompts import build_runtime_system_prompt
 from openharness.ui.runtime import RuntimeBundle, _last_user_text, build_runtime, close_runtime, start_runtime
 
+from ohmo.gateway.config import load_gateway_config
 from ohmo.prompts import build_ohmo_system_prompt
 from ohmo.session_storage import OhmoSessionBackend
 from ohmo.workspace import get_plugins_dir, get_skills_dir, initialize_workspace
@@ -81,12 +82,25 @@ class OhmoSessionRuntimePool:
         self._model = model
         self._max_turns = max_turns
         self._workspace = initialize_workspace(workspace)
+        self._gateway_config = load_gateway_config(self._workspace)
         self._session_backend = OhmoSessionBackend(self._workspace)
         self._bundles: dict[str, RuntimeBundle] = {}
 
     @property
     def active_sessions(self) -> int:
         return len(self._bundles)
+
+    def _remote_admin_allowed(self, command) -> bool:
+        if not getattr(command, "remote_admin_opt_in", False):
+            return False
+        if not self._gateway_config.allow_remote_admin_commands:
+            return False
+        allowed = {
+            str(name).strip().lower()
+            for name in self._gateway_config.allowed_remote_admin_commands
+            if str(name).strip()
+        }
+        return command.name.lower() in allowed
 
     async def get_bundle(self, session_key: str, latest_user_prompt: str | None = None) -> RuntimeBundle:
         """Return an existing bundle or create a new one."""
@@ -149,7 +163,17 @@ class OhmoSessionRuntimePool:
         parsed = bundle.commands.lookup(user_prompt)
         if parsed is not None and not message.media:
             command, args = parsed
-            if not getattr(command, "remote_invocable", True):
+            remote_allowed = getattr(command, "remote_invocable", True)
+            if not remote_allowed and self._remote_admin_allowed(command):
+                remote_allowed = True
+                logger.warning(
+                    "ohmo gateway remote administrative command accepted channel=%s chat_id=%s sender_id=%s command=%s",
+                    message.channel,
+                    message.chat_id,
+                    message.sender_id,
+                    command.name,
+                )
+            if not remote_allowed:
                 result = CommandResult(
                     message=f"/{command.name} is only available in the local OpenHarness UI."
                 )

--- a/ohmo/gateway/runtime.py
+++ b/ohmo/gateway/runtime.py
@@ -12,7 +12,7 @@ import os
 import string
 
 from openharness.channels.bus.events import InboundMessage
-from openharness.commands import CommandContext
+from openharness.commands import CommandContext, CommandResult
 from openharness.engine.messages import ConversationMessage, ImageBlock, TextBlock
 from openharness.engine.query import MaxTurnsExceeded
 from openharness.engine.stream_events import (
@@ -149,6 +149,19 @@ class OhmoSessionRuntimePool:
         parsed = bundle.commands.lookup(user_prompt)
         if parsed is not None and not message.media:
             command, args = parsed
+            if not getattr(command, "remote_invocable", True):
+                result = CommandResult(
+                    message=f"/{command.name} is only available in the local OpenHarness UI."
+                )
+                async for update in self._stream_command_result(
+                    bundle=bundle,
+                    message=message,
+                    session_key=session_key,
+                    user_prompt=user_prompt,
+                    result=result,
+                ):
+                    yield update
+                return
             result = await command.handler(
                 args,
                 CommandContext(

--- a/ohmo/gateway/service.py
+++ b/ohmo/gateway/service.py
@@ -43,6 +43,11 @@ class OhmoGatewayService:
         root = initialize_workspace(self._workspace)
         os.environ["OHMO_WORKSPACE"] = str(root)
         self._config = load_gateway_config(self._workspace)
+        if self._config.allow_remote_admin_commands and self._config.allowed_remote_admin_commands:
+            logger.warning(
+                "ohmo gateway remote administrative commands enabled commands=%s",
+                ",".join(self._config.allowed_remote_admin_commands),
+            )
         self._bus = MessageBus()
         self._runtime_pool = OhmoSessionRuntimePool(
             cwd=self._cwd,

--- a/ohmo/workspace.py
+++ b/ohmo/workspace.py
@@ -283,6 +283,8 @@ def initialize_workspace(workspace: str | Path | None = None) -> Path:
                     "send_tool_hints": True,
                     "permission_mode": "default",
                     "sandbox_enabled": False,
+                    "allow_remote_admin_commands": False,
+                    "allowed_remote_admin_commands": [],
                     "log_level": "INFO",
                     "channel_configs": {},
                 },

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -101,6 +101,7 @@ class SlashCommand:
     description: str
     handler: CommandHandler
     remote_invocable: bool = True
+    remote_admin_opt_in: bool = False
 
 
 class CommandRegistry:
@@ -1552,6 +1553,7 @@ def create_default_command_registry(
             "Show or update permission mode",
             _permissions_handler,
             remote_invocable=False,
+            remote_admin_opt_in=True,
         )
     )
     registry.register(
@@ -1560,6 +1562,7 @@ def create_default_command_registry(
             "Toggle plan permission mode",
             _plan_handler,
             remote_invocable=False,
+            remote_admin_opt_in=True,
         )
     )
     registry.register(SlashCommand("fast", "Show or update fast mode", _fast_handler))

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -100,6 +100,7 @@ class SlashCommand:
     name: str
     description: str
     handler: CommandHandler
+    remote_invocable: bool = True
 
 
 class CommandRegistry:
@@ -375,9 +376,9 @@ def create_default_command_registry(
             return CommandResult(message="\n".join(path.name for path in memory_files))
         if action == "show" and rest:
             memory_dir = get_project_memory_dir(context.cwd)
-            path = memory_dir / rest
-            if not path.exists():
-                path = memory_dir / f"{rest}.md"
+            path = _resolve_memory_entry_path(memory_dir, rest)
+            if path is None:
+                return CommandResult(message="Memory entry path must stay within the project memory directory.")
             if not path.exists():
                 return CommandResult(message=f"Memory entry not found: {rest}")
             return CommandResult(message=path.read_text(encoding="utf-8"))
@@ -1545,8 +1546,22 @@ def create_default_command_registry(
     registry.register(SlashCommand("mcp", "Show MCP status", _mcp_handler))
     registry.register(SlashCommand("plugin", "Manage plugins", _plugin_handler))
     registry.register(SlashCommand("reload-plugins", "Reload plugin discovery for this workspace", _reload_plugins_handler))
-    registry.register(SlashCommand("permissions", "Show or update permission mode", _permissions_handler))
-    registry.register(SlashCommand("plan", "Toggle plan permission mode", _plan_handler))
+    registry.register(
+        SlashCommand(
+            "permissions",
+            "Show or update permission mode",
+            _permissions_handler,
+            remote_invocable=False,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "plan",
+            "Toggle plan permission mode",
+            _plan_handler,
+            remote_invocable=False,
+        )
+    )
     registry.register(SlashCommand("fast", "Show or update fast mode", _fast_handler))
     registry.register(SlashCommand("effort", "Show or update reasoning effort", _effort_handler))
     registry.register(SlashCommand("passes", "Show or update reasoning pass count", _passes_handler))
@@ -1602,3 +1617,28 @@ def create_default_command_registry(
             )
         )
     return registry
+
+
+def _resolve_memory_entry_path(memory_dir: Path, candidate: str) -> Path | None:
+    """Resolve a memory entry path while enforcing containment under ``memory_dir``."""
+
+    base = memory_dir.resolve()
+    resolved = _resolve_memory_candidate(base, candidate)
+    if resolved is not None and resolved.exists():
+        return resolved
+    fallback = _resolve_memory_candidate(base, f"{candidate}.md")
+    if fallback is not None:
+        return fallback
+    return None
+
+
+def _resolve_memory_candidate(memory_dir: Path, candidate: str) -> Path | None:
+    path = Path(candidate).expanduser()
+    if not path.is_absolute():
+        path = memory_dir / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(memory_dir)
+    except ValueError:
+        return None
+    return resolved

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -76,6 +76,44 @@ async def test_permissions_command_persists(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_permissions_command_is_marked_local_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/permissions set full_auto")
+    assert command is not None
+    assert command.remote_invocable is False
+
+
+@pytest.mark.asyncio
+async def test_memory_show_rejects_path_traversal(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    registry = create_default_command_registry()
+    command, args = registry.lookup("/memory show ../../../../../../etc/hosts")
+    assert command is not None
+
+    result = await command.handler(args, CommandContext(engine=_make_engine(tmp_path), cwd=str(tmp_path)))
+
+    assert result.message == "Memory entry path must stay within the project memory directory."
+
+
+@pytest.mark.asyncio
+async def test_memory_show_reads_normal_entries_with_md_fallback(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    registry = create_default_command_registry()
+
+    add_command, add_args = registry.lookup("/memory add Notes :: hello world")
+    assert add_command is not None
+    await add_command.handler(add_args, CommandContext(engine=_make_engine(tmp_path), cwd=str(tmp_path)))
+
+    show_command, show_args = registry.lookup("/memory show Notes")
+    result = await show_command.handler(show_args, CommandContext(engine=_make_engine(tmp_path), cwd=str(tmp_path)))
+
+    assert "hello world" in result.message
+
+
+@pytest.mark.asyncio
 async def test_model_command_persists(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
     registry = create_default_command_registry()

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -85,6 +85,15 @@ async def test_permissions_command_is_marked_local_only(tmp_path: Path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_permissions_command_supports_explicit_remote_admin_opt_in(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/permissions set full_auto")
+    assert command is not None
+    assert getattr(command, "remote_admin_opt_in", False) is True
+
+
+@pytest.mark.asyncio
 async def test_memory_show_rejects_path_traversal(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -17,7 +17,8 @@ from openharness.engine.messages import ConversationMessage, ImageBlock, TextBlo
 from openharness.engine.stream_events import AssistantTextDelta, CompactProgressEvent, ToolExecutionStarted
 
 from ohmo.gateway.bridge import OhmoGatewayBridge, _format_gateway_error
-from ohmo.gateway.models import GatewayState
+from ohmo.gateway.config import save_gateway_config
+from ohmo.gateway.models import GatewayConfig, GatewayState
 from ohmo.gateway.runtime import OhmoSessionRuntimePool, _build_inbound_user_message, _format_channel_progress
 from ohmo.gateway.service import OhmoGatewayService, gateway_status, stop_gateway_process
 from ohmo.gateway.router import session_key_for_message
@@ -382,6 +383,7 @@ async def test_runtime_pool_blocks_local_only_commands_from_remote_messages(tmp_
             forbidden_handler,
             remote_invocable=False,
         )
+        command.remote_admin_opt_in = True
         return SimpleNamespace(
             engine=FakeEngine(),
             session_id="sess123",
@@ -402,6 +404,73 @@ async def test_runtime_pool_blocks_local_only_commands_from_remote_messages(tmp_
     assert handler_called is False
     assert updates[-1].kind == "final"
     assert updates[-1].text == "/permissions is only available in the local OpenHarness UI."
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_allows_opted_in_remote_admin_commands(tmp_path, monkeypatch, caplog):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    save_gateway_config(
+        GatewayConfig(
+            provider_profile="codex",
+            allow_remote_admin_commands=True,
+            allowed_remote_admin_commands=["permissions"],
+        ),
+        workspace,
+    )
+    handler_called = False
+
+    async def allowed_handler(args, context):
+        nonlocal handler_called
+        handler_called = True
+        return CommandResult(message=f"ran with {args}")
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        command = SlashCommand(
+            "permissions",
+            "Show or update permission mode",
+            allowed_handler,
+            remote_invocable=False,
+        )
+        command.remote_admin_opt_in = True
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=SimpleNamespace(lookup=lambda raw: (command, "full_auto")),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+            cwd=str(tmp_path),
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    with caplog.at_level(logging.WARNING):
+        pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+        message = InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="/permissions full_auto")
+        updates = [u async for u in pool.stream_message(message, "feishu:c1")]
+
+    assert handler_called is True
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "ran with full_auto"
+    assert "remote administrative command accepted" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -12,6 +12,7 @@ from openharness.api.usage import UsageSnapshot
 from openharness.channels.bus.events import InboundMessage
 from openharness.channels.bus.queue import MessageBus
 from openharness.commands import CommandResult
+from openharness.commands.registry import SlashCommand
 from openharness.engine.messages import ConversationMessage, ImageBlock, TextBlock
 from openharness.engine.stream_events import AssistantTextDelta, CompactProgressEvent, ToolExecutionStarted
 
@@ -354,6 +355,53 @@ async def test_runtime_pool_stream_message_uses_english_progress_for_english_inp
     assert "Thinking" in updates[0].text or "Working" in updates[0].text or "Looking" in updates[0].text or "Following" in updates[0].text or "Pulling" in updates[0].text
     assert updates[1].kind == "tool_hint"
     assert updates[1].text.startswith("🛠️ Using web_fetch")
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_local_only_commands_from_remote_messages(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    handler_called = False
+
+    async def forbidden_handler(args, context):
+        nonlocal handler_called
+        handler_called = True
+        return CommandResult(message="should not run")
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        command = SlashCommand(
+            "permissions",
+            "Show or update permission mode",
+            forbidden_handler,
+            remote_invocable=False,
+        )
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=SimpleNamespace(lookup=lambda raw: (command, "full_auto")),
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+    message = InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="/permissions full_auto")
+    updates = [u async for u in pool.stream_message(message, "feishu:c1")]
+
+    assert handler_called is False
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "/permissions is only available in the local OpenHarness UI."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the gateway/slash-command path against two verified security issues:
- remote gateway users could invoke local-only administrative commands from chat
- `/memory show` could read files outside the project memory directory via path traversal
- the gateway now supports a secure opt-in path for trusted remote admin commands using an explicit config gate plus a command allowlist
- regression tests now cover the default-deny path and the trusted opt-in behavior

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Remote slash-command permission-mode escalation | Remote users can change a local safety boundary from chat | High |
| Arbitrary file read via `/memory show` | Remote users can read host files outside project memory | High |

## Before this PR

- inbound remote messages could execute sensitive slash commands without distinguishing local-only administrative actions from remote-safe commands
- `/memory show` accepted attacker-controlled path input and could resolve reads outside the project memory directory
- there was no secure built-in way to preserve trusted remote admin workflows without leaving sensitive commands remotely reachable by default
- these trust boundaries were not explicitly covered by regression tests in the gateway/slash-command path

## After this PR

- sensitive administrative slash commands remain denied by default when received through the remote gateway path
- selected administrative slash commands can now be re-enabled only through an explicit gateway config gate and per-command allowlist
- accepted remote administrative commands emit warning-level audit logs and gateway startup warns when the opt-in is enabled
- `/memory show` resolves targets safely and enforces containment under the project memory directory before reading
- regression tests verify default-deny, trusted opt-in, and traversal rejection behavior

## Why this matters

These issues sit on trust boundaries that are reachable from remote chat/gateway usage:
1. permission mode is a safety boundary and should not be mutable by remote chat users unless an operator explicitly opts into that behavior
2. memory entry reads should stay inside the project memory directory and never escape to arbitrary host files

In practice, one issue weakens a meaningful safety control and the other exposes arbitrary file-read behavior from the host running OpenHarness.

## Attack flow

```text
Remote user message
    -> gateway slash-command handling
        -> sensitive command accepted from remote chat
            -> permission mode changed

Remote user message
    -> /memory show <attacker-controlled path>
        -> path joined to memory directory without containment check
            -> host file outside project memory returned to remote user
```

## Affected code

| Issue | Files |
|-------|-------|
| Remote slash-command permission-mode escalation | `ohmo/gateway/runtime.py`, `ohmo/gateway/models.py`, `ohmo/gateway/service.py`, `ohmo/cli.py`, `src/openharness/commands/registry.py` |
| Arbitrary file read via `/memory show` | `src/openharness/commands/registry.py`, `src/openharness/memory/paths.py` |

## Root cause

Issue 1: remote slash-command permission-mode escalation
- the gateway accepted slash commands directly from inbound remote messages
- sensitive administrative commands were not distinguished from normal remote-safe commands before execution
- there was no explicit secure-default override model for operators who wanted trusted remote admin behavior

Issue 2: arbitrary file read via `/memory show`
- `/memory show` joined attacker-controlled input onto the memory directory path
- the resulting path was read without enforcing containment under the project memory directory

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Remote slash-command permission-mode escalation | 8.8 High | `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` |
| Arbitrary file read via `/memory show` | 8.6 High | `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- Issue 1 allows a remote gateway user with chat access to disable a meaningful protection boundary and unlock dangerous follow-on operations when the deployment has not intentionally opted into remote admin behavior.
- Issue 2 allows a remote gateway user with chat access to read arbitrary host files reachable by the OpenHarness process.

## Safe reproduction steps

### 1. Remote slash-command permission-mode escalation
1. Run the gateway and connect a remote channel.
2. From the remote chat, send:
   - `/permissions full_auto`
3. Observe that permission mode changes from chat, even though this is a local safety control.

### 2. Arbitrary file read via `/memory show`
1. Run the gateway or slash-command surface against a project.
2. From chat or command input, request:
   - `/memory show ../../../../../../etc/hosts`
3. Observe that the command returns file content outside the memory directory instead of rejecting traversal.

## Expected vulnerable behavior
- remote users should not be able to switch permission mode from chat by default
- `/memory show` should not read files outside the project memory directory

## Changes in this PR
- add `remote_admin_opt_in` to `SlashCommand`
- keep `/permissions` and `/plan` remote-denied by default while marking them eligible for explicit remote opt-in
- add `allow_remote_admin_commands` and `allowed_remote_admin_commands` to gateway config
- allow only explicitly listed remote admin commands when the gateway opt-in is enabled
- emit warning-level audit logs when a remote administrative command is accepted
- emit a gateway startup warning when remote admin opt-in is enabled
- expose the remote admin opt-in and allowlist in the gateway config wizard and config summary
- resolve `/memory show` targets safely and enforce containment under the project memory directory
- add regression tests for default-deny, trusted opt-in, and traversal rejection

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Gateway enforcement | `ohmo/gateway/runtime.py` | Keeps remote admin denied by default, permits only explicitly opted-in commands, and logs accepted remote admin events |
| Gateway config model | `ohmo/gateway/models.py`, `ohmo/workspace.py` | Adds persisted remote admin opt-in fields and secure defaults for new workspaces |
| Gateway startup behavior | `ohmo/gateway/service.py` | Warns at startup when remote admin opt-in is enabled |
| Gateway configuration UX | `ohmo/cli.py` | Adds config wizard prompts and summary output for remote admin opt-in and allowlisted commands |
| Command metadata + memory read hardening | `src/openharness/commands/registry.py` | Adds `remote_admin_opt_in`, marks sensitive commands as explicitly opt-in only, and hardens `/memory show` |
| Regression coverage | `tests/test_commands/test_registry.py`, `tests/test_ohmo/test_gateway.py` | Adds tests for explicit remote admin opt-in and preserves traversal/blocking coverage |

## Maintainer impact

- no frontend behavior is changed
- the patch remains narrowly scoped to gateway command enforcement, gateway configuration, memory-path validation, and tests
- deployments that do nothing keep the secure default: remote admin commands stay blocked
- self-hosted trusted deployments now have a built-in, explicit, auditable opt-in path instead of needing to weaken the default boundary
- regression coverage reduces the risk of reintroducing these trust-boundary failures during later refactors

## Suggested fix rationale
- keep administrative safety toggles local-only by default
- allow trusted operators to opt into specific remote admin commands explicitly instead of reopening the whole slash-command surface
- validate filesystem containment before any read
- add regression tests so these issues do not reappear through future command or gateway refactors

## Reference patterns from other software
- GitHub Actions requires explicit approval for workflow runs from public forks before untrusted PR code gets access to privileged CI execution: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
- GitLab restricts access to protected variables and runners for merge request pipelines unless explicitly allowed, keeping privileged automation behind an opt-in trust boundary: https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/#control-access-to-protected-variables-and-runners
- Kubernetes RBAC separates privileged operations behind explicit role bindings rather than exposing administrative actions to every authenticated caller by default: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
- Keycloak documents fine-grained administrative permissions so sensitive management actions can be delegated narrowly instead of broadly enabling admin behavior: https://www.keycloak.org/docs/latest/server_admin/#_fine_grain_permissions

These are not identical products, but they reflect the same secure-default pattern: privileged actions stay off by default for untrusted remote inputs, and trusted exceptions require explicit configuration.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `tests/test_commands/test_registry.py::test_permissions_command_persists`
- [x] `tests/test_commands/test_registry.py::test_permissions_command_is_marked_local_only`
- [x] `tests/test_commands/test_registry.py::test_permissions_command_supports_explicit_remote_admin_opt_in`
- [x] `tests/test_commands/test_registry.py::test_memory_show_rejects_path_traversal`
- [x] `tests/test_commands/test_registry.py::test_memory_show_reads_normal_entries_with_md_fallback`
- [x] `tests/test_ohmo/test_gateway.py::test_runtime_pool_stream_message_emits_progress_and_tool_hint`
- [x] `tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_local_only_commands_from_remote_messages`
- [x] `tests/test_ohmo/test_gateway.py::test_runtime_pool_allows_opted_in_remote_admin_commands`
- [x] `uv run ruff check src tests ohmo`

Executed with:
- `PYTHONPATH=src:. .venv/bin/python -m pytest tests/test_commands/test_registry.py::test_permissions_command_persists tests/test_commands/test_registry.py::test_permissions_command_is_marked_local_only tests/test_commands/test_registry.py::test_permissions_command_supports_explicit_remote_admin_opt_in tests/test_commands/test_registry.py::test_memory_show_rejects_path_traversal tests/test_commands/test_registry.py::test_memory_show_reads_normal_entries_with_md_fallback tests/test_ohmo/test_gateway.py::test_runtime_pool_stream_message_emits_progress_and_tool_hint tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_local_only_commands_from_remote_messages tests/test_ohmo/test_gateway.py::test_runtime_pool_allows_opted_in_remote_admin_commands -q`
- `uv run ruff check src tests ohmo`

## Disclosure notes
- claims are intentionally bounded to what is demonstrated by code review and local reproduction
- this PR fixes the behavior directly and adds regression coverage
- no unrelated project files are changed
