### PR TITLE
[codex] fix agent spawn overrides and task cleanup

### DIFF
--- a/src/openharness/swarm/subprocess_backend.py
+++ b/src/openharness/swarm/subprocess_backend.py
@@ -58,15 +58,21 @@ class SubprocessBackend:
         )
         extra_env = build_inherited_env_vars()
 
-        # Build environment export prefix for shell invocation
-        env_prefix = " ".join(f"{k}={v!r}" for k, v in extra_env.items())
+        command = config.command
+        if command is None:
+            # Build environment export prefix for shell invocation
+            env_prefix = " ".join(f"{k}={v!r}" for k, v in extra_env.items())
 
-        teammate_cmd = get_teammate_command()
-        if teammate_cmd.endswith("python") or teammate_cmd.endswith("python3") or "/python" in teammate_cmd:
-            cmd_parts = [teammate_cmd, "-m", "openharness", "--task-worker"] + flags
-        else:
-            cmd_parts = [teammate_cmd, "--task-worker"] + flags
-        command = f"{env_prefix} {' '.join(cmd_parts)}" if env_prefix else " ".join(cmd_parts)
+            teammate_cmd = get_teammate_command()
+            if (
+                teammate_cmd.endswith("python")
+                or teammate_cmd.endswith("python3")
+                or "/python" in teammate_cmd
+            ):
+                cmd_parts = [teammate_cmd, "-m", "openharness", "--task-worker"] + flags
+            else:
+                cmd_parts = [teammate_cmd, "--task-worker"] + flags
+            command = f"{env_prefix} {' '.join(cmd_parts)}" if env_prefix else " ".join(cmd_parts)
 
         manager = get_task_manager()
         try:
@@ -74,7 +80,7 @@ class SubprocessBackend:
                 prompt=config.prompt,
                 description=f"Teammate: {agent_id}",
                 cwd=config.cwd,
-                task_type="in_process_teammate",
+                task_type=config.task_type,
                 model=config.model,
                 command=command,
             )

--- a/src/openharness/swarm/types.py
+++ b/src/openharness/swarm/types.py
@@ -276,6 +276,9 @@ class TeammateSpawnConfig:
     model: str | None = None
     """Model override for this teammate."""
 
+    command: str | None = None
+    """Optional explicit command override for subprocess-backed teammates."""
+
     system_prompt: str | None = None
     """System prompt resolved from workflow config."""
 
@@ -305,6 +308,9 @@ class TeammateSpawnConfig:
 
     subscriptions: list[str] = field(default_factory=list)
     """Event topics this teammate subscribes to."""
+
+    task_type: Literal["local_agent", "remote_agent", "in_process_teammate"] = "local_agent"
+    """Background task type recorded for subprocess-backed teammates."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/openharness/tasks/manager.py
+++ b/src/openharness/tasks/manager.py
@@ -139,6 +139,7 @@ class BackgroundTaskManager:
         except asyncio.TimeoutError:
             process.kill()
             await process.wait()
+        await _close_process_stdin(process)
 
         task.status = "killed"
         task.ended_at = time.time()
@@ -176,6 +177,7 @@ class BackgroundTaskManager:
         reader = asyncio.create_task(self._copy_output(task_id, process))
         return_code = await process.wait()
         await reader
+        await _close_process_stdin(process)
 
         current_generation = self._generations.get(task_id)
         if current_generation != generation:
@@ -253,6 +255,52 @@ class BackgroundTaskManager:
         task.return_code = None
         return await self._start_process(task.id)
 
+    def close(self) -> None:
+        """Best-effort cleanup for any tracked subprocesses and watcher tasks."""
+        for waiter in list(self._waiters.values()):
+            waiter.cancel()
+        self._waiters.clear()
+
+        for process in list(self._processes.values()):
+            stdin = process.stdin
+            if stdin is not None and not stdin.is_closing():
+                try:
+                    stdin.close()
+                except RuntimeError:
+                    pass
+            if process.returncode is None:
+                try:
+                    process.kill()
+                except (ProcessLookupError, RuntimeError):
+                    pass
+        self._processes.clear()
+
+    async def aclose(self) -> None:
+        """Asynchronously shut down tracked subprocesses and waiters."""
+        processes = list(self._processes.values())
+        waiters = list(self._waiters.values())
+
+        for process in processes:
+            if process.returncode is None:
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+            await _close_process_stdin(process)
+
+        for process in processes:
+            if process.returncode is None:
+                try:
+                    await process.wait()
+                except ProcessLookupError:
+                    pass
+
+        if waiters:
+            await asyncio.gather(*waiters, return_exceptions=True)
+
+        self._processes.clear()
+        self._waiters.clear()
+
 
 _DEFAULT_MANAGER: BackgroundTaskManager | None = None
 _DEFAULT_MANAGER_KEY: str | None = None
@@ -263,9 +311,29 @@ def get_task_manager() -> BackgroundTaskManager:
     global _DEFAULT_MANAGER, _DEFAULT_MANAGER_KEY
     current_key = str(get_tasks_dir().resolve())
     if _DEFAULT_MANAGER is None or _DEFAULT_MANAGER_KEY != current_key:
+        if _DEFAULT_MANAGER is not None:
+            _DEFAULT_MANAGER.close()
         _DEFAULT_MANAGER = BackgroundTaskManager()
         _DEFAULT_MANAGER_KEY = current_key
     return _DEFAULT_MANAGER
+
+
+def reset_task_manager() -> None:
+    """Reset the singleton task manager, closing tracked subprocesses first."""
+    global _DEFAULT_MANAGER, _DEFAULT_MANAGER_KEY
+    if _DEFAULT_MANAGER is not None:
+        _DEFAULT_MANAGER.close()
+    _DEFAULT_MANAGER = None
+    _DEFAULT_MANAGER_KEY = None
+
+
+async def shutdown_task_manager() -> None:
+    """Async reset that fully reaps tracked subprocesses before clearing state."""
+    global _DEFAULT_MANAGER, _DEFAULT_MANAGER_KEY
+    if _DEFAULT_MANAGER is not None:
+        await _DEFAULT_MANAGER.aclose()
+    _DEFAULT_MANAGER = None
+    _DEFAULT_MANAGER_KEY = None
 
 
 def _task_id(task_type: TaskType) -> str:
@@ -276,3 +344,14 @@ def _task_id(task_type: TaskType) -> str:
         "in_process_teammate": "t",
     }
     return f"{prefixes[task_type]}{uuid4().hex[:8]}"
+
+
+async def _close_process_stdin(process: asyncio.subprocess.Process) -> None:
+    stdin = process.stdin
+    if stdin is None or stdin.is_closing():
+        return
+    stdin.close()
+    try:
+        await stdin.wait_closed()
+    except (BrokenPipeError, ConnectionResetError):
+        pass

--- a/src/openharness/tools/agent_tool.py
+++ b/src/openharness/tools/agent_tool.py
@@ -70,8 +70,10 @@ class AgentTool(BaseTool):
             cwd=str(context.cwd),
             parent_session_id="main",
             model=arguments.model or (agent_def.model if agent_def else None),
+            command=arguments.command,
             system_prompt=agent_def.system_prompt if agent_def else None,
             permissions=agent_def.permissions if agent_def else [],
+            task_type=arguments.mode,
         )
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,13 @@
 """Shared test fixtures."""
+
+from __future__ import annotations
+
+import pytest_asyncio
+
+from openharness.tasks.manager import shutdown_task_manager
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_background_task_manager():
+    yield
+    await shutdown_task_manager()

--- a/tests/test_tools/test_integration_flows.py
+++ b/tests/test_tools/test_integration_flows.py
@@ -3,12 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from pathlib import Path
 
 import pytest
 
+from openharness.tasks.manager import get_task_manager
 from openharness.tools import create_default_tool_registry
 from openharness.tools.base import ToolExecutionContext
+
+
+async def _wait_for_terminal_task(task_id: str, *, timeout_seconds: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    manager = get_task_manager()
+    while asyncio.get_running_loop().time() < deadline:
+        task = manager.get_task(task_id)
+        if task is not None and task.status in {"completed", "failed", "killed"}:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"Task {task_id} did not reach a terminal status in time")
 
 
 @pytest.mark.asyncio
@@ -129,7 +142,6 @@ async def test_skill_and_config_flow_across_registry(tmp_path: Path, monkeypatch
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Flaky timing-dependent test", strict=False)
 async def test_agent_send_message_flow_restarts_completed_agent(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     registry = create_default_tool_registry()
@@ -147,7 +159,9 @@ async def test_agent_send_message_flow_restarts_completed_agent(tmp_path: Path, 
         ),
         context,
     )
-    task_id = create_result.output.split()[-1]
+    match = re.search(r"task_id=(\S+?)[,)]", create_result.output)
+    assert match, create_result.output
+    task_id = match.group(1)
 
     for _ in range(80):
         output = await task_output.execute(task_output.input_model(task_id=task_id), context)
@@ -174,6 +188,7 @@ async def test_agent_send_message_flow_restarts_completed_agent(tmp_path: Path, 
 
     assert "AGENT_ECHO:ready" in output.output
     assert "AGENT_ECHO:agent ping" in output.output
+    await _wait_for_terminal_task(task_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_task_tools.py
+++ b/tests/test_tools/test_task_tools.py
@@ -17,6 +17,17 @@ from openharness.tools.task_update_tool import TaskUpdateTool, TaskUpdateToolInp
 from openharness.tools.team_create_tool import TeamCreateTool, TeamCreateToolInput
 
 
+async def _wait_for_terminal_task(task_id: str, *, timeout_seconds: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    manager = get_task_manager()
+    while asyncio.get_running_loop().time() < deadline:
+        task = manager.get_task(task_id)
+        if task is not None and task.status in {"completed", "failed", "killed"}:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"Task {task_id} did not reach a terminal status in time")
+
+
 @pytest.mark.asyncio
 async def test_task_create_and_output_tool(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
@@ -142,8 +153,9 @@ async def test_agent_tool_uses_subprocess_backend_and_task_is_pollable(
         f"task_id {task_id!r} not found in BackgroundTaskManager — "
         "task tools (TaskGet, TaskOutput, etc.) would have failed"
     )
-    assert record.command is not None
-    assert "--task-worker" in record.command
+    assert record.command == 'python -u -c "import sys; print(sys.stdin.readline().strip())"'
+    assert record.type == "local_agent"
+    await _wait_for_terminal_task(task_id)
 
 
 @pytest.mark.asyncio
@@ -225,5 +237,12 @@ async def test_agent_tool_supports_remote_and_teammate_modes(tmp_path: Path, mon
             context,
         )
         assert result.is_error is False
-        # Output format: "Spawned agent X (task_id=Y, backend=Z)"
-        assert "agent" in result.output.lower() or "task_id" in result.output.lower()
+        import re
+
+        match = re.search(r"task_id=(\S+?)[,)]", result.output)
+        assert match, result.output
+        task_id = match.group(1)
+        record = get_task_manager().get_task(task_id)
+        assert record is not None
+        assert record.type == mode
+        await _wait_for_terminal_task(task_id)


### PR DESCRIPTION
## Summary
- honor explicit `AgentTool(command=...)` overrides when spawning subprocess-backed agents
- preserve requested agent task types for `local_agent`, `remote_agent`, and `in_process_teammate`
- harden task-manager cleanup so short-lived agent subprocesses are reaped cleanly in regression tests

## Why
`AgentTool` exposed a `command` override and `mode` selector, but both were dropped before the subprocess backend called the task manager. In practice that caused custom worker commands to be ignored, unexpectedly triggered real provider auth, and made follow-up `send_message` coverage flaky. The task manager also lacked an async shutdown path for test isolation, which left subprocess transports open at teardown.

## Validation
- `. .venv/bin/activate && pytest -q tests/test_tasks/test_manager.py tests/test_tools/test_task_tools.py tests/test_tools/test_integration_flows.py -W error::pytest.PytestUnraisableExceptionWarning`
- `. .venv/bin/activate && ruff check src tests scripts`
- `. .venv/bin/activate && pytest -q`
  - Fails on this macOS environment in unrelated areas:
    - auth tests reading a real `OPENAI_API_KEY` from the shell
    - bash-tool tests expecting GNU `script -f`, while `/usr/bin/script` on macOS rejects that flag
