### PR TITLE
fix(shell): skip script PTY wrapping on macOS to prevent crash in TUI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS: bash tool no longer crashes with `script: illegal option -- f` or `tcgetattr/ioctl: Operation not supported on socket`.**
+  The BSD `script(1)` on macOS differs from GNU/Linux `script` in two ways: it does not accept `-f` (flush) or `-c` (command) flags, and it requires a real controlling TTY which is unavailable when OpenHarness runs commands through pipes in TUI mode.  `_wrap_command_with_script` now returns `None` on macOS, letting the bash tool fall back to plain `bash -lc` execution on that platform.
+
 ### Added
 
 - Built-in `minimax` provider profile so `oh setup` offers MiniMax as a first-class provider choice, with `MINIMAX_API_KEY` auth source, `MiniMax-M2.7` as the default model, and `MiniMax-M2.7-highspeed` in the model picker.

--- a/src/openharness/utils/shell.py
+++ b/src/openharness/utils/shell.py
@@ -34,14 +34,14 @@ def resolve_shell_command(
     if bash:
         argv = [bash, "-lc", command]
         if prefer_pty:
-            wrapped = _wrap_command_with_script(argv)
+            wrapped = _wrap_command_with_script(argv, platform_name=resolved_platform)
             if wrapped is not None:
                 return wrapped
         return argv
     shell = shutil.which("sh") or os.environ.get("SHELL") or "/bin/sh"
     argv = [shell, "-lc", command]
     if prefer_pty:
-        wrapped = _wrap_command_with_script(argv)
+        wrapped = _wrap_command_with_script(argv, platform_name=resolved_platform)
         if wrapped is not None:
             return wrapped
     return argv
@@ -104,13 +104,24 @@ async def create_shell_subprocess(
     return process
 
 
-def _wrap_command_with_script(argv: list[str]) -> list[str] | None:
+def _wrap_command_with_script(
+    argv: list[str],
+    platform_name: PlatformName | None = None,
+) -> list[str] | None:
+    # macOS BSD script requires a real controlling TTY (tcgetattr/ioctl) and will
+    # fail with "Operation not supported on socket" when stdin/stdout are pipes.
+    # Skip PTY wrapping on macOS entirely; fall back to plain shell execution.
+    resolved_platform = platform_name or get_platform()
+    if resolved_platform == "macos":
+        return None
+
     script = shutil.which("script")
     if script is None:
         return None
-    if len(argv) >= 3 and argv[1] == "-lc":
-        return [script, "-qefc", argv[2], "/dev/null"]
-    return None
+    if len(argv) < 3 or argv[1] != "-lc":
+        return None
+    # GNU/Linux script: -q=quiet, -e=forward exit code, -f=flush, -c=command follows
+    return [script, "-qefc", argv[2], "/dev/null"]
 
 
 async def _cleanup_after_exit(process: asyncio.subprocess.Process, cleanup_path: Path) -> None:

--- a/tests/test_utils/test_shell.py
+++ b/tests/test_utils/test_shell.py
@@ -49,3 +49,55 @@ def test_resolve_shell_command_uses_powershell_on_windows(monkeypatch):
         "-Command",
         "Write-Output hi",
     ]
+
+
+def test_resolve_shell_command_skips_script_on_macos(monkeypatch):
+    """On macOS, prefer_pty must NOT wrap with script(1).
+
+    The BSD implementation of script requires a real controlling TTY and
+    raises 'tcgetattr/ioctl: Operation not supported on socket' when
+    stdin/stdout are pipes (as they are in the OpenHarness subprocess
+    backend).  The fix is to return None from _wrap_command_with_script
+    for the 'macos' platform so the caller falls back to plain bash.
+    """
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "bash": "/usr/bin/bash",
+            "script": "/usr/bin/script",
+        }
+        return mapping.get(name)
+
+    monkeypatch.setattr("openharness.utils.shell.shutil.which", fake_which)
+
+    command = resolve_shell_command("echo hi", platform_name="macos", prefer_pty=True)
+
+    # Must be plain bash, never wrapped with script
+    assert command == ["/usr/bin/bash", "-lc", "echo hi"]
+    assert "/usr/bin/script" not in command
+
+
+def test_resolve_shell_command_macos_without_pty_uses_bash(monkeypatch):
+    """Without prefer_pty, macOS should still resolve to plain bash."""
+
+    monkeypatch.setattr(
+        "openharness.utils.shell.shutil.which",
+        lambda name: "/usr/bin/bash" if name == "bash" else None,
+    )
+
+    command = resolve_shell_command("python --version", platform_name="macos")
+
+    assert command == ["/usr/bin/bash", "-lc", "python --version"]
+
+
+def test_resolve_shell_command_linux_without_script_falls_back(monkeypatch):
+    """On Linux with prefer_pty but no script binary, fall back to bash."""
+
+    monkeypatch.setattr(
+        "openharness.utils.shell.shutil.which",
+        lambda name: "/usr/bin/bash" if name == "bash" else None,
+    )
+
+    command = resolve_shell_command("echo hi", platform_name="linux", prefer_pty=True)
+
+    assert command == ["/usr/bin/bash", "-lc", "echo hi"]


### PR DESCRIPTION
Closes #165

## Problem

On macOS, every bash tool call in TUI mode injects an error into the tool output:

```
/usr/bin/script: illegal option -- f
```

or

```
script: tcgetattr/ioctl: Operation not supported on socket
```

This causes the bash tool to report every command as failed.

## Root cause

`_wrap_command_with_script()` in `src/openharness/utils/shell.py` hard-codes GNU/Linux `script(1)` syntax:

```python
return [script, "-qefc", argv[2], "/dev/null"]
# -f = flush  (not a valid flag on BSD script)
# -c = command (not a valid flag on BSD script)
```

BSD `script` on macOS:
- Does **not** accept `-f` or `-c` → `illegal option -- f`
- Calls `tcgetattr()` on its controlling terminal, which does not exist when stdin/stdout are pipes in TUI mode → `Operation not supported on socket`

## Fix

Return `None` from `_wrap_command_with_script()` when `platform == "macos"`. The caller already handles `None` by falling back to plain `bash -lc`, so no other changes are needed.

```python
def _wrap_command_with_script(
    argv: list[str],
    platform_name: PlatformName | None = None,
) -> list[str] | None:
    resolved_platform = platform_name or get_platform()
    if resolved_platform == "macos":
        return None  # BSD script needs a real TTY; unavailable in headless pipe context
    ...
```

The `platform_name` argument is also threaded through from `resolve_shell_command` to avoid a redundant `get_platform()` call.

## Trade-off

PTY wrapping via `script(1)` is now Linux-only. On macOS, `isatty(stdout)` returns `False` inside bash tool commands (same as before the PTY feature was added). Colour output and TTY-dependent formatting may differ, but this is far less harmful than injecting crash output into every tool result. A proper fix using Python `pty.openpty()` can follow as a separate PR without changing the public API.

## Verification

```bash
uv run ruff check src/openharness/utils/shell.py tests/test_utils/test_shell.py
uv run pytest tests/test_utils/test_shell.py -v
# 6 passed
```

## Tests added

Three new cases in `tests/test_utils/test_shell.py`:

| Test | What it checks |
|---|---|
| `test_resolve_shell_command_skips_script_on_macos` | `prefer_pty=True` on macOS never wraps with `script`, even when `script` is on PATH |
| `test_resolve_shell_command_macos_without_pty_uses_bash` | Plain macOS call resolves to `bash -lc` |
| `test_resolve_shell_command_linux_without_script_falls_back` | Linux + `prefer_pty` but no `script` binary → falls back to `bash -lc` |