### PR TITLE
fix(engine): keep parallel tool turns alive when one tool raises

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -545,8 +545,28 @@ async def run_query(
             async def _run(tc):
                 return await _execute_tool_call(context, tc.name, tc.id, tc.input)
 
-            results = await asyncio.gather(*[_run(tc) for tc in tool_calls])
-            tool_results = list(results)
+            # Use return_exceptions=True so a single failing tool does not abandon
+            # its siblings as cancelled coroutines and leave the conversation with
+            # un-replied tool_use blocks (Anthropic's API rejects the next request
+            # on the session if any tool_use is missing a matching tool_result).
+            raw_results = await asyncio.gather(
+                *[_run(tc) for tc in tool_calls], return_exceptions=True
+            )
+            tool_results = []
+            for tc, result in zip(tool_calls, raw_results):
+                if isinstance(result, BaseException):
+                    log.exception(
+                        "tool execution raised: name=%s id=%s",
+                        tc.name,
+                        tc.id,
+                        exc_info=result,
+                    )
+                    result = ToolResultBlock(
+                        tool_use_id=tc.id,
+                        content=f"Tool {tc.name} failed: {type(result).__name__}: {result}",
+                        is_error=True,
+                    )
+                tool_results.append(result)
 
             for tc, result in zip(tool_calls, tool_results):
                 yield ToolExecutionCompleted(

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -24,9 +24,11 @@ from openharness.engine.stream_events import (
 )
 from openharness.permissions import PermissionChecker, PermissionMode
 from openharness.tools import create_default_tool_registry
-from openharness.tools.base import ToolRegistry, ToolResult
+from openharness.tools.base import BaseTool, ToolExecutionContext, ToolRegistry, ToolResult
 from openharness.tools.glob_tool import GlobTool
 from openharness.tools.grep_tool import GrepTool
+from pydantic import BaseModel
+from openharness.engine.messages import ToolResultBlock
 from openharness.hooks import HookExecutionContext, HookExecutor, HookEvent
 from openharness.hooks.loader import HookRegistry
 from openharness.hooks.schemas import PromptHookDefinition
@@ -820,3 +822,99 @@ async def test_query_engine_applies_path_rules_to_write_file_targets_in_full_aut
     assert tool_results[0].is_error is True
     assert "matches deny rule" in tool_results[0].output
     assert target.exists() is False
+
+
+class _OkInput(BaseModel):
+    pass
+
+
+class _OkTool(BaseTool):
+    name = "ok_tool"
+    description = "Returns success."
+    input_model = _OkInput
+
+    def is_read_only(self, arguments: BaseModel) -> bool:
+        return True
+
+    async def execute(self, arguments: BaseModel, context: ToolExecutionContext) -> ToolResult:
+        del arguments, context
+        return ToolResult(output="ok")
+
+
+class _BoomTool(BaseTool):
+    name = "boom_tool"
+    description = "Always raises."
+    input_model = _OkInput
+
+    def is_read_only(self, arguments: BaseModel) -> bool:
+        return True
+
+    async def execute(self, arguments: BaseModel, context: ToolExecutionContext) -> ToolResult:
+        del arguments, context
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_query_engine_synthesizes_tool_result_when_parallel_tool_raises(tmp_path: Path):
+    """Parallel tool calls must each yield a tool_result even when one tool raises.
+
+    Regression for the case where ``asyncio.gather`` (without
+    ``return_exceptions=True``) propagated the first exception, abandoned the
+    sibling coroutines, and left the conversation with un-replied ``tool_use``
+    blocks — Anthropic's API then rejects the next request on the session.
+    """
+
+    registry = ToolRegistry()
+    registry.register(_OkTool())
+    registry.register(_BoomTool())
+
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            TextBlock(text="Running two tools."),
+                            ToolUseBlock(id="toolu_ok", name="ok_tool", input={}),
+                            ToolUseBlock(id="toolu_boom", name="boom_tool", input={}),
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="Recovered from the failure.")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=registry,
+        permission_checker=PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO)),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+    )
+
+    events = [event async for event in engine.submit_message("run both tools")]
+
+    completed = [event for event in events if isinstance(event, ToolExecutionCompleted)]
+    completed_by_name = {event.tool_name: event for event in completed}
+    assert set(completed_by_name) == {"ok_tool", "boom_tool"}
+    assert completed_by_name["ok_tool"].is_error is False
+    assert completed_by_name["ok_tool"].output == "ok"
+    assert completed_by_name["boom_tool"].is_error is True
+    assert "RuntimeError" in completed_by_name["boom_tool"].output
+    assert "boom" in completed_by_name["boom_tool"].output
+
+    user_tool_messages = [
+        msg for msg in engine.messages if msg.role == "user" and any(isinstance(block, ToolResultBlock) for block in msg.content)
+    ]
+    assert len(user_tool_messages) == 1
+    result_blocks = [block for block in user_tool_messages[0].content if isinstance(block, ToolResultBlock)]
+    assert {block.tool_use_id for block in result_blocks} == {"toolu_ok", "toolu_boom"}
+
+    assert isinstance(events[-1], AssistantTurnComplete)
+    assert events[-1].message.text == "Recovered from the failure."


### PR DESCRIPTION
Closes #137.

## Summary

`asyncio.gather` for parallel tool calls in `engine/query.py:548` was called without `return_exceptions=True`. A single unhandled exception from any tool propagated out of the gather, abandoned its sibling coroutines, and exited the loop before any `tool_result` blocks were appended to the conversation. The next API request on the session was then rejected with `tool_use ids were found without tool_result blocks` — i.e. the session was effectively bricked by one bad tool exception during a multi-tool turn. See #137 for two reproduction scenarios and the user-facing error.

## Change

- `src/openharness/engine/query.py` — pass `return_exceptions=True` to the parallel `asyncio.gather`. For each raised exception, synthesize a `ToolResultBlock(tool_use_id=tc.id, is_error=True, content="Tool {name} failed: {ExcType}: {msg}")` matched to the originating `tool_use_id`, and `log.exception` the failure so it is still observable in debug logs. Per-tool error events are still emitted via `ToolExecutionCompleted(is_error=True, ...)`.

The single-tool branch (`len(tool_calls) == 1`) is unchanged — it already `await`s sequentially and any exception is handled by `_execute_tool_call`'s outer machinery on the model retry/loop.

## Tests

Added `test_query_engine_synthesizes_tool_result_when_parallel_tool_raises` in `tests/test_engine/test_query_engine.py` covering the regression: two parallel tool calls in one assistant message, one tool raises `RuntimeError`, the test asserts:

- both `tool_use` ids receive a matching `ToolResultBlock` in the appended user message
- the failing tool's `ToolExecutionCompleted` event has `is_error=True` with the exception type and message in `output`
- the sibling tool's result is preserved
- the next assistant turn completes normally (the loop continues instead of exiting)

## Validation

- `uv run ruff check src tests scripts` → clean
- `uv run pytest -q` → 678 passed, 6 skipped, 1 xfailed (full suite)
- Per CONTRIBUTING.md: no CHANGELOG entry intentionally — left for maintainer discretion on this internal-reliability fix; happy to add one on request.

## Test plan

- [x] Regression test added and passing
- [x] Full pytest suite green
- [x] Ruff clean
- [x] No frontend or unrelated files touched
