### PR TITLE
feat: add MiniMax as a first-class provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- Built-in `minimax` provider profile so `oh setup` offers MiniMax as a first-class provider choice, with `MINIMAX_API_KEY` auth source, `MiniMax-M2.7` as the default model, and `MiniMax-M2.7-highspeed` in the model picker.
 - Docker as an alternative sandbox backend (`sandbox.backend = "docker"`) for stronger execution isolation with configurable resource limits, network isolation, and automatic image management.
 - Built-in `gemini` provider profile so `oh setup` offers Google Gemini as a first-class provider choice, with `gemini_api_key` auth source and `gemini-2.5-flash` as the default model.
 - `diagnose` skill: trace agent run failures and regressions using structured evidence from run artifacts.

--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -36,6 +36,7 @@ _KNOWN_PROVIDERS = [
     "vertex",
     "moonshot",
     "gemini",
+    "minimax",
 ]
 
 _AUTH_SOURCES = [
@@ -49,6 +50,7 @@ _AUTH_SOURCES = [
     "vertex_api_key",
     "moonshot_api_key",
     "gemini_api_key",
+    "minimax_api_key",
 ]
 
 _PROFILE_BY_PROVIDER = {
@@ -59,6 +61,7 @@ _PROFILE_BY_PROVIDER = {
     "copilot": "copilot",
     "moonshot": "moonshot",
     "gemini": "gemini",
+    "minimax": "minimax",
 }
 
 
@@ -239,6 +242,14 @@ class AuthManager:
                     configured = True
                     source = "env"
                 elif load_credential("moonshot", "api_key"):
+                    configured = True
+                    source = "file"
+
+            elif provider == "minimax":
+                if os.environ.get("MINIMAX_API_KEY"):
+                    configured = True
+                    source = "env"
+                elif load_credential("minimax", "api_key"):
                     configured = True
                     source = "file"
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -272,6 +272,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "vertex": "Google Vertex AI",
     "moonshot": "Moonshot (Kimi)",
     "gemini": "Google Gemini",
+    "minimax": "MiniMax",
 }
 
 _AUTH_SOURCE_LABELS: dict[str, str] = {
@@ -285,6 +286,7 @@ _AUTH_SOURCE_LABELS: dict[str, str] = {
     "vertex_api_key": "Vertex credentials",
     "moonshot_api_key": "Moonshot API key",
     "gemini_api_key": "Gemini API key",
+    "minimax_api_key": "MiniMax API key",
 }
 
 
@@ -576,7 +578,7 @@ def _specialize_setup_target(manager, target: str) -> str:
         defaults = {
             "kimi-anthropic": ("Kimi (Anthropic-compatible)", "https://api.moonshot.cn/anthropic", "kimi-k2.5"),
             "glm-anthropic": ("GLM (Anthropic-compatible)", "", "glm-4.5"),
-            "minimax-anthropic": ("MiniMax (Anthropic-compatible)", "", "minimax-m1"),
+            "minimax-anthropic": ("MiniMax (Anthropic-compatible)", "", "MiniMax-M2.7"),
         }
         label, suggested_base_url, suggested_model = defaults[choice]
         base_url = _text_prompt("Base URL", default=suggested_base_url).strip()
@@ -726,7 +728,7 @@ def _login_provider(provider: str) -> None:
         _bind_external_provider(provider)
         return
 
-    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini"):
+    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini", "minimax"):
         label = _PROVIDER_LABELS.get(provider, provider)
         flow = ApiKeyFlow(provider=provider, prompt_text=f"Enter your {label} API key")
         try:
@@ -808,7 +810,7 @@ def auth_login(
     """Interactively authenticate with a provider.
 
     Run without arguments to choose a provider from a menu.
-    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot.
+    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot, minimax.
     """
     if provider is None:
         print("Select a provider to authenticate:", flush=True)

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -232,6 +232,14 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             default_model="gemini-2.5-flash",
             base_url="https://generativelanguage.googleapis.com/v1beta/openai",
         ),
+        "minimax": ProviderProfile(
+            label="MiniMax",
+            provider="minimax",
+            api_format="openai",
+            auth_source="minimax_api_key",
+            default_model="MiniMax-M2.7",
+            base_url="https://api.minimax.io/v1",
+        ),
     }
 
 
@@ -319,6 +327,7 @@ def auth_source_provider_name(auth_source: str) -> str:
         "vertex_api_key": "vertex",
         "moonshot_api_key": "moonshot",
         "gemini_api_key": "gemini",
+        "minimax_api_key": "minimax",
     }
     return mapping.get(auth_source, auth_source)
 
@@ -358,6 +367,8 @@ def default_auth_source_for_provider(provider: str, api_format: str | None = Non
         return "moonshot_api_key"
     if provider == "gemini":
         return "gemini_api_key"
+    if provider == "minimax":
+        return "minimax_api_key"
     if provider == "openai" or api_format == "openai":
         return "openai_api_key"
     return "anthropic_api_key"
@@ -674,6 +685,7 @@ class Settings(BaseModel):
             "openai_api_key": "OPENAI_API_KEY",
             "dashscope_api_key": "DASHSCOPE_API_KEY",
             "moonshot_api_key": "MOONSHOT_API_KEY",
+            "minimax_api_key": "MINIMAX_API_KEY",
         }.get(auth_source)
         if env_var:
             env_value = os.environ.get(env_var, "")

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -657,6 +657,13 @@ class ReactBackendHost:
                     ("gemini-2.5-flash", "Gemini Flash"),
                 ]
             )
+        elif provider_name == "minimax":
+            families.extend(
+                [
+                    ("MiniMax-M2.7", "MiniMax flagship"),
+                    ("MiniMax-M2.7-highspeed", "MiniMax fast"),
+                ]
+            )
 
         seen: set[str] = set()
         options: list[dict[str, object]] = []

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -529,3 +529,67 @@ class TestAnsiEscapeSequences:
         s = Settings()
         updated = s.merge_cli_overrides(model="\x1b[1mclaude-opus-4-6\x1b[0m")
         assert updated.model == "claude-opus-4-6"
+
+
+class TestMiniMaxProvider:
+    """Tests for MiniMax provider profile and auth integration."""
+
+    def test_minimax_in_default_provider_profiles(self):
+        from openharness.config.settings import default_provider_profiles
+
+        profiles = default_provider_profiles()
+        assert "minimax" in profiles
+        profile = profiles["minimax"]
+        assert profile.provider == "minimax"
+        assert profile.api_format == "openai"
+        assert profile.auth_source == "minimax_api_key"
+        assert profile.default_model == "MiniMax-M2.7"
+        assert profile.base_url == "https://api.minimax.io/v1"
+
+    def test_auth_source_provider_name_minimax(self):
+        from openharness.config.settings import auth_source_provider_name
+
+        assert auth_source_provider_name("minimax_api_key") == "minimax"
+
+    def test_default_auth_source_for_minimax_provider(self):
+        from openharness.config.settings import default_auth_source_for_provider
+
+        assert default_auth_source_for_provider("minimax") == "minimax_api_key"
+
+    def test_resolve_auth_reads_minimax_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "minimax-test-key")
+        settings = Settings(
+            active_profile="minimax",
+            profiles={
+                "minimax": ProviderProfile(
+                    label="MiniMax",
+                    provider="minimax",
+                    api_format="openai",
+                    auth_source="minimax_api_key",
+                    default_model="MiniMax-M2.7",
+                    base_url="https://api.minimax.io/v1",
+                )
+            },
+        )
+        resolved = settings.resolve_auth()
+        assert resolved.value == "minimax-test-key"
+        assert "MINIMAX_API_KEY" in resolved.source
+
+    def test_minimax_profile_materializes_default_model(self):
+        settings = Settings(
+            active_profile="minimax",
+            profiles={
+                "minimax": ProviderProfile(
+                    label="MiniMax",
+                    provider="minimax",
+                    api_format="openai",
+                    auth_source="minimax_api_key",
+                    default_model="MiniMax-M2.7",
+                    base_url="https://api.minimax.io/v1",
+                )
+            },
+        )
+        materialized = settings.materialize_active_profile()
+        assert materialized.model == "MiniMax-M2.7"
+        assert materialized.provider == "minimax"
+        assert materialized.api_format == "openai"


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a first-class provider in OpenHarness, giving it the same treatment as Moonshot and Gemini.

### Changes

**`src/openharness/config/settings.py`**
- Add built-in `minimax` entry to `default_provider_profiles()` with `MiniMax-M2.7` as the default model and `https://api.minimax.io/v1` as the base URL
- Add `minimax_api_key` → `minimax` mapping to `auth_source_provider_name()`
- Add `minimax` case to `default_auth_source_for_provider()` returning `minimax_api_key`
- Add `MINIMAX_API_KEY` env-var lookup to `resolve_auth()`

**`src/openharness/auth/manager.py`**
- Add `minimax` to `_KNOWN_PROVIDERS`, `_AUTH_SOURCES`, `_PROFILE_BY_PROVIDER`
- Add `elif provider == "minimax"` branch to auth-status check (reads `MINIMAX_API_KEY` env var or stored credential)

**`src/openharness/cli.py`**
- Add `"minimax": "MiniMax"` to `_PROVIDER_LABELS`
- Add `"minimax_api_key": "MiniMax API key"` to `_AUTH_SOURCE_LABELS`
- Add `minimax` to the `oh auth login` API-key provider set
- Fix the `minimax-anthropic` interactive flow's suggested model from `minimax-m1` → `MiniMax-M2.7`
- Update `oh auth login` docstring

**`src/openharness/ui/backend_host.py`**
- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to the model-picker suggestion list when the active provider is `minimax`

**`tests/test_config/test_settings.py`**
- Add `TestMiniMaxProvider` covering: profile presence, auth-source mapping, `default_auth_source_for_provider`, env-var resolution via `MINIMAX_API_KEY`, and profile materialisation

**`CHANGELOG.md`**
- Add entry under `[Unreleased]`

### How to use

```bash
oh auth login minimax   # enter MINIMAX_API_KEY
oh setup minimax        # select model (MiniMax-M2.7 or MiniMax-M2.7-highspeed)
oh                      # start a session
```

Or set the environment variable directly:

```bash
export MINIMAX_API_KEY=your-key
oh --provider minimax --model MiniMax-M2.7
```

### API reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

### Verification

```
uv run pytest tests/test_config/test_settings.py -k minimax -v
# 5 passed in 2.08s
```