### PR TITLE
[security] fix(personalization): stop replaying exported env var values

### DIFF
--- a/src/openharness/personalization/extractor.py
+++ b/src/openharness/personalization/extractor.py
@@ -28,7 +28,7 @@ _FACT_PATTERNS: list[tuple[str, str, re.Pattern]] = [
         r"(https?://\S+/v\d+/?)\b"
     )),
     ("env_var", "Environment variable", re.compile(
-        r"export\s+([A-Z][A-Z0-9_]+=\S+)"
+        r"export\s+([A-Z][A-Z0-9_]+)(?:=\S+)?"
     )),
     ("git_remote", "Git remote", re.compile(
         r"(?:github|gitlab)\.com[:/](\S+?)(?:\.git)?"

--- a/tests/test_personalization/test_extractor.py
+++ b/tests/test_personalization/test_extractor.py
@@ -29,7 +29,14 @@ class TestExtractFacts:
         text = 'export OPENAI_BASE_URL="https://relay.nf.video/v1"'
         facts = extract_facts_from_text(text)
         env_facts = [f for f in facts if f["type"] == "env_var"]
-        assert any("OPENAI_BASE_URL" in f["value"] for f in env_facts)
+        assert env_facts[0]["value"] == "OPENAI_BASE_URL"
+
+    def test_env_var_does_not_capture_secret_value(self):
+        text = "export OPENAI_API_KEY=sk-secret-value"
+        facts = extract_facts_from_text(text)
+        env_facts = [f for f in facts if f["type"] == "env_var"]
+        assert env_facts[0]["value"] == "OPENAI_API_KEY"
+        assert "sk-secret-value" not in env_facts[0]["value"]
 
     def test_extracts_api_endpoint(self):
         text = "curl https://api.minimax.chat/v1/chat/completions"

--- a/tests/test_prompts/test_claudemd.py
+++ b/tests/test_prompts/test_claudemd.py
@@ -9,6 +9,9 @@ from openharness.config.paths import (
     get_project_issue_file,
     get_project_pr_comments_file,
 )
+from openharness.engine.messages import ConversationMessage, TextBlock
+from openharness.personalization import rules as personalization_rules
+from openharness.personalization.session_hook import update_rules_from_session
 from openharness.prompts import build_runtime_system_prompt, discover_claude_md_files, load_claude_md_prompt
 from openharness.config.settings import Settings
 
@@ -116,3 +119,29 @@ def test_build_runtime_system_prompt_skips_coordinator_context_when_disabled(tmp
     assert 'subagent_type="worker"' in prompt
     assert "/agents show TASK_ID" in prompt
     assert "Environment" in prompt
+
+
+def test_build_runtime_system_prompt_does_not_reinject_exported_secret_values(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rules_dir = tmp_path / "local_rules"
+    monkeypatch.setattr(personalization_rules, "_RULES_DIR", rules_dir)
+    monkeypatch.setattr(personalization_rules, "_RULES_FILE", rules_dir / "rules.md")
+    monkeypatch.setattr(personalization_rules, "_FACTS_FILE", rules_dir / "facts.json")
+
+    secret = "sk-test-secret"
+    update_rules_from_session(
+        [
+            ConversationMessage(
+                role="user",
+                content=[TextBlock(text=f"export OPENAI_API_KEY={secret}")],
+            )
+        ]
+    )
+
+    prompt = build_runtime_system_prompt(Settings(), cwd=repo, latest_user_prompt="hello")
+
+    assert "OPENAI_API_KEY" in prompt
+    assert secret not in prompt


### PR DESCRIPTION
Closes #149.

## Summary

This PR narrows personalization env-var extraction so exported environment variables are stored by **name only**, not by raw `NAME=value` payload.

Concretely:
- `export OPENAI_API_KEY=...` is now remembered as `OPENAI_API_KEY`
- raw env-var values are no longer persisted into `local_rules`
- later runtime system prompts no longer replay those raw secret values
- regression tests cover both extraction and prompt assembly

## Why

PR #65 introduced personalization so OpenHarness can remember local environment context such as hosts, paths, and endpoints. That feature direction makes sense.

The problem is that the current implementation also captures full exported values. For secrets, that creates a different class of behavior:
- the value is written to `facts.json`
- the value is rendered into `rules.md`
- the value is replayed into future `build_runtime_system_prompt(...)` output

So a one-off shell snippet like `export OPENAI_API_KEY=...` can become a persistent prompt-side secret disclosure path.

## Root cause

`src/openharness/personalization/extractor.py` currently captures the full `NAME=value` payload for `export ...` patterns.

That makes sense for general parsing, but it is too broad for a personalization feature whose output is persisted and later injected into prompts.

## Change

- update env-var extraction to keep only the variable name
- keep the rest of the personalization flow unchanged
- add a regression test showing the extractor does not retain secret values
- add a prompt-level regression test showing exported secret values are not replayed into the runtime system prompt

## Before / After

### Before
- `export OPENAI_API_KEY=sk-test-secret` -> personalization stores `OPENAI_API_KEY=sk-test-secret`
- later sessions replay `sk-test-secret` via local rules in the system prompt

### After
- `export OPENAI_API_KEY=sk-test-secret` -> personalization stores `OPENAI_API_KEY`
- later sessions can still see that the variable exists, but not the secret value

## Validation

- [x] `PYTHONPATH=src pytest -q tests/test_personalization/test_extractor.py tests/test_prompts/test_claudemd.py`
- [x] `PYTHONPATH=src ruff check src tests`
- [x] targeted regression coverage added for extraction + prompt assembly

## Notes

- I intentionally kept this PR narrow: it fixes the confirmed secret-persistence path without redesigning the whole personalization feature.
- Full `pytest -q` on this local environment is currently blocked by unrelated collection errors caused by a missing optional `pyperclip` dependency; I did not change any of the affected command/UI code paths.
