### PR TITLE
feat(memory): pluggable MemoryProvider protocol (ref #67)

### DIFF
--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -65,6 +65,14 @@ class MemorySettings(BaseModel):
     max_entrypoint_lines: int = 200
     context_window_tokens: int | None = None
     auto_compact_threshold_tokens: int | None = None
+    # Pluggable memory backend. "local" keeps the existing project-markdown
+    # search; additional backends are registered via
+    # openharness.memory.register_memory_provider.
+    backend: str = "local"
+    # Per-provider configuration, keyed by provider name. Shape is
+    # intentionally loose so new providers can grow their own config without
+    # schema churn here.
+    providers: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
 class SandboxNetworkSettings(BaseModel):

--- a/src/openharness/memory/__init__.py
+++ b/src/openharness/memory/__init__.py
@@ -3,16 +3,30 @@
 from openharness.memory.memdir import load_memory_prompt
 from openharness.memory.manager import add_memory_entry, list_memory_files, remove_memory_entry
 from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.memory.providers import (
+    LocalMarkdownProvider,
+    MemoryProvider,
+    MemoryResult,
+    get_memory_provider,
+    known_memory_providers,
+    register_memory_provider,
+)
 from openharness.memory.scan import scan_memory_files
 from openharness.memory.search import find_relevant_memories
 
 __all__ = [
+    "LocalMarkdownProvider",
+    "MemoryProvider",
+    "MemoryResult",
     "add_memory_entry",
     "find_relevant_memories",
     "get_memory_entrypoint",
+    "get_memory_provider",
     "get_project_memory_dir",
+    "known_memory_providers",
     "list_memory_files",
     "load_memory_prompt",
+    "register_memory_provider",
     "remove_memory_entry",
     "scan_memory_files",
 ]

--- a/src/openharness/memory/providers/__init__.py
+++ b/src/openharness/memory/providers/__init__.py
@@ -1,0 +1,39 @@
+"""Pluggable memory providers.
+
+The default ``local`` provider wraps the existing project-memory search and
+preserves byte-for-byte the prior behavior of :func:`build_runtime_system_prompt`.
+Additional providers (HTTP, MCP, ...) register themselves via
+:func:`register_memory_provider` and are selected by ``settings.memory.backend``.
+"""
+
+from __future__ import annotations
+
+from openharness.memory.providers.base import (
+    MemoryProvider,
+    MemoryResult,
+    clear_memory_providers,
+    get_memory_provider,
+    known_memory_providers,
+    register_memory_provider,
+)
+from openharness.memory.providers.local import LocalMarkdownProvider
+
+
+def _ensure_defaults() -> None:
+    """Register the built-in ``local`` provider exactly once."""
+    if "local" not in known_memory_providers():
+        register_memory_provider("local", LocalMarkdownProvider)
+
+
+_ensure_defaults()
+
+
+__all__ = [
+    "LocalMarkdownProvider",
+    "MemoryProvider",
+    "MemoryResult",
+    "clear_memory_providers",
+    "get_memory_provider",
+    "known_memory_providers",
+    "register_memory_provider",
+]

--- a/src/openharness/memory/providers/base.py
+++ b/src/openharness/memory/providers/base.py
@@ -1,0 +1,119 @@
+"""Memory provider protocol and registry.
+
+The provider protocol is intentionally synchronous for this first iteration
+so it drops into the existing :func:`build_runtime_system_prompt` hot path
+without forcing an async refactor of the prompt assembler. Providers that
+perform network I/O should apply their own short timeout and return an empty
+list on failure — the caller treats a provider exception as "no memories"
+rather than failing the prompt build.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class MemoryResult:
+    """A single memory entry returned by a :class:`MemoryProvider`.
+
+    ``content`` is the full body to inject into the system prompt; the caller
+    does not re-read from disk or re-fetch from the provider. ``source``
+    identifies which provider produced the result (useful for debugging and
+    for provenance labeling in the prompt). ``metadata`` is provider-specific
+    and opaque to the harness.
+    """
+
+    id: str
+    title: str
+    content: str
+    description: str = ""
+    score: float | None = None
+    source: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class MemoryProvider(Protocol):
+    """Retrieve memory entries relevant to a query.
+
+    Implementations must be safe to call once per user turn — the current
+    call site runs inside the synchronous prompt-assembly path. Anything
+    slower than ~100 ms is likely to be user-perceptible; providers that talk
+    to a remote service should either cache or bound their work with a tight
+    timeout and fail open (return ``[]``).
+    """
+
+    name: str
+
+    def search(
+        self,
+        query: str,
+        *,
+        cwd: str | Path,
+        limit: int = 5,
+    ) -> list[MemoryResult]:
+        """Return up to ``limit`` results most relevant to ``query``."""
+        ...
+
+    def close(self) -> None:
+        """Release any held resources. No-op for stateless providers."""
+        ...
+
+
+ProviderFactory = Callable[..., MemoryProvider]
+
+# Module-level registry. Kept private; callers go through the helpers below
+# so provider resolution can grow additional behavior (e.g. caching, plugin
+# discovery) without touching every call site.
+_REGISTRY: dict[str, ProviderFactory] = {}
+
+
+def register_memory_provider(name: str, factory: ProviderFactory) -> None:
+    """Register a memory provider factory under ``name``.
+
+    Raises ``ValueError`` if ``name`` is already registered. Silent
+    replacement makes plugin conflicts hard to debug; a future PR can add an
+    explicit ``override=True`` parameter when a real use case arises.
+    """
+    if not name:
+        raise ValueError("Memory provider name must be non-empty")
+    if name in _REGISTRY:
+        raise ValueError(f"Memory provider '{name}' is already registered")
+    _REGISTRY[name] = factory
+
+
+def get_memory_provider(name: str, *, settings: Any | None = None) -> MemoryProvider:
+    """Instantiate the memory provider registered under ``name``.
+
+    ``settings`` is the Settings object (duck-typed so tests can pass a
+    stub). The provider's configuration is looked up under
+    ``settings.memory.providers[name]`` and forwarded as kwargs to the
+    factory. Unknown backends raise ``ValueError`` with a descriptive
+    message listing the known names.
+    """
+    if name not in _REGISTRY:
+        known = ", ".join(sorted(_REGISTRY)) or "<none registered>"
+        raise ValueError(
+            f"Unknown memory backend '{name}'. "
+            f"Known backends: {known}. "
+            f"Set memory.backend in settings.json to one of the known values."
+        )
+    factory = _REGISTRY[name]
+    provider_config: dict[str, Any] = {}
+    if settings is not None:
+        providers = getattr(getattr(settings, "memory", None), "providers", {}) or {}
+        provider_config = dict(providers.get(name, {}) or {})
+    return factory(**provider_config)
+
+
+def known_memory_providers() -> list[str]:
+    """Return the sorted list of registered backend names."""
+    return sorted(_REGISTRY)
+
+
+def clear_memory_providers() -> None:
+    """Reset the provider registry. Intended for tests only."""
+    _REGISTRY.clear()

--- a/src/openharness/memory/providers/local.py
+++ b/src/openharness/memory/providers/local.py
@@ -1,0 +1,55 @@
+"""Default memory provider backed by project-local markdown files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openharness.memory.providers.base import MemoryResult
+from openharness.memory.search import find_relevant_memories
+
+
+class LocalMarkdownProvider:
+    """Wrap :func:`openharness.memory.search.find_relevant_memories`.
+
+    The prompt injection produced by this provider is byte-for-byte identical
+    to the pre-provider path — the existing integration test in
+    ``tests/test_memory/test_memdir.py`` already pins the underlying search
+    behavior. Swapping it out with a remote provider is therefore a
+    zero-risk change for existing users who keep ``memory.backend = "local"``.
+    """
+
+    name = "local"
+
+    def search(
+        self,
+        query: str,
+        *,
+        cwd: str | Path,
+        limit: int = 5,
+    ) -> list[MemoryResult]:
+        headers = find_relevant_memories(query, cwd, max_results=limit)
+        results: list[MemoryResult] = []
+        for header in headers:
+            try:
+                content = header.path.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                # Skip unreadable files; scan.py already filtered most of
+                # these, but a race with deletion is still possible.
+                continue
+            results.append(
+                MemoryResult(
+                    id=header.path.name,
+                    title=header.path.name,
+                    content=content,
+                    description=header.description,
+                    source=self.name,
+                    metadata={
+                        "memory_type": header.memory_type,
+                        "path": str(header.path),
+                    },
+                )
+            )
+        return results
+
+    def close(self) -> None:
+        return None

--- a/src/openharness/prompts/context.py
+++ b/src/openharness/prompts/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Iterable
 
@@ -12,11 +13,13 @@ from openharness.config.paths import (
 )
 from openharness.config.settings import Settings
 from openharness.coordinator.coordinator_mode import get_coordinator_system_prompt, is_coordinator_mode
-from openharness.memory import find_relevant_memories, load_memory_prompt
+from openharness.memory import MemoryResult, get_memory_provider, load_memory_prompt
 from openharness.personalization.rules import load_local_rules
 from openharness.prompts.claudemd import load_claude_md_prompt
 from openharness.prompts.system_prompt import build_system_prompt
 from openharness.skills.loader import load_skill_registry
+
+logger = logging.getLogger(__name__)
 
 
 def _build_skills_section(
@@ -139,24 +142,42 @@ def build_runtime_system_prompt(
             sections.append(memory_section)
 
         if latest_user_prompt:
-            relevant = find_relevant_memories(
-                latest_user_prompt,
-                cwd,
-                max_results=settings.memory.max_files,
-            )
-            if relevant:
+            results = _search_memory_provider(settings, latest_user_prompt, cwd)
+            if results:
                 lines = ["# Relevant Memories"]
-                for header in relevant:
-                    content = header.path.read_text(encoding="utf-8", errors="replace").strip()
+                for result in results:
                     lines.extend(
                         [
                             "",
-                            f"## {header.path.name}",
+                            f"## {result.title}",
                             "```md",
-                            content[:8000],
+                            result.content[:8000],
                             "```",
                         ]
                     )
                 sections.append("\n".join(lines))
 
     return "\n\n".join(section for section in sections if section.strip())
+
+
+def _search_memory_provider(
+    settings: Settings, query: str, cwd: str | Path
+) -> list[MemoryResult]:
+    """Resolve the configured memory provider and return its results.
+
+    Any provider-side failure (unknown backend, search error) is logged and
+    treated as "no memories" so prompt assembly never fails because of a
+    misconfigured remote store.
+    """
+    try:
+        provider = get_memory_provider(settings.memory.backend, settings=settings)
+    except ValueError as exc:
+        logger.warning("Memory provider setup failed: %s", exc)
+        return []
+    try:
+        return provider.search(query, cwd=cwd, limit=settings.memory.max_files)
+    except Exception as exc:  # noqa: BLE001 — provider contract: fail open
+        logger.warning(
+            "Memory provider '%s' search failed: %s", settings.memory.backend, exc
+        )
+        return []

--- a/tests/test_memory/test_provider.py
+++ b/tests/test_memory/test_provider.py
@@ -1,0 +1,301 @@
+"""Tests for the memory provider protocol and registry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.memory import (
+    LocalMarkdownProvider,
+    MemoryResult,
+    get_memory_provider,
+    known_memory_providers,
+    register_memory_provider,
+)
+from openharness.memory.providers.base import clear_memory_providers
+
+
+@pytest.fixture
+def isolated_registry():
+    """Give each test a fresh registry with just the built-in 'local' provider."""
+    clear_memory_providers()
+    register_memory_provider("local", LocalMarkdownProvider)
+    yield
+    clear_memory_providers()
+    register_memory_provider("local", LocalMarkdownProvider)
+
+
+# --- MemoryResult -----------------------------------------------------------
+
+
+def test_memory_result_defaults_are_sensible():
+    result = MemoryResult(id="x.md", title="x", content="body")
+    assert result.description == ""
+    assert result.score is None
+    assert result.source == ""
+    assert result.metadata == {}
+
+
+def test_memory_result_is_hashable_via_frozen_dataclass():
+    # Frozen dataclasses let callers use MemoryResult in dedupe sets when
+    # the metadata dict is empty (i.e. for the common case).
+    a = MemoryResult(id="a.md", title="a", content="hello")
+    b = MemoryResult(id="a.md", title="a", content="hello")
+    assert a == b
+
+
+# --- Registry ---------------------------------------------------------------
+
+
+def test_local_provider_registered_by_default():
+    # No fixture: just importing openharness.memory should register 'local'.
+    assert "local" in known_memory_providers()
+
+
+def test_register_and_get_provider(isolated_registry):
+    class FakeProvider:
+        name = "fake"
+
+        def __init__(self, greeting: str = "hi"):
+            self.greeting = greeting
+
+        def search(self, query, *, cwd, limit=5):
+            return [MemoryResult(id="f", title=self.greeting, content=query)]
+
+        def close(self):
+            return None
+
+    register_memory_provider("fake", FakeProvider)
+
+    provider = get_memory_provider("fake")
+    results = provider.search("query", cwd="/tmp")
+    assert results[0].content == "query"
+    assert results[0].title == "hi"
+
+
+def test_get_provider_forwards_settings_kwargs(isolated_registry):
+    class ConfigurableProvider:
+        name = "configurable"
+
+        def __init__(self, *, url: str, timeout: float = 1.0):
+            self.url = url
+            self.timeout = timeout
+
+        def search(self, query, *, cwd, limit=5):
+            return []
+
+        def close(self):
+            return None
+
+    register_memory_provider("configurable", ConfigurableProvider)
+
+    class _Settings:
+        class _Mem:
+            providers = {"configurable": {"url": "https://mem", "timeout": 5.0}}
+
+        memory = _Mem()
+
+    provider = get_memory_provider("configurable", settings=_Settings())
+    assert isinstance(provider, ConfigurableProvider)
+    assert provider.url == "https://mem"
+    assert provider.timeout == 5.0
+
+
+def test_get_provider_unknown_backend_lists_known(isolated_registry):
+    with pytest.raises(ValueError) as exc:
+        get_memory_provider("does-not-exist")
+    # The error must be actionable — it should list what *is* available so
+    # users can fix settings.json without reading the source.
+    assert "does-not-exist" in str(exc.value)
+    assert "local" in str(exc.value)
+
+
+def test_register_rejects_empty_name(isolated_registry):
+    with pytest.raises(ValueError):
+        register_memory_provider("", LocalMarkdownProvider)
+
+
+def test_register_rejects_duplicate(isolated_registry):
+    with pytest.raises(ValueError):
+        register_memory_provider("local", LocalMarkdownProvider)
+
+
+# --- LocalMarkdownProvider --------------------------------------------------
+
+
+def _write_memory(project_dir: Path, filename: str, body: str) -> Path:
+    from openharness.memory.paths import get_project_memory_dir
+
+    memory_dir = get_project_memory_dir(project_dir)
+    path = memory_dir / filename
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_local_provider_populates_content_and_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+    _write_memory(
+        project,
+        "auth_rewrite.md",
+        "---\nname: auth-rewrite\ndescription: Auth middleware rewrite\ntype: project\n---\n"
+        "Session token storage rework.\n",
+    )
+
+    provider = LocalMarkdownProvider()
+    results = provider.search("auth middleware", cwd=project)
+
+    assert results
+    top = results[0]
+    assert top.content.startswith("---")
+    assert "Session token storage rework" in top.content
+    assert top.source == "local"
+    assert top.metadata["memory_type"] == "project"
+    assert top.metadata["path"].endswith("auth_rewrite.md")
+
+
+def test_local_provider_matches_find_relevant_memories_ordering(tmp_path, monkeypatch):
+    """The provider layer must not change the default search ranking."""
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+    _write_memory(
+        project,
+        "cache_layer.md",
+        "---\nname: cache-layer\ndescription: Redis caching strategy\n---\nNotes.\n",
+    )
+    _write_memory(
+        project,
+        "infra_notes.md",
+        "---\nname: infra-notes\ndescription: Infrastructure overview\n---\n"
+        "We use redis for sessions.\n",
+    )
+
+    from openharness.memory import find_relevant_memories
+
+    legacy = find_relevant_memories("redis caching", project)
+    provider_results = LocalMarkdownProvider().search("redis caching", cwd=project)
+
+    assert [r.metadata["path"] for r in provider_results] == [str(h.path) for h in legacy]
+
+
+def test_local_provider_respects_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+    for i in range(5):
+        _write_memory(
+            project,
+            f"note_{i}.md",
+            f"---\nname: note-{i}\ndescription: pytest fixtures {i}\n---\nBody.\n",
+        )
+
+    results = LocalMarkdownProvider().search("pytest fixtures", cwd=project, limit=2)
+    assert len(results) == 2
+
+
+def test_local_provider_close_is_noop():
+    # close() on a stateless provider must be safe to call repeatedly.
+    provider = LocalMarkdownProvider()
+    provider.close()
+    provider.close()
+
+
+# --- Integration with build_runtime_system_prompt ---------------------------
+
+
+def test_build_runtime_prompt_uses_provider_for_memory_section(tmp_path, monkeypatch):
+    """End-to-end: the provider path produces the same 'Relevant Memories'
+    section the pre-provider code produced.
+    """
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+    _write_memory(
+        project,
+        "kubectl_tips.md",
+        "---\nname: kubectl-tips\ndescription: kubectl rollout patterns\n---\n"
+        "Use rollout status.\n",
+    )
+
+    from openharness.config.settings import Settings
+    from openharness.prompts.context import build_runtime_system_prompt
+
+    settings = Settings()
+    prompt = build_runtime_system_prompt(
+        settings,
+        cwd=project,
+        latest_user_prompt="kubectl rollout help",
+    )
+
+    assert "# Relevant Memories" in prompt
+    assert "kubectl_tips.md" in prompt
+    assert "Use rollout status" in prompt
+
+
+def test_build_runtime_prompt_falls_back_on_unknown_backend(tmp_path, monkeypatch, caplog):
+    """A misconfigured backend must not fail prompt assembly — it logs and
+    omits the Relevant Memories section.
+    """
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+    _write_memory(
+        project,
+        "note.md",
+        "---\nname: note\ndescription: something\n---\nbody\n",
+    )
+
+    from openharness.config.settings import Settings
+    from openharness.prompts.context import build_runtime_system_prompt
+
+    settings = Settings()
+    settings.memory.backend = "not-registered"
+
+    with caplog.at_level("WARNING"):
+        prompt = build_runtime_system_prompt(
+            settings,
+            cwd=project,
+            latest_user_prompt="something",
+        )
+
+    assert "# Relevant Memories" not in prompt
+    assert any("not-registered" in record.message for record in caplog.records)
+
+
+def test_build_runtime_prompt_falls_back_when_provider_raises(
+    tmp_path, monkeypatch, caplog, isolated_registry
+):
+    """Provider exceptions during search must not crash prompt assembly."""
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project = tmp_path / "repo"
+    project.mkdir()
+
+    class BrokenProvider:
+        name = "broken"
+
+        def search(self, query, *, cwd, limit=5):
+            raise RuntimeError("boom")
+
+        def close(self):
+            return None
+
+    register_memory_provider("broken", BrokenProvider)
+
+    from openharness.config.settings import Settings
+    from openharness.prompts.context import build_runtime_system_prompt
+
+    settings = Settings()
+    settings.memory.backend = "broken"
+
+    with caplog.at_level("WARNING"):
+        prompt = build_runtime_system_prompt(
+            settings,
+            cwd=project,
+            latest_user_prompt="anything",
+        )
+
+    assert "# Relevant Memories" not in prompt
+    assert any("broken" in record.message and "boom" in record.message for record in caplog.records)


### PR DESCRIPTION
Opens the extension point for #67 so external memory backends — MCP memory servers, HTTP services like PowerMem — can plug into the system-prompt injection path without each one forking `prompts/context.py`. @siaochuan's [earlier comment](https://github.com/HKUDS/OpenHarness/issues/67#issuecomment-4204323890) sketched the use case well (their Dongtian MCP server plus PowerMem both want the same shape), so I used that as the anchor.

The default `"local"` backend wraps `find_relevant_memories` byte-for-byte, so anyone who doesn't touch `memory.backend` sees no change. The existing ranking tests in `tests/test_memory/test_memdir.py` already pin that behavior end-to-end.

### What's in the patch

- `MemoryProvider` Protocol + `MemoryResult` frozen dataclass in `src/openharness/memory/providers/base.py`
- Registry: `register_memory_provider`, `get_memory_provider`, `known_memory_providers`, `clear_memory_providers` (test-only)
- `LocalMarkdownProvider` wrapping `find_relevant_memories` (`src/openharness/memory/providers/local.py`)
- `MemorySettings.backend` (default `"local"`) and `MemorySettings.providers` in `config/settings.py`
- `build_runtime_system_prompt` resolves the provider from settings and renders its results as `# Relevant Memories`. Any provider exception — unknown backend, network timeout, malformed response — is caught, logged at WARNING, and the section is dropped.

Total: +557 / -11 across 3 new files, 3 modified, and 1 new test file.

### The calls I made

**In core, not a plugin.** The config surface belongs next to the rest of `MemorySettings`, and every future backend will use the same registry — shipping it through a plugin would duplicate that registry across every plugin that wants to extend memory. The registry is exported from `openharness.memory`, so a plugin can still call `register_memory_provider` on its own import without this layer needing to know about it.

**Config shape is `memory.backend = "name"` + `memory.providers.<name>.{...}`.** Mirrors the `sandbox.backend` + `sandbox.docker: {...}` pattern already used elsewhere in `Settings`, so there's no new convention to learn. A nested `memory.provider: {type, config}` would give a slightly tighter schema per provider, but at the cost of needing to touch `MemorySettings` for every new backend — which is the exact coupling this PR is meant to break. Ordered-fallback lists are a separate shape that can land as `memory.backend_stack` if a real use case turns up.

**Sync, not async.** `build_runtime_system_prompt` is synchronous and called from several sync sites; going async cascades through the entire prompt-assembly layer for no immediate payoff. Remote providers can wrap an async client behind a sync `search()` with a tight timeout, and there's no parallelism to preserve across a single-provider call. An `AsyncMemoryProvider` sibling protocol can land alongside this one when multi-backend fanout actually exists.

**No `store()` method.** Nothing in core calls a provider-level store today — memory writes go through `add_memory_entry` in `memory/manager.py`. Pinning the `store()` shape before a real caller exists is the kind of thing we'd regret in six months. A `WritableMemoryProvider(MemoryProvider)` sub-protocol is the clean extension when a remote backend actually needs write semantics.

**Fail-open on any provider error.** If `memory.backend` points at something unregistered, or a provider raises during `search()`, the harness logs a WARNING and continues with no memory section. Memory is auxiliary context — a misconfigured remote store shouldn't kill prompt assembly for an interactive session.

**Protocol-only, no adapters.** Keeps the diff small and leaves room for a Dongtian adapter and a PowerMem adapter to land as independent follow-ups without tangling scope with the protocol design.

### Verification

```
uv run ruff check src tests scripts     # clean
uv run pytest -q                        # 755 passed, 6 skipped (pre-existing)
uv run pytest tests/test_memory/ -q     # 27 passed (13 pre-existing + 14 new)
```

`tests/test_memory/test_provider.py` covers registry round-trips, the unknown-backend error listing known names, `LocalMarkdownProvider` ranking parity with `find_relevant_memories`, end-to-end `build_runtime_system_prompt` integration, and both fail-open paths (unknown backend + provider-raised exception).

### CHANGELOG

Not in this patch — left for the reviewer to write in their own voice when merging. Suggested text:

> ### Added
> - Pluggable memory backends via `openharness.memory.MemoryProvider` protocol + `MemoryResult` dataclass and a `settings.memory.backend` selector (defaults to `"local"` — no behavior change for existing users). New backends register via `register_memory_provider(...)`. Ref #67.
