### PR TITLE
[security] fix(sandbox): fail closed for unsupported Docker domain policies

### DIFF
--- a/src/openharness/sandbox/docker_backend.py
+++ b/src/openharness/sandbox/docker_backend.py
@@ -95,11 +95,16 @@ class DockerSandboxSession:
             self._container_name,
         ]
 
-        # Network isolation
-        if sandbox.network.allowed_domains:
-            argv.extend(["--network", "bridge"])
-        else:
-            argv.extend(["--network", "none"])
+        # Docker backend currently supports only fully disabled networking.
+        # Domain-level allow/deny policies exist for the srt backend, but Docker
+        # does not enforce them yet. Fail closed instead of silently widening
+        # egress to unrestricted bridge networking.
+        if sandbox.network.allowed_domains or sandbox.network.denied_domains:
+            logger.warning(
+                "Docker sandbox does not enforce allowed_domains/denied_domains yet; "
+                "keeping network disabled"
+            )
+        argv.extend(["--network", "none"])
 
         # Resource limits
         if docker_cfg.cpu_limit > 0:

--- a/tests/test_sandbox/test_docker_backend.py
+++ b/tests/test_sandbox/test_docker_backend.py
@@ -134,7 +134,7 @@ def test_network_none_by_default(monkeypatch):
     assert argv[net_idx + 1] == "none"
 
 
-def test_network_bridge_when_domains_allowed(monkeypatch):
+def test_network_none_and_warning_when_domain_policy_is_configured(monkeypatch, caplog):
     monkeypatch.setattr(
         "openharness.sandbox.docker_backend.shutil.which",
         lambda name: "/usr/bin/docker",
@@ -143,7 +143,10 @@ def test_network_bridge_when_domains_allowed(monkeypatch):
         sandbox=SandboxSettings(
             enabled=True,
             backend="docker",
-            network=SandboxNetworkSettings(allowed_domains=["github.com"]),
+            network=SandboxNetworkSettings(
+                allowed_domains=["github.com"],
+                denied_domains=["example.com"],
+            ),
         )
     )
     session = DockerSandboxSession(settings=settings, session_id="abc", cwd=Path("/repo"))
@@ -151,7 +154,8 @@ def test_network_bridge_when_domains_allowed(monkeypatch):
     argv = session._build_run_argv()
 
     net_idx = argv.index("--network")
-    assert argv[net_idx + 1] == "bridge"
+    assert argv[net_idx + 1] == "none"
+    assert "does not enforce allowed_domains/denied_domains yet" in caplog.text
 
 
 def test_resource_limits_applied(monkeypatch):


### PR DESCRIPTION
Closes #150.

## Summary

This PR makes the Docker sandbox backend fail closed when `allowed_domains` / `denied_domains` are configured but not actually enforceable.

Concretely:
- Docker sandbox keeps `--network none`
- a warning is emitted when domain policies are configured under Docker mode
- regression tests cover the fail-closed behavior

## Why

Issue #120 / PR #121 introduced Docker sandboxing as part of the project’s safety-boundary story and exposed domain-policy settings through sandbox config.

The current Docker path, however, does not enforce those policy contents. Any non-empty `allowed_domains` list switches Docker networking from `none` to plain `bridge`.

That means two different policies such as:
- allow `github.com`, deny `example.com`
- allow `internal.example`, deny `google.com`

produce the same unrestricted bridge configuration.

## Root cause

`src/openharness/sandbox/docker_backend.py` checks only whether `allowed_domains` is non-empty, but it does not propagate the policy contents into any enforcement layer.

So the current behavior is effectively:
- empty list -> no network
- non-empty list -> unrestricted bridge network

which is broader than the config semantics imply.

## Change

- keep Docker networking disabled when domain policies are configured
- emit a warning explaining that Docker domain-policy enforcement is not implemented yet
- update sandbox tests to lock in the fail-closed behavior

## Before / After

### Before
- non-empty `allowed_domains` enabled `--network bridge`
- configured policy contents had no effect on Docker runtime behavior

### After
- non-empty `allowed_domains` / `denied_domains` keeps `--network none`
- operators get an explicit warning instead of a silent widening of egress

## Compatibility

- this changes behavior only for the Docker backend when domain policies are configured
- the `srt` backend is unchanged
- this does not attempt to design a full Docker egress-filtering system in one patch

## Validation

- [x] `PYTHONPATH=src pytest -q tests/test_sandbox/test_docker_backend.py tests/test_sandbox/test_adapter.py`
- [x] `PYTHONPATH=src ruff check src tests`
- [x] targeted regression coverage added for the warning + fail-closed path

## Notes

- I chose the smallest safe fix here: fail closed until Docker domain-policy enforcement actually exists.
- Full `pytest -q` on this local environment is currently blocked by unrelated collection errors caused by a missing optional `pyperclip` dependency; I did not change the command/UI modules involved in those collection failures.
