### PR TITLE
fix(settings): Add Ollama Support and prevent env overrides from clobbering provider profile…

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,44 @@ oh provider add my-endpoint \
 
 For custom compatible endpoints, OpenHarness can bind credentials per profile instead of forcing every Anthropic-compatible or OpenAI-compatible backend to share the same API key.
 
+### Ollama (Local Models)
+
+Run local models through Ollama's OpenAI-compatible endpoint:
+
+```bash
+# Add an Ollama provider profile
+oh provider add ollama \
+  --label "Ollama" \
+  --provider Ollama \
+  --api-format openai \
+  --auth-source openai_api_key \
+  --model glm-4.7-flash:q8_0 \
+  --base-url http://localhost:11434/v1
+```
+```
+Saved provider profile: ollama
+```
+
+```bash
+# Activate and verify
+oh provider use ollama
+```
+```
+Activated provider profile: ollama
+```
+
+```bash
+oh provider list
+```
+```
+  claude-api: Anthropic-Compatible API [ready]
+  ...
+  moonshot: Moonshot (Kimi) [missing auth]
+    auth=moonshot_api_key model=kimi-k2.5 base_url=https://api.moonshot.cn/v1
+* ollama: Ollama [ready]
+    auth=openai_api_key model=glm-4.7-flash:q8_0 base_url=http://localhost:11434/v1
+```
+
 ### GitHub Copilot Format (`--api-format copilot`)
 
 Use your existing GitHub Copilot subscription as the LLM backend. Authentication uses GitHub's OAuth device flow — no API keys needed.

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -740,21 +740,38 @@ class Settings(BaseModel):
 
 
 def _apply_env_overrides(settings: Settings) -> Settings:
-    """Apply supported environment variable overrides over loaded settings."""
-    updates: dict[str, Any] = {}
-    model = os.environ.get("ANTHROPIC_MODEL") or os.environ.get("OPENHARNESS_MODEL")
-    if model:
-        # Strip ANSI escape sequences that may be present if the environment
-        # variable was set with terminal formatting (e.g., bold text)
-        updates["model"] = strip_ansi_escape_sequences(model)
+    """Apply supported environment variable overrides over loaded settings.
 
-    base_url = (
-        os.environ.get("ANTHROPIC_BASE_URL")
-        or os.environ.get("OPENAI_BASE_URL")
-        or os.environ.get("OPENHARNESS_BASE_URL")
-    )
-    if base_url:
-        updates["base_url"] = base_url
+    Provider-scoped env vars (``ANTHROPIC_BASE_URL``, ``ANTHROPIC_MODEL``,
+    ``OPENAI_BASE_URL``) only apply when the active profile does *not*
+    explicitly configure the corresponding field.  ``OPENHARNESS_*`` env vars
+    always override (explicit user intent).
+    """
+    updates: dict[str, Any] = {}
+
+    # Resolve the active profile to check for explicit settings.
+    _, active_profile = settings.resolve_profile()
+    profile_has_base_url = active_profile.base_url is not None
+    profile_explicit_model = (active_profile.last_model or "").strip()
+    profile_has_explicit_model = bool(profile_explicit_model) and profile_explicit_model.lower() not in {"", "default"}
+
+    # --- model ---
+    openharness_model = os.environ.get("OPENHARNESS_MODEL")
+    if openharness_model:
+        updates["model"] = strip_ansi_escape_sequences(openharness_model)
+    elif not profile_has_explicit_model:
+        anthropic_model = os.environ.get("ANTHROPIC_MODEL")
+        if anthropic_model:
+            updates["model"] = strip_ansi_escape_sequences(anthropic_model)
+
+    # --- base_url ---
+    openharness_base = os.environ.get("OPENHARNESS_BASE_URL")
+    if openharness_base:
+        updates["base_url"] = openharness_base
+    elif not profile_has_base_url:
+        generic_base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
+        if generic_base:
+            updates["base_url"] = generic_base
 
     max_tokens = os.environ.get("OPENHARNESS_MAX_TOKENS")
     if max_tokens:


### PR DESCRIPTION
… base_url and model

ANTHROPIC_BASE_URL and ANTHROPIC_MODEL were applied unconditionally after profile materialization, replacing explicit profile settings like Ollama's base_url with unrelated endpoints. Now OPENHARNESS_* env vars always override, while ANTHROPIC_*/OPENAI_* vars only apply when the active profile doesn't explicitly configure the corresponding field.

Also adds Ollama setup instructions to README.

## Summary

- What problem does this PR solve?
- What changed?

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q`
- [x] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue:
- Follow-up work:
