### PR TITLE
fix(tools): todo_write updates existing items in-place instead of duplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- `todo_write` tool now updates an existing unchecked item in-place when `checked=True` instead of appending a duplicate `[x]` line.
+
 - React TUI spinner now stays visible throughout the entire agent turn: `assistant_complete` no longer resets `busy` state prematurely, and `tool_started` explicitly sets `busy=true` so the status bar remains active even when tool calls follow an assistant message. `line_complete` is the sole signal that ends the turn and clears the spinner.
 - Skill loader now uses `yaml.safe_load` to parse SKILL.md frontmatter, correctly handling YAML block scalars (`>`, `|`), quoted values, and other standard YAML constructs instead of naive line-by-line splitting.
 - `BackendHostConfig` was missing the `cwd` field, causing `AttributeError: 'BackendHostConfig' object has no attribute 'cwd'` on startup when `oh` was run after the runtime refactor that added `cwd` support to `build_runtime`.

--- a/src/openharness/tools/todo_write_tool.py
+++ b/src/openharness/tools/todo_write_tool.py
@@ -18,16 +18,29 @@ class TodoWriteToolInput(BaseModel):
 
 
 class TodoWriteTool(BaseTool):
-    """Append an item to a TODO markdown file."""
+    """Add or update an item in a TODO markdown file."""
 
     name = "todo_write"
-    description = "Append a TODO item to a markdown checklist file."
+    description = "Add or update a TODO item in a markdown checklist file. If the item already exists as unchecked and checked=True, it will be marked done in-place rather than appended."
     input_model = TodoWriteToolInput
 
     async def execute(self, arguments: TodoWriteToolInput, context: ToolExecutionContext) -> ToolResult:
         path = Path(context.cwd) / arguments.path
-        prefix = "- [x]" if arguments.checked else "- [ ]"
         existing = path.read_text(encoding="utf-8") if path.exists() else "# TODO\n"
-        updated = existing.rstrip() + f"\n{prefix} {arguments.item}\n"
+
+        unchecked_line = f"- [ ] {arguments.item}"
+        checked_line = f"- [x] {arguments.item}"
+        target_line = checked_line if arguments.checked else unchecked_line
+
+        if unchecked_line in existing and arguments.checked:
+            # Mark existing unchecked item as done (in-place update)
+            updated = existing.replace(unchecked_line, checked_line, 1)
+        elif target_line in existing:
+            # Item already in desired state — no-op
+            return ToolResult(output=f"No change needed in {path}")
+        else:
+            # New item — append
+            updated = existing.rstrip() + f"\n{target_line}\n"
+
         path.write_text(updated, encoding="utf-8")
         return ToolResult(output=f"Updated {path}")

--- a/src/openharness/tools/todo_write_tool.py
+++ b/src/openharness/tools/todo_write_tool.py
@@ -21,7 +21,7 @@ class TodoWriteTool(BaseTool):
     """Add or update an item in a TODO markdown file."""
 
     name = "todo_write"
-    description = "Add or update a TODO item in a markdown checklist file. If the item already exists as unchecked and checked=True, it will be marked done in-place rather than appended."
+    description = "Add a new TODO item or mark an existing one as done in a markdown checklist file."
     input_model = TodoWriteToolInput
 
     async def execute(self, arguments: TodoWriteToolInput, context: ToolExecutionContext) -> ToolResult:

--- a/tests/test_tools/test_core_tools.py
+++ b/tests/test_tools/test_core_tools.py
@@ -136,6 +136,30 @@ async def test_skill_todo_and_config_tools(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_todo_write_upsert(tmp_path: Path):
+    tool = TodoWriteTool()
+    ctx = ToolExecutionContext(cwd=tmp_path)
+
+    await tool.execute(TodoWriteToolInput(item="task A"), ctx)
+    await tool.execute(TodoWriteToolInput(item="task B"), ctx)
+
+    # Marking done should update in-place, not append a duplicate
+    result = await tool.execute(TodoWriteToolInput(item="task A", checked=True), ctx)
+    assert result.is_error is False
+
+    content = (tmp_path / "TODO.md").read_text(encoding="utf-8")
+    assert content.count("task A") == 1
+    assert "- [x] task A" in content
+    assert "- [ ] task A" not in content
+    assert "- [ ] task B" in content
+
+    # Calling again with same state is a no-op
+    noop = await tool.execute(TodoWriteToolInput(item="task A", checked=True), ctx)
+    assert "No change" in noop.output
+    assert (tmp_path / "TODO.md").read_text(encoding="utf-8").count("task A") == 1
+
+
+@pytest.mark.asyncio
 async def test_notebook_edit_tool(tmp_path: Path):
     result = await NotebookEditTool().execute(
         NotebookEditToolInput(path="demo.ipynb", cell_index=0, new_source="print('nb ok')\n"),


### PR DESCRIPTION
Closes #134

## What changed

`TodoWriteTool.execute` now does an upsert instead of always appending:

- `[ ] item` + `checked=True` → replaces the line with `[x] item`
- Item already in target state → no-op (returns `No change needed`)
- New item → appends as before

## How to verify

```
uv run pytest tests/test_tools/test_core_tools.py -q -k todo
```