### PR TITLE
fix(installer): detect installed launcher instead of hard-coding openh

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -260,25 +260,46 @@ Write-Step "Verifying installation"
 
 $OhPath = "$VenvBinDir\oh.exe"
 $OpenhPath = "$VenvBinDir\openh.exe"
+$OpenharnessPath = "$VenvBinDir\openharness.exe"
 $OhmoPath = "$VenvBinDir\ohmo.exe"
 
-if ((Test-Path $OpenhPath) -and (Test-Path $OhmoPath)) {
-    $OhVersion = & $OpenhPath --version 2>&1
+# Pick the best available launcher. The 'openh' alias was added after v0.1.6,
+# so PyPI installs of older releases won't have openh.exe. Prefer it when
+# present, otherwise fall back to 'openharness', then 'oh' (which collides
+# with PowerShell's Out-Host alias unless invoked as oh.exe).
+$Launcher = $null
+$LauncherExe = $null
+if (Test-Path $OpenhPath) {
+    $Launcher = "openh"
+    $LauncherExe = $OpenhPath
+} elseif (Test-Path $OpenharnessPath) {
+    $Launcher = "openharness"
+    $LauncherExe = $OpenharnessPath
+} elseif (Test-Path $OhPath) {
+    $Launcher = "oh"
+    $LauncherExe = $OhPath
+}
+
+if ($LauncherExe -and (Test-Path $OhmoPath)) {
+    $OhVersion = & $LauncherExe --version 2>&1
     Write-Success "Installation successful!"
     Write-Host ""
-    Write-Host "  openh is ready: $OhVersion" -ForegroundColor Green
-    if (Test-Path $OhPath) {
-        Write-Host "  oh is also installed, but PowerShell may resolve 'oh' to Out-Host first." -ForegroundColor Yellow
+    Write-Host "  $Launcher is ready: $OhVersion" -ForegroundColor Green
+    if ($Launcher -eq "oh") {
+        Write-Host "  Note: 'oh' collides with PowerShell's built-in Out-Host alias." -ForegroundColor Yellow
+        Write-Host "        Invoke it as 'oh.exe', or use 'openharness' instead." -ForegroundColor Yellow
+    } elseif (Test-Path $OhPath) {
+        Write-Host "  'oh' is also installed, but PowerShell may resolve it to Out-Host first." -ForegroundColor Yellow
     }
     Write-Host "  ohmo is ready" -ForegroundColor Green
 } else {
     # Try module execution
     $ModuleVersion = python -m openharness --version 2>&1
     if ($ModuleVersion) {
-        Write-Warn "'openh'/'ohmo' commands not yet available. Run via: python -m openharness"
+        Write-Warn "Launcher commands not yet available on PATH. Run via: python -m openharness"
         Write-Host "  Version: $ModuleVersion"
     } else {
-        Write-Warn "Could not verify 'openh'/'ohmo' commands. The package may need a PATH update."
+        Write-Warn "Could not verify launcher commands. The package may need a PATH update."
         Write-Host "  Try: python -m openharness --version"
     }
 }
@@ -293,8 +314,16 @@ Write-Host "  Next steps:"
 Write-Host "    1. Restart terminal, or run: refreshenv (if using Chocolatey)"
 Write-Host "       Or manually refresh: `$env:PATH = [System.Environment]::GetEnvironmentVariable('PATH','User')"
 Write-Host "    2. Set your API key:        `$env:ANTHROPIC_API_KEY = 'your_key'"
-Write-Host "    3. Launch (PowerShell):     openh"
+if ($Launcher -eq "openharness") {
+    Write-Host "    3. Launch (PowerShell):     openharness"
+    Write-Host "       ('openh' is not available on this release; 'oh' collides with PowerShell's Out-Host alias.)"
+} elseif ($Launcher -eq "oh") {
+    Write-Host "    3. Launch (PowerShell):     oh.exe"
+    Write-Host "       ('oh' alone collides with PowerShell's Out-Host alias — use 'oh.exe' or 'openharness'.)"
+} else {
+    Write-Host "    3. Launch (PowerShell):     openh"
+    Write-Host "       Note: 'oh' may collide with the built-in Out-Host alias in PowerShell."
+}
 Write-Host "    4. Launch ohmo:             ohmo"
-Write-Host "       Note: 'oh' may collide with the built-in Out-Host alias in PowerShell."
 Write-Host "    5. Docs:                    https://github.com/HKUDS/OpenHarness"
 Write-Host ""

--- a/tests/test_install/test_windows_alias.py
+++ b/tests/test_install/test_windows_alias.py
@@ -22,3 +22,20 @@ def test_powershell_installer_recommends_openh_for_windows():
     assert "openh.exe" in script
     assert "Launch (PowerShell):     openh" in script
     assert "Out-Host" in script
+
+
+def test_powershell_installer_falls_back_when_openh_exe_missing():
+    """Older PyPI releases don't ship an `openh` console script.
+
+    When `openh.exe` is absent from the venv, the installer must still pick a
+    working launcher (`openharness` or `oh.exe`) and guide the user to it
+    rather than telling them to run a binary that doesn't exist (issue #144).
+    """
+    script = Path("scripts/install.ps1").read_text(encoding="utf-8")
+    # Every launcher produced by the pyproject `[project.scripts]` table is
+    # probed during verification.
+    assert "openharness.exe" in script
+    assert "oh.exe" in script
+    # Fallback guidance for users on a release without the `openh` alias.
+    assert "Launch (PowerShell):     openharness" in script
+    assert "Launch (PowerShell):     oh.exe" in script


### PR DESCRIPTION
Fixes #144.

## Problem

`scripts/install.ps1` assumes `openh.exe` exists in the venv and tells users to launch via `openh`. The `openh` alias was added in [`ce84a6a`](https://github.com/HKUDS/OpenHarness/commit/ce84a6a) — **after** `v0.1.6` was tagged. The published `openharness-ai==0.1.6` wheel only declares `oh`, `ohmo`, `openharness` console scripts (verified against `entry_points.txt`), so `openh.exe` is never created and users hit `The term 'openh' is not recognized` even with PATH correctly set.

## Fix

Detect which launcher the wheel actually produced and adapt verification + "Next steps" accordingly. Preference order:

1. `openh` — no shell collisions; preferred once shipped on PyPI.
2. `openharness` — no collisions, always present.
3. `oh` — collides with PowerShell's `Out-Host` alias unless invoked as `oh.exe`.

| Scenario | Before | After |
|---|---|---|
| PyPI `v0.1.6` (no `openh.exe`) | Banner says "Launch: openh" → user error | Banner says "Launch: openharness" |
| `-FromSource` / future PyPI with `openh` | Works | Works (unchanged) |
| Only `oh.exe` present | Misleading | Recommends `oh.exe` with Out-Host caveat |

The Out-Host guidance is preserved in every branch. No library code touched.

## Files

- `scripts/install.ps1` — launcher detection in verification + "Next steps".
- `tests/test_install/test_windows_alias.py` — new regression test covering fallback guidance. Existing `test_powershell_installer_recommends_openh_for_windows` still passes (the `openh` literal stays in the default branch).

## Test plan

- [x] `uv run ruff check src tests scripts` — clean
- [x] `uv run pytest -q` — 688 passed (same baseline as `main`)
- [x] Manual verification on Windows against PyPI `v0.1.6` — confirmed in [follow-up comment](https://github.com/HKUDS/OpenHarness/pull/145#issuecomment-4247436444).

No `CHANGELOG.md` entry in this PR; happy to add one if maintainers prefer it bundled here.
