### PR TITLE
fix(persistence): atomic writes and locks for shared state

### DIFF
--- a/ohmo/session_storage.py
+++ b/ohmo/session_storage.py
@@ -13,6 +13,7 @@ from openharness.api.usage import UsageSnapshot
 from openharness.engine.messages import ConversationMessage
 from openharness.services.session_backend import SessionBackend
 from openharness.services.session_storage import _persistable_tool_metadata
+from openharness.utils.fs import atomic_write_text
 
 from ohmo.workspace import get_sessions_dir
 
@@ -72,11 +73,11 @@ def save_session_snapshot(
     }
     data = json.dumps(payload, indent=2) + "\n"
     latest_path = session_dir / "latest.json"
-    latest_path.write_text(data, encoding="utf-8")
+    atomic_write_text(latest_path, data)
     if session_key:
-        _session_key_latest_path(workspace, session_key).write_text(data, encoding="utf-8")
+        atomic_write_text(_session_key_latest_path(workspace, session_key), data)
     session_path = session_dir / f"session-{sid}.json"
-    session_path.write_text(data, encoding="utf-8")
+    atomic_write_text(session_path, data)
     return latest_path
 
 
@@ -139,7 +140,7 @@ def export_session_markdown(
         text = message.text.strip()
         if text:
             parts.append(text)
-    path.write_text("\n".join(parts).strip() + "\n", encoding="utf-8")
+    atomic_write_text(path, "\n".join(parts).strip() + "\n")
     return path
 
 

--- a/src/openharness/api/copilot_auth.py
+++ b/src/openharness/api/copilot_auth.py
@@ -26,6 +26,7 @@ from typing import Any
 import httpx
 
 from openharness.config.paths import get_config_dir
+from openharness.utils.fs import atomic_write_text
 
 log = logging.getLogger(__name__)
 
@@ -96,19 +97,14 @@ def _auth_file_path() -> Path:
 def save_copilot_auth(token: str, *, enterprise_url: str | None = None) -> None:
     """Persist the GitHub OAuth token (and optional enterprise URL) to disk."""
     path = _auth_file_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
     payload: dict[str, Any] = {"github_token": token}
     if enterprise_url:
         payload["enterprise_url"] = enterprise_url
-    path.write_text(
+    atomic_write_text(
+        path,
         json.dumps(payload, indent=2) + "\n",
-        encoding="utf-8",
+        mode=0o600,
     )
-    # Best-effort permission restriction (ignored on Windows).
-    try:
-        path.chmod(0o600)
-    except OSError:
-        pass
     log.info("Copilot auth saved to %s", path)
 
 

--- a/src/openharness/auth/external.py
+++ b/src/openharness/auth/external.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from openharness.auth.storage import ExternalAuthBinding
+from openharness.utils.fs import atomic_write_text
 
 CODEX_PROVIDER = "openai_codex"
 CLAUDE_PROVIDER = "anthropic_claude"
@@ -494,12 +495,11 @@ def write_claude_credentials(
         refresh_token=refresh_token,
         expires_at_ms=expires_at_ms,
     )
-    source_path.parent.mkdir(parents=True, exist_ok=True)
-    source_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
-    try:
-        source_path.chmod(0o600)
-    except OSError:
-        pass
+    atomic_write_text(
+        source_path,
+        json.dumps(existing, indent=2) + "\n",
+        mode=0o600,
+    )
 
 
 def _write_claude_credentials_to_keychain(

--- a/src/openharness/auth/storage.py
+++ b/src/openharness/auth/storage.py
@@ -22,11 +22,17 @@ from pathlib import Path
 from typing import Any
 
 from openharness.config.paths import get_config_dir
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
 
 log = logging.getLogger(__name__)
 
 _CREDS_FILE_NAME = "credentials.json"
 _KEYRING_SERVICE = "openharness"
+
+
+def _creds_lock_path() -> Path:
+    return _creds_path().with_suffix(".json.lock")
 
 
 @dataclass(frozen=True)
@@ -62,12 +68,11 @@ def _load_creds_file() -> dict[str, Any]:
 
 def _save_creds_file(data: dict[str, Any]) -> None:
     path = _creds_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    try:
-        path.chmod(0o600)
-    except OSError:
-        pass
+    atomic_write_text(
+        path,
+        json.dumps(data, indent=2) + "\n",
+        mode=0o600,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -132,9 +137,10 @@ def store_credential(provider: str, key: str, value: str, *, use_keyring: bool |
         except Exception as exc:
             log.warning("Keyring store failed, falling back to file: %s", exc)
 
-    data = _load_creds_file()
-    data.setdefault(provider, {})[key] = value
-    _save_creds_file(data)
+    with exclusive_file_lock(_creds_lock_path()):
+        data = _load_creds_file()
+        data.setdefault(provider, {})[key] = value
+        _save_creds_file(data)
     log.debug("Stored %s/%s in credentials file", provider, key)
 
 
@@ -176,10 +182,11 @@ def clear_provider_credentials(provider: str, *, use_keyring: bool | None = None
         except ImportError:
             pass
 
-    data = _load_creds_file()
-    if provider in data:
-        del data[provider]
-        _save_creds_file(data)
+    with exclusive_file_lock(_creds_lock_path()):
+        data = _load_creds_file()
+        if provider in data:
+            del data[provider]
+            _save_creds_file(data)
     log.debug("Cleared credentials for provider: %s", provider)
 
 
@@ -190,10 +197,11 @@ def list_stored_providers() -> list[str]:
 
 def store_external_binding(binding: ExternalAuthBinding) -> None:
     """Persist metadata describing an external auth source for *provider*."""
-    data = _load_creds_file()
-    entry = data.setdefault(binding.provider, {})
-    entry["external_binding"] = asdict(binding)
-    _save_creds_file(data)
+    with exclusive_file_lock(_creds_lock_path()):
+        data = _load_creds_file()
+        entry = data.setdefault(binding.provider, {})
+        entry["external_binding"] = asdict(binding)
+        _save_creds_file(data)
     log.debug("Stored external auth binding for provider: %s", binding.provider)
 
 

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel, Field
 from openharness.hooks.schemas import HookDefinition
 from openharness.mcp.types import McpServerConfig
 from openharness.permissions.modes import PermissionMode
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
 
 
 # ANSI escape sequence pattern
@@ -859,8 +861,9 @@ def save_settings(settings: Settings, config_path: Path | None = None) -> None:
         config_path = get_config_file_path()
 
     settings = settings.sync_active_profile_from_flat_fields().materialize_active_profile()
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(
-        settings.model_dump_json(indent=2) + "\n",
-        encoding="utf-8",
-    )
+    lock_path = config_path.with_suffix(config_path.suffix + ".lock")
+    with exclusive_file_lock(lock_path):
+        atomic_write_text(
+            config_path,
+            settings.model_dump_json(indent=2) + "\n",
+        )

--- a/src/openharness/memory/manager.py
+++ b/src/openharness/memory/manager.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from re import sub
 
 from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
+
+
+def _memory_lock_path(cwd: str | Path) -> Path:
+    return get_project_memory_dir(cwd) / ".memory.lock"
 
 
 def list_memory_files(cwd: str | Path) -> list[Path]:
@@ -19,13 +25,14 @@ def add_memory_entry(cwd: str | Path, title: str, content: str) -> Path:
     memory_dir = get_project_memory_dir(cwd)
     slug = sub(r"[^a-zA-Z0-9]+", "_", title.strip().lower()).strip("_") or "memory"
     path = memory_dir / f"{slug}.md"
-    path.write_text(content.strip() + "\n", encoding="utf-8")
+    with exclusive_file_lock(_memory_lock_path(cwd)):
+        atomic_write_text(path, content.strip() + "\n")
 
-    entrypoint = get_memory_entrypoint(cwd)
-    existing = entrypoint.read_text(encoding="utf-8") if entrypoint.exists() else "# Memory Index\n"
-    if path.name not in existing:
-        existing = existing.rstrip() + f"\n- [{title}]({path.name})\n"
-        entrypoint.write_text(existing, encoding="utf-8")
+        entrypoint = get_memory_entrypoint(cwd)
+        existing = entrypoint.read_text(encoding="utf-8") if entrypoint.exists() else "# Memory Index\n"
+        if path.name not in existing:
+            existing = existing.rstrip() + f"\n- [{title}]({path.name})\n"
+            atomic_write_text(entrypoint, existing)
     return path
 
 
@@ -36,15 +43,16 @@ def remove_memory_entry(cwd: str | Path, name: str) -> bool:
     if not matches:
         return False
     path = matches[0]
-    if path.exists():
-        path.unlink()
+    with exclusive_file_lock(_memory_lock_path(cwd)):
+        if path.exists():
+            path.unlink()
 
-    entrypoint = get_memory_entrypoint(cwd)
-    if entrypoint.exists():
-        lines = [
-            line
-            for line in entrypoint.read_text(encoding="utf-8").splitlines()
-            if path.name not in line
-        ]
-        entrypoint.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        entrypoint = get_memory_entrypoint(cwd)
+        if entrypoint.exists():
+            lines = [
+                line
+                for line in entrypoint.read_text(encoding="utf-8").splitlines()
+                if path.name not in line
+            ]
+            atomic_write_text(entrypoint, "\n".join(lines).rstrip() + "\n")
     return True

--- a/src/openharness/services/cron.py
+++ b/src/openharness/services/cron.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from croniter import croniter
 
 from openharness.config.paths import get_cron_registry_path
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
+
+
+def _cron_lock_path() -> Path:
+    path = get_cron_registry_path()
+    return path.with_suffix(path.suffix + ".lock")
 
 
 def load_cron_jobs() -> list[dict[str, Any]]:
@@ -25,9 +33,10 @@ def load_cron_jobs() -> list[dict[str, Any]]:
 
 def save_cron_jobs(jobs: list[dict[str, Any]]) -> None:
     """Persist cron jobs to disk."""
-    path = get_cron_registry_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(jobs, indent=2) + "\n", encoding="utf-8")
+    atomic_write_text(
+        get_cron_registry_path(),
+        json.dumps(jobs, indent=2) + "\n",
+    )
 
 
 def validate_cron_expression(expression: str) -> bool:
@@ -54,19 +63,21 @@ def upsert_cron_job(job: dict[str, Any]) -> None:
     if validate_cron_expression(schedule):
         job["next_run"] = next_run_time(schedule).isoformat()
 
-    jobs = [existing for existing in load_cron_jobs() if existing.get("name") != job.get("name")]
-    jobs.append(job)
-    jobs.sort(key=lambda item: str(item.get("name", "")))
-    save_cron_jobs(jobs)
+    with exclusive_file_lock(_cron_lock_path()):
+        jobs = [existing for existing in load_cron_jobs() if existing.get("name") != job.get("name")]
+        jobs.append(job)
+        jobs.sort(key=lambda item: str(item.get("name", "")))
+        save_cron_jobs(jobs)
 
 
 def delete_cron_job(name: str) -> bool:
     """Delete one cron job by name."""
-    jobs = load_cron_jobs()
-    filtered = [job for job in jobs if job.get("name") != name]
-    if len(filtered) == len(jobs):
-        return False
-    save_cron_jobs(filtered)
+    with exclusive_file_lock(_cron_lock_path()):
+        jobs = load_cron_jobs()
+        filtered = [job for job in jobs if job.get("name") != name]
+        if len(filtered) == len(jobs):
+            return False
+        save_cron_jobs(filtered)
     return True
 
 
@@ -80,25 +91,27 @@ def get_cron_job(name: str) -> dict[str, Any] | None:
 
 def set_job_enabled(name: str, enabled: bool) -> bool:
     """Enable or disable a cron job. Returns False if job not found."""
-    jobs = load_cron_jobs()
-    for job in jobs:
-        if job.get("name") == name:
-            job["enabled"] = enabled
-            save_cron_jobs(jobs)
-            return True
+    with exclusive_file_lock(_cron_lock_path()):
+        jobs = load_cron_jobs()
+        for job in jobs:
+            if job.get("name") == name:
+                job["enabled"] = enabled
+                save_cron_jobs(jobs)
+                return True
     return False
 
 
 def mark_job_run(name: str, *, success: bool) -> None:
     """Update last_run and recompute next_run after a job executes."""
-    jobs = load_cron_jobs()
-    now = datetime.now(timezone.utc)
-    for job in jobs:
-        if job.get("name") == name:
-            job["last_run"] = now.isoformat()
-            job["last_status"] = "success" if success else "failed"
-            schedule = job.get("schedule", "")
-            if validate_cron_expression(schedule):
-                job["next_run"] = next_run_time(schedule, now).isoformat()
-            save_cron_jobs(jobs)
-            return
+    with exclusive_file_lock(_cron_lock_path()):
+        jobs = load_cron_jobs()
+        now = datetime.now(timezone.utc)
+        for job in jobs:
+            if job.get("name") == name:
+                job["last_run"] = now.isoformat()
+                job["last_status"] = "success" if success else "failed"
+                schedule = job.get("schedule", "")
+                if validate_cron_expression(schedule):
+                    job["next_run"] = next_run_time(schedule, now).isoformat()
+                save_cron_jobs(jobs)
+                return

--- a/src/openharness/services/session_storage.py
+++ b/src/openharness/services/session_storage.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from openharness.api.usage import UsageSnapshot
 from openharness.config.paths import get_sessions_dir
 from openharness.engine.messages import ConversationMessage
+from openharness.utils.fs import atomic_write_text
 
 
 _PERSISTED_TOOL_METADATA_KEYS = (
@@ -95,11 +96,11 @@ def save_session_snapshot(
 
     # Save as latest
     latest_path = session_dir / "latest.json"
-    latest_path.write_text(data, encoding="utf-8")
+    atomic_write_text(latest_path, data)
 
     # Save by session ID
     session_path = session_dir / f"session-{sid}.json"
-    session_path.write_text(data, encoding="utf-8")
+    atomic_write_text(session_path, data)
 
     return latest_path
 
@@ -210,5 +211,5 @@ def export_session_markdown(
         for block in message.content:
             if getattr(block, "type", "") == "tool_result":
                 parts.append(f"\n```tool-result\n{block.content}\n```")
-    path.write_text("\n".join(parts).strip() + "\n", encoding="utf-8")
+    atomic_write_text(path, "\n".join(parts).strip() + "\n")
     return path

--- a/src/openharness/swarm/lockfile.py
+++ b/src/openharness/swarm/lockfile.py
@@ -1,73 +1,24 @@
-"""Cross-platform file-lock helpers for swarm mailbox and permission storage."""
+"""Backwards-compatible re-export of the generic file-lock helpers.
+
+The implementation lives in :mod:`openharness.utils.file_lock`. This module
+is retained so existing callers (swarm mailbox, permission sync, external
+plugins) keep working without changes.
+"""
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Iterator
+from openharness.utils.file_lock import (
+    SwarmLockError,
+    SwarmLockUnavailableError,
+    _exclusive_posix_lock,
+    _exclusive_windows_lock,
+    exclusive_file_lock,
+)
 
-from openharness.platforms import PlatformName, get_platform
-
-
-class SwarmLockError(RuntimeError):
-    """Base error for swarm lock failures."""
-
-
-class SwarmLockUnavailableError(SwarmLockError):
-    """Raised when file locking is unavailable on the current platform."""
-
-
-@contextmanager
-def exclusive_file_lock(
-    lock_path: Path,
-    *,
-    platform_name: PlatformName | None = None,
-) -> Iterator[None]:
-    """Acquire an exclusive file lock for swarm mailbox/permission operations."""
-    resolved_platform = platform_name or get_platform()
-    if resolved_platform == "windows":
-        with _exclusive_windows_lock(lock_path):
-            yield
-        return
-    if resolved_platform in {"macos", "linux", "wsl"}:
-        with _exclusive_posix_lock(lock_path):
-            yield
-        return
-    raise SwarmLockUnavailableError(
-        f"swarm file locking is not supported on platform {resolved_platform!r}"
-    )
-
-
-@contextmanager
-def _exclusive_posix_lock(lock_path: Path) -> Iterator[None]:
-    import fcntl
-
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.touch(exist_ok=True)
-    with lock_path.open("a+b") as lock_file:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
-
-@contextmanager
-def _exclusive_windows_lock(lock_path: Path) -> Iterator[None]:
-    import msvcrt
-
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+b") as lock_file:
-        # msvcrt.locking requires a byte range to exist and the file be open in
-        # binary mode. Lock the first byte for the lifetime of the critical section.
-        lock_file.seek(0)
-        if lock_path.stat().st_size == 0:
-            lock_file.write(b"\0")
-            lock_file.flush()
-        lock_file.seek(0)
-        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
-        try:
-            yield
-        finally:
-            lock_file.seek(0)
-            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+__all__ = [
+    "SwarmLockError",
+    "SwarmLockUnavailableError",
+    "_exclusive_posix_lock",
+    "_exclusive_windows_lock",
+    "exclusive_file_lock",
+]

--- a/src/openharness/utils/file_lock.py
+++ b/src/openharness/utils/file_lock.py
@@ -1,0 +1,80 @@
+"""Cross-platform exclusive file-lock helpers.
+
+Used to serialise read-modify-write sequences on shared JSON registries
+(credentials, settings, cron, memory index, swarm mailbox). Pair with
+:func:`openharness.utils.fs.atomic_write_text` to make each critical section
+both race-free and crash-safe.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from openharness.platforms import PlatformName, get_platform
+
+
+class SwarmLockError(RuntimeError):
+    """Base error for file-lock failures."""
+
+
+class SwarmLockUnavailableError(SwarmLockError):
+    """Raised when file locking is unavailable on the current platform."""
+
+
+@contextmanager
+def exclusive_file_lock(
+    lock_path: Path,
+    *,
+    platform_name: PlatformName | None = None,
+) -> Iterator[None]:
+    """Acquire an exclusive file lock for the duration of the context."""
+    resolved_platform = platform_name or get_platform()
+    if resolved_platform == "windows":
+        with _exclusive_windows_lock(lock_path):
+            yield
+        return
+    if resolved_platform in {"macos", "linux", "wsl"}:
+        with _exclusive_posix_lock(lock_path):
+            yield
+        return
+    raise SwarmLockUnavailableError(
+        f"file locking is not supported on platform {resolved_platform!r}"
+    )
+
+
+@contextmanager
+def _exclusive_posix_lock(lock_path: Path) -> Iterator[None]:
+    import fcntl
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch(exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _exclusive_windows_lock(lock_path: Path) -> Iterator[None]:
+    import msvcrt
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        # msvcrt.locking requires a byte range to exist and the file be open
+        # in binary mode. Lock the first byte for the lifetime of the
+        # critical section.
+        lock_file.seek(0)
+        if lock_path.stat().st_size == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)

--- a/src/openharness/utils/fs.py
+++ b/src/openharness/utils/fs.py
@@ -1,0 +1,98 @@
+"""Atomic file-write helpers for persistent state.
+
+Every file under ``~/.openharness/`` that is rewritten during normal use —
+credentials, settings, session snapshots, cron registry, memory index — must
+be written atomically. A crash, SIGKILL, power loss, or out-of-disk error
+during a naive :meth:`pathlib.Path.write_text` leaves a truncated file on
+disk, and the next read silently returns ``{}`` (for credentials) or raises
+:class:`json.JSONDecodeError` (for sessions). Both outcomes are recoverable
+only by manual intervention.
+
+The pattern implemented here is the standard temp-file-plus-rename dance:
+
+1. Create a same-directory temp file (so the final :func:`os.replace` is a
+   rename on the same filesystem, never a cross-filesystem copy).
+2. Write the payload, ``flush`` and ``fsync``.
+3. Apply the target POSIX mode while the file is still private.
+4. :func:`os.replace` atomically swaps the temp file into place. On POSIX
+   the kernel guarantees that any concurrent reader sees either the old
+   inode or the new one, never a half-written one. Since Python 3.3
+   :func:`os.replace` provides the same guarantee on Windows.
+
+For read-modify-write sequences on shared files (credentials, settings, cron
+registry), pair atomic writes with :func:`exclusive_file_lock` from
+:mod:`openharness.swarm.lockfile` so two concurrent ``oh`` processes cannot
+clobber each other's updates.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+__all__ = ["atomic_write_bytes", "atomic_write_text"]
+
+
+def atomic_write_bytes(path: str | os.PathLike[str], data: bytes, *, mode: int | None = None) -> None:
+    """Write ``data`` to ``path`` atomically.
+
+    When ``mode`` is given, the final file is created with that POSIX mode
+    even if it did not previously exist. When ``mode`` is ``None``, the
+    existing file's mode is preserved; for new files the current umask
+    determines the mode, matching the historical behaviour of
+    :meth:`pathlib.Path.write_text`.
+    """
+    dst = Path(path)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    target_mode = _resolve_target_mode(dst, mode)
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{dst.name}.", suffix=".tmp", dir=str(dst.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        _apply_mode(tmp_path, target_mode)
+        os.replace(tmp_path, dst)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
+def atomic_write_text(
+    path: str | os.PathLike[str],
+    data: str,
+    *,
+    encoding: str = "utf-8",
+    mode: int | None = None,
+) -> None:
+    """Text variant of :func:`atomic_write_bytes`."""
+    atomic_write_bytes(path, data.encode(encoding), mode=mode)
+
+
+def _resolve_target_mode(path: Path, explicit_mode: int | None) -> int:
+    if explicit_mode is not None:
+        return explicit_mode
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        return 0o666 & ~current_umask
+    return stat.S_IMODE(st.st_mode)
+
+
+def _apply_mode(path: Path, target_mode: int) -> None:
+    try:
+        os.chmod(path, target_mode)
+    except OSError:
+        # chmod can fail on Windows / FAT / some network mounts. The payload
+        # is still intact; only permission enforcement is weakened.
+        pass

--- a/tests/test_swarm/test_lockfile.py
+++ b/tests/test_swarm/test_lockfile.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from openharness.swarm import lockfile
+from openharness.utils import file_lock
 
 
 def test_exclusive_file_lock_creates_lock_file_on_posix(tmp_path: Path):
@@ -27,7 +28,9 @@ def test_exclusive_file_lock_routes_windows_branch(monkeypatch, tmp_path: Path):
         calls.append(lock_path)
         yield
 
-    monkeypatch.setattr(lockfile, "_exclusive_windows_lock", _fake_windows_lock)
+    # The implementation lives in ``openharness.utils.file_lock``;
+    # ``openharness.swarm.lockfile`` re-exports it for backwards compatibility.
+    monkeypatch.setattr(file_lock, "_exclusive_windows_lock", _fake_windows_lock)
 
     lock_path = tmp_path / "windows.lock"
     with lockfile.exclusive_file_lock(lock_path, platform_name="windows"):
@@ -40,3 +43,10 @@ def test_exclusive_file_lock_rejects_unknown_platform(tmp_path: Path):
     with pytest.raises(lockfile.SwarmLockUnavailableError, match="not supported"):
         with lockfile.exclusive_file_lock(tmp_path / "unknown.lock", platform_name="unknown"):
             pass
+
+
+def test_swarm_lockfile_shim_re_exports_public_api():
+    """Existing callers importing from ``swarm.lockfile`` must keep working."""
+    assert lockfile.exclusive_file_lock is file_lock.exclusive_file_lock
+    assert lockfile.SwarmLockError is file_lock.SwarmLockError
+    assert lockfile.SwarmLockUnavailableError is file_lock.SwarmLockUnavailableError

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -1,0 +1,175 @@
+"""Tests for :mod:`openharness.utils.fs` atomic-write helpers."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from openharness.utils.fs import atomic_write_bytes, atomic_write_text
+
+
+# ---------------------------------------------------------------------------
+# Core behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_text_creates_file(tmp_path: Path) -> None:
+    path = tmp_path / "out.json"
+    atomic_write_text(path, '{"hello": "world"}\n')
+    assert path.read_text() == '{"hello": "world"}\n'
+
+
+def test_atomic_write_bytes_creates_file(tmp_path: Path) -> None:
+    path = tmp_path / "out.bin"
+    atomic_write_bytes(path, b"\x00\x01\x02")
+    assert path.read_bytes() == b"\x00\x01\x02"
+
+
+def test_atomic_write_creates_parent_directory(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "deep" / "out.txt"
+    atomic_write_text(path, "hi")
+    assert path.read_text() == "hi"
+
+
+def test_atomic_write_overwrites_existing_file(tmp_path: Path) -> None:
+    path = tmp_path / "out.txt"
+    path.write_text("old contents")
+    atomic_write_text(path, "new contents")
+    assert path.read_text() == "new contents"
+
+
+def test_atomic_write_does_not_leave_tempfiles(tmp_path: Path) -> None:
+    path = tmp_path / "out.txt"
+    atomic_write_text(path, "payload")
+    assert path.exists()
+    leftover = [p for p in tmp_path.iterdir() if p != path]
+    assert leftover == []
+
+
+# ---------------------------------------------------------------------------
+# Mode handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes not enforced on Windows")
+def test_mode_is_applied_to_new_file(tmp_path: Path) -> None:
+    path = tmp_path / "creds.json"
+    atomic_write_text(path, "secret", mode=0o600)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes not enforced on Windows")
+def test_credentials_are_never_world_readable(tmp_path: Path) -> None:
+    """Regression test: the file must be 0o600 from the very first byte.
+
+    The previous ``write_text`` + ``chmod`` sequence left a window during
+    which a co-resident attacker could stat the file with the default umask
+    mode (commonly 0o644). The atomic helper closes that window by applying
+    the mode before the tempfile is renamed into place.
+    """
+    path = tmp_path / "credentials.json"
+    atomic_write_text(
+        path,
+        json.dumps({"anthropic": {"api_key": "sk-secret"}}),
+        mode=0o600,
+    )
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode & 0o077 == 0, f"file is readable by group/other: {oct(mode)}"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes not enforced on Windows")
+def test_mode_preserved_on_overwrite_when_not_specified(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    path.write_text("{}")
+    os.chmod(path, 0o640)
+    atomic_write_text(path, '{"updated": true}')
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX modes not enforced on Windows")
+def test_explicit_mode_overrides_existing_mode(tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
+    path.write_text("{}")
+    os.chmod(path, 0o644)
+    atomic_write_text(path, "{}", mode=0o600)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Atomicity under write failure
+# ---------------------------------------------------------------------------
+
+
+def test_existing_file_is_untouched_on_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the write raises before ``os.replace`` runs, the old file survives."""
+    path = tmp_path / "settings.json"
+    path.write_text('{"kept": true}')
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("openharness.utils.fs.os.replace", _boom)
+
+    with pytest.raises(OSError, match="disk full"):
+        atomic_write_text(path, '{"overwritten": true}')
+
+    assert json.loads(path.read_text()) == {"kept": True}
+    leftover = sorted(p.name for p in tmp_path.iterdir() if p != path)
+    assert leftover == [], f"tempfile leaked: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writers (end-to-end — exercises lock + atomic write together)
+# ---------------------------------------------------------------------------
+
+
+def _concurrent_writer(target_path: str, lock_path: str, key: str, value: str) -> None:
+    """Read-modify-write entry point for :func:`test_concurrent_writers_all_survive`.
+
+    Must be a module-level function so it is picklable by ``multiprocessing``.
+    """
+    from openharness.utils.file_lock import exclusive_file_lock
+    from openharness.utils.fs import atomic_write_text
+
+    target = Path(target_path)
+    lock = Path(lock_path)
+    with exclusive_file_lock(lock):
+        if target.exists():
+            data = json.loads(target.read_text())
+        else:
+            data = {}
+        data[key] = value
+        atomic_write_text(target, json.dumps(data, indent=2) + "\n")
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX fork semantics keep this test deterministic; skip on Windows CI",
+)
+def test_concurrent_writers_all_survive(tmp_path: Path) -> None:
+    """Two concurrent read-modify-write processes must not lose updates."""
+    target = tmp_path / "credentials.json"
+    lock = tmp_path / "credentials.json.lock"
+
+    ctx = mp.get_context("fork")
+    writers = [
+        ctx.Process(target=_concurrent_writer, args=(str(target), str(lock), f"key_{i}", f"value_{i}"))
+        for i in range(8)
+    ]
+    for w in writers:
+        w.start()
+    for w in writers:
+        w.join(timeout=10)
+        assert w.exitcode == 0, f"writer {w.pid} failed with exit code {w.exitcode}"
+
+    result = json.loads(target.read_text())
+    assert set(result) == {f"key_{i}" for i in range(8)}
+    assert all(result[f"key_{i}"] == f"value_{i}" for i in range(8))


### PR DESCRIPTION
## Summary

Closes #129.

Every file under `~/.openharness/` that gets rewritten during normal use — credentials, settings, session snapshots, cron registry, memory index — is currently written with `Path.write_text()` in truncating mode. A crash, SIGKILL, power loss, or out-of-disk error during the write leaves a truncated file on disk; concurrent writers clobber each other's updates; and the credentials file spends a brief window at the default umask mode (commonly `0o644`) before `chmod(0o600)` runs. See #129 for concrete failure scenarios and blast radius.

This PR introduces `openharness.utils.fs.atomic_write_text` / `atomic_write_bytes` and threads them through every persistence writer. For read-modify-write on shared files (credentials, settings, cron, memory index), atomic writes are paired with the existing `exclusive_file_lock` primitive so two `oh` processes can no longer race.

## Mechanism

The pattern is the standard temp-file-plus-rename dance:

1. Create a same-directory temp file (so the final `os.replace` is a rename on the same filesystem, never a cross-filesystem copy).
2. Write the payload, `flush`, `fsync`.
3. Apply the target POSIX mode while the file is still private.
4. `os.replace(tmp, path)` — atomic on POSIX and on Windows since Python 3.3.

If any step before `os.replace` raises, the original file on disk is untouched and the temp file is cleaned up. As a side benefit, credentials are now created with mode `0o600` from the very first byte instead of spending a brief window at the umask-derived mode before `chmod` runs.

## What changed

**New modules**
- `src/openharness/utils/fs.py` — `atomic_write_text`, `atomic_write_bytes`.
- `src/openharness/utils/file_lock.py` — the canonical home for the cross-platform lock helper (moved from `swarm/lockfile.py`).

**Updated call sites**
- `src/openharness/auth/storage.py` — atomic write with `mode=0o600`; `store_credential`, `clear_provider_credentials`, `store_external_binding` wrap read-modify-write in `exclusive_file_lock`.
- `src/openharness/auth/external.py` — atomic write of the upstream Claude-subscription credentials file with `mode=0o600`.
- `src/openharness/api/copilot_auth.py` — atomic write of the Copilot OAuth credentials file with `mode=0o600`.
- `src/openharness/config/settings.py` — atomic write + lock around `save_settings`.
- `src/openharness/services/session_storage.py` — atomic writes for `latest.json`, `session-<id>.json`, `transcript.md`.
- `ohmo/session_storage.py` — atomic writes for `latest.json`, per-session-key latest, `session-<id>.json`, `transcript.md`.
- `src/openharness/services/cron.py` — atomic write + lock around `upsert_cron_job`, `delete_cron_job`, `set_job_enabled`, `mark_job_run`.
- `src/openharness/memory/manager.py` — atomic write + lock around the two-file op in `add_memory_entry` / `remove_memory_entry` so a crash can no longer leave the `.md` file orphaned from `MEMORY.md`.

**Compatibility**
- `src/openharness/swarm/lockfile.py` is now a thin re-export of `openharness.utils.file_lock`. Existing callers — `swarm/mailbox.py`, `swarm/permission_sync.py`, any external plugin — keep working without changes.
- Public API surface is unchanged — only internal persistence behaviour.

## Tests

- `tests/test_utils/test_fs.py` (new, 11 tests) — covers file creation, parent-directory creation, overwrite, no leftover tempfiles, explicit mode application, credentials being `0o600` from byte 0, existing-mode preservation on overwrite, explicit-mode override, and a monkeypatched `os.replace` failure path that asserts the original file is untouched and the tempfile is cleaned up.
- Concurrent-writer regression — eight `multiprocessing` workers each perform a read-modify-write with distinct keys; the final file contains all eight keys with no lost updates.
- `tests/test_swarm/test_lockfile.py` — updated to patch the canonical implementation path and added a shim sanity check that `swarm.lockfile` re-exports the same objects.

## Validation

- [x] `uv run ruff check src tests scripts` — all checks passed
- [x] `uv run pytest -q` — 662 passed, 6 skipped, 1 xfailed (pre-existing)
- [x] `uv run pytest tests/test_utils/test_fs.py tests/test_swarm/test_lockfile.py -q` — 16 passed, including the multi-process concurrent-writer test
- [x] Frontend not touched — no `tsc` check needed

## Notes

- Per request from the contributor, this PR intentionally omits a `CHANGELOG.md` entry; one can be added in a follow-up if preferred by the maintainers.
- The lock relocation keeps `openharness.swarm.lockfile` as a re-export, so no external caller should need to adjust imports.
