### PR TITLE
fix(tui): write trailing newline on exit so shell prompt starts on a fresh line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 - Fixed concurrent permission modals overwriting each other in TUI default mode when the LLM returns multiple tool calls in one response; `_ask_permission` now serialises callers via an `asyncio.Lock` so each modal is shown and resolved before the next one is emitted.
 - Fixed React TUI Markdown tables to size columns from rendered cell text so inline formatting like code spans and bold text no longer breaks alignment.
 - Fixed grep tool crashing with `ValueError` / `LimitOverrunError` when ripgrep outputs a line longer than 64 KB (e.g. minified assets or lock files). The asyncio subprocess stream limit is now 8 MB and oversized lines are skipped rather than terminating the session.
+- Fixed React TUI exit leaving the shell prompt concatenated with the last TUI line. The terminal cleanup handler now writes a trailing newline (`\n`) alongside the cursor-show escape sequence so the shell prompt always starts on a fresh line.
 
 ### Changed
 

--- a/frontend/terminal/src/index.tsx
+++ b/frontend/terminal/src/index.tsx
@@ -39,17 +39,19 @@ process.on('uncaughtException', (err: NodeJS.ErrnoException) => {
 
 const config = JSON.parse(process.env.OPENHARNESS_FRONTEND_CONFIG ?? '{}') as FrontendConfig;
 
-// Restore terminal cursor visibility on exit (Ink hides it by default)
-const restoreCursor = (): void => {
-	process.stdout.write('\x1B[?25h');
+// Restore terminal cursor visibility on exit (Ink hides it by default).
+// Also write a newline so the shell prompt starts on a fresh line and does
+// not run into the last line of the TUI output.
+const restoreTerminal = (): void => {
+	process.stdout.write('\x1B[?25h\n');
 };
-process.on('exit', restoreCursor);
+process.on('exit', restoreTerminal);
 process.on('SIGINT', () => {
-	restoreCursor();
+	restoreTerminal();
 	process.exit(130);
 });
 process.on('SIGTERM', () => {
-	restoreCursor();
+	restoreTerminal();
 	process.exit(143);
 });
 

--- a/tests/test_ohmo/test_cli.py
+++ b/tests/test_ohmo/test_cli.py
@@ -56,6 +56,7 @@ def test_ohmo_init_interactive_writes_gateway_config(tmp_path: Path, monkeypatch
             "n",  # feishu
             "y",  # send_progress
             "y",  # send_tool_hints
+            "n",  # allow_remote_admin_commands
         ]
     )
     result = runner.invoke(app, ["init", "--workspace", str(workspace)], input=user_input)
@@ -85,6 +86,7 @@ def test_ohmo_init_interactive_writes_feishu_gateway_config(tmp_path: Path, monk
             "OK",        # react_emoji
             "y",         # send_progress
             "n",         # send_tool_hints
+            "n",         # allow_remote_admin_commands
         ]
     )
     result = runner.invoke(app, ["init", "--workspace", str(workspace)], input=user_input)
@@ -122,6 +124,7 @@ def test_ohmo_config_interactive_can_restart_gateway(tmp_path: Path, monkeypatch
             "OK",         # react_emoji
             "y",          # send_progress
             "y",          # send_tool_hints
+            "n",          # allow_remote_admin_commands
             "y",          # restart gateway
         ]
     )
@@ -162,6 +165,7 @@ def test_ohmo_config_keeps_existing_channel_when_not_reconfigured(tmp_path: Path
             "n",  # reconfigure feishu? keep existing
             "y",  # send_progress
             "y",  # send_tool_hints
+            "n",  # allow_remote_admin_commands
         ]
     )
     result = runner.invoke(app, ["config", "--workspace", str(workspace)], input=user_input)

--- a/tests/test_ui/test_tui_exit_sequence.py
+++ b/tests/test_ui/test_tui_exit_sequence.py
@@ -1,0 +1,49 @@
+"""Regression guard: the React TUI exit handler must write a trailing newline.
+
+When the TUI process exits, Ink leaves the cursor at the end of the last
+rendered line.  Without a newline the shell prompt appears concatenated with
+the TUI output, which is visually broken.  This test reads the TypeScript
+entry-point source and asserts that the exit-cleanup write includes '\\n'
+alongside the cursor-show escape sequence.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _frontend_index() -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    return repo_root / "frontend" / "terminal" / "src" / "index.tsx"
+
+
+def test_tui_exit_handler_writes_newline() -> None:
+    """restoreTerminal must emit \\x1B[?25h\\n so the shell prompt starts on a new line.
+
+    Regression for: TUI exit leaves shell prompt concatenated with last TUI line.
+    """
+    source = _frontend_index().read_text(encoding="utf-8")
+
+    # Locate the cleanup function body and verify it includes a trailing \\n.
+    # The expected write is: process.stdout.write('\\x1B[?25h\\n')
+    pattern = re.compile(
+        r"process\.stdout\.write\(['\"].*\\x1B\[\?25h\\n.*['\"]\)",
+        re.MULTILINE,
+    )
+    assert pattern.search(source), (
+        "The TUI exit handler must call process.stdout.write with a trailing '\\n' "
+        "so the shell prompt starts on a fresh line after the TUI exits. "
+        f"Check {_frontend_index()} and ensure the cursor-restore write ends with \\n."
+    )
+
+
+def test_tui_exit_handler_registered_for_all_signals() -> None:
+    """restoreTerminal must be attached to 'exit', SIGINT, and SIGTERM."""
+    source = _frontend_index().read_text(encoding="utf-8")
+
+    for signal in ("exit", "SIGINT", "SIGTERM"):
+        assert f"process.on('{signal}'" in source, (
+            f"The TUI exit cleanup must be registered for '{signal}'. "
+            f"Check {_frontend_index()}."
+        )


### PR DESCRIPTION
## Summary

Fixes #132

### Problem

When the React TUI exits (via `ctrl+c`, `SIGTERM`, or normal process end), the shell prompt appears **concatenated with the last rendered TUI line**:

```
 enter send  / commands  ↑↓ history  ctrl+c exit(openharness-ai) user@host:~/project$
```

### Root cause

`frontend/terminal/src/index.tsx` registers an exit-cleanup handler that restores cursor visibility (`\x1B[?25h`) but does not emit a trailing newline. Ink renders inline and leaves the cursor at the end of the last rendered line on unmount. The shell then prints its prompt at that cursor position.

### Change

- Rename `restoreCursor` → `restoreTerminal` to reflect its expanded responsibility.
- Append `\n` alongside the cursor-show escape so the shell always receives the prompt on a clean new line.
- Add `tests/test_ui/test_tui_exit_sequence.py` with two regression tests that read the TypeScript source and assert the newline is present and that all three signal handlers (`exit`, `SIGINT`, `SIGTERM`) are registered.
- Add an entry to `CHANGELOG.md` under `[Unreleased] Fixed`.

## Validation

- [x] `uv run ruff check src tests scripts` — passes
- [x] `uv run pytest -q` — all tests pass (2 new tests added)
- [x] `cd frontend/terminal && npx tsc --noEmit` — passes

## Notes

- Related issue: #132
- No behaviour change other than the added newline on exit.