### PR TITLE
fix(runtime): resolve profile base_url and support openai_compat format

### DIFF
--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -116,6 +116,8 @@ class RuntimeBundle:
 
 def _resolve_api_client_from_settings(settings) -> SupportsStreamingMessages:
     """Build the appropriate API client for the resolved settings."""
+    # Ensure profile fields (base_url, model, api_format) are projected to settings
+    settings = settings.materialize_active_profile()
 
     def _safe_resolve_auth():
         try:
@@ -151,7 +153,7 @@ def _resolve_api_client_from_settings(settings) -> SupportsStreamingMessages:
             claude_oauth=True,
             auth_token_resolver=lambda: settings.resolve_auth().value,
         )
-    if settings.api_format == "openai":
+    if settings.api_format in ("openai", "openai_compat"):
         auth = _safe_resolve_auth()
         return OpenAICompatibleClient(
             api_key=auth.value,


### PR DESCRIPTION

## Problem

Two bugs prevented custom OpenAI-compatible provider profiles from working correctly:

1. **Profile `base_url` not applied**: The global `settings.base_url` (often empty or stale) was used directly instead of the profile's configured `base_url`. This caused custom providers to connect to wrong endpoints.

2. **`openai_compat` format treated as Anthropic**: The condition only checked for `api_format == "openai"`, missing `"openai_compat"` which is used by custom provider profiles created via `oh provider add`. Requests were sent via `AnthropicApiClient` with wrong path (`/v1/v1/messages`).

## Fix

- Call `materialize_active_profile()` to project profile fields onto settings
- Update condition to handle both `"openai"` and `"openai_compat"` formats

## Testing

Verified with custom provider `packycode`:
```
oh provider add packycode --label "My Custom API" --provider openai --api-format openai_compat --auth-source openai_api_key --model gpt-5.4 --base-url https://www.packyapi.com/v1
oh provider use packycode
oh -p "Hello"
# Output: OK ✓
```

Fixes custom OpenAI-compatible provider profiles (#issue)
```

