### PR TITLE
feat(hooks): add user_prompt_submit, notification, stop events

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -591,6 +591,14 @@ async def run_query(
             messages.append(coordinator_context_message)
 
         if not final_message.tool_uses:
+            if context.hook_executor is not None:
+                await context.hook_executor.execute(
+                    HookEvent.STOP,
+                    {
+                        "event": HookEvent.STOP.value,
+                        "stop_reason": "tool_uses_empty",
+                    },
+                )
             return
 
         tool_calls = final_message.tool_uses
@@ -706,6 +714,16 @@ async def _execute_tool_call(
     if not decision.allowed:
         if decision.requires_confirmation and context.permission_prompt is not None:
             log.debug("permission prompt for %s: %s", tool_name, decision.reason)
+            if context.hook_executor is not None:
+                await context.hook_executor.execute(
+                    HookEvent.NOTIFICATION,
+                    {
+                        "event": HookEvent.NOTIFICATION.value,
+                        "notification_type": "permission_prompt",
+                        "tool_name": tool_name,
+                        "reason": decision.reason,
+                    },
+                )
             confirmed = await context.permission_prompt(tool_name, decision.reason)
             if not confirmed:
                 log.debug("permission denied by user for %s", tool_name)

--- a/src/openharness/engine/query_engine.py
+++ b/src/openharness/engine/query_engine.py
@@ -11,7 +11,7 @@ from openharness.coordinator.coordinator_mode import get_coordinator_user_contex
 from openharness.engine.messages import ConversationMessage, TextBlock, ToolResultBlock
 from openharness.engine.query import AskUserPrompt, PermissionPrompt, QueryContext, remember_user_goal, run_query
 from openharness.engine.stream_events import AssistantTurnComplete, StreamEvent
-from openharness.hooks import HookExecutor
+from openharness.hooks import HookEvent, HookExecutor
 from openharness.permissions.checker import PermissionChecker
 from openharness.tools.base import ToolRegistry
 
@@ -154,6 +154,14 @@ class QueryEngine:
         if user_message.text.strip():
             remember_user_goal(self._tool_metadata, user_message.text)
         self._messages.append(user_message)
+        if self._hook_executor is not None:
+            await self._hook_executor.execute(
+                HookEvent.USER_PROMPT_SUBMIT,
+                {
+                    "event": HookEvent.USER_PROMPT_SUBMIT.value,
+                    "prompt": user_message.text,
+                },
+            )
         context = QueryContext(
             api_client=self._api_client,
             tool_registry=self._tool_registry,

--- a/src/openharness/hooks/events.py
+++ b/src/openharness/hooks/events.py
@@ -14,3 +14,6 @@ class HookEvent(str, Enum):
     POST_COMPACT = "post_compact"
     PRE_TOOL_USE = "pre_tool_use"
     POST_TOOL_USE = "post_tool_use"
+    USER_PROMPT_SUBMIT = "user_prompt_submit"
+    NOTIFICATION = "notification"
+    STOP = "stop"

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -601,6 +601,170 @@ async def test_query_engine_respects_pre_tool_hook_blocks(tmp_path: Path):
     assert "no reading" in tool_results[0].output
 
 
+class _RecordingHookExecutor:
+    """Duck-typed hook executor that records every fired event + payload."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[HookEvent, dict]] = []
+
+    async def execute(self, event: HookEvent, payload: dict):
+        from openharness.hooks.types import AggregatedHookResult
+
+        self.calls.append((event, dict(payload)))
+        return AggregatedHookResult(results=[])
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_submit_hook_fires(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    recorder = _RecordingHookExecutor()
+    engine = QueryEngine(
+        api_client=StaticApiClient("done"),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        hook_executor=recorder,  # type: ignore[arg-type]
+    )
+
+    _ = [event async for event in engine.submit_message("hello world")]
+
+    user_prompt_calls = [c for c in recorder.calls if c[0] == HookEvent.USER_PROMPT_SUBMIT]
+    assert len(user_prompt_calls) == 1
+    assert user_prompt_calls[0][1]["event"] == "user_prompt_submit"
+    assert user_prompt_calls[0][1]["prompt"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_stop_hook_fires_on_clean_turn(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    recorder = _RecordingHookExecutor()
+    engine = QueryEngine(
+        api_client=StaticApiClient("all done"),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        hook_executor=recorder,  # type: ignore[arg-type]
+    )
+
+    _ = [event async for event in engine.submit_message("hi")]
+
+    stop_calls = [c for c in recorder.calls if c[0] == HookEvent.STOP]
+    assert len(stop_calls) == 1
+    assert stop_calls[0][1]["event"] == "stop"
+    assert stop_calls[0][1]["stop_reason"] == "tool_uses_empty"
+
+
+@pytest.mark.asyncio
+async def test_stop_hook_does_not_fire_when_tool_uses_present(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    sample = tmp_path / "hello.txt"
+    sample.write_text("alpha\n", encoding="utf-8")
+    recorder = _RecordingHookExecutor()
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_1",
+                                name="read_file",
+                                input={"path": str(sample), "offset": 0, "limit": 1},
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="wrapped up")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        hook_executor=recorder,  # type: ignore[arg-type]
+    )
+
+    _ = [event async for event in engine.submit_message("read the file")]
+
+    stop_calls = [c for c in recorder.calls if c[0] == HookEvent.STOP]
+    # STOP fires exactly once — at the end of the second turn (no tool_uses),
+    # NOT after the first turn that contained a tool_use.
+    assert len(stop_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_notification_hook_fires_on_permission_prompt(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_COORDINATOR_MODE", raising=False)
+    recorder = _RecordingHookExecutor()
+    prompt_tool_calls: list[tuple[str, str]] = []
+
+    async def _permission_prompt(tool_name: str, reason: str) -> bool:
+        prompt_tool_calls.append((tool_name, reason))
+        # Assert the NOTIFICATION hook fired before this callback was invoked.
+        notif = [c for c in recorder.calls if c[0] == HookEvent.NOTIFICATION]
+        assert notif, "notification hook must fire before permission prompt"
+        return False  # deny — keeps the turn short
+
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_bash_1",
+                                name="bash",
+                                input={"command": "echo hi"},
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="denied")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings(mode=PermissionMode.DEFAULT)),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        permission_prompt=_permission_prompt,
+        hook_executor=recorder,  # type: ignore[arg-type]
+    )
+
+    _ = [event async for event in engine.submit_message("run something")]
+
+    notification_calls = [c for c in recorder.calls if c[0] == HookEvent.NOTIFICATION]
+    assert len(notification_calls) == 1
+    payload = notification_calls[0][1]
+    assert payload["event"] == "notification"
+    assert payload["notification_type"] == "permission_prompt"
+    assert payload["tool_name"] == "bash"
+    # The permission prompt callback was invoked (confirms the hook fired on the
+    # correct branch, not on the silently-denied branch).
+    assert prompt_tool_calls
+
+
 def _tool_context(tmp_path: Path, registry: ToolRegistry, settings: PermissionSettings) -> QueryContext:
     return QueryContext(
         api_client=_NoopApiClient(),


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  - Plugin authors writing Claude Code `hooks.json` configs cannot target `UserPromptSubmit`, `Notification`, or `Stop` on OpenHarness today; the `HookEvent` enum only exposes 6 of the 10 lifecycle events Claude Code emits.
- What changed?
  - Adds `USER_PROMPT_SUBMIT`, `NOTIFICATION`, and `STOP` members to `HookEvent` (snake_case values, consistent with existing events).
  - Fires `user_prompt_submit` in `QueryEngine.submit_message()` before the model sees a new user message. Payload: `{event, prompt}`.
  - Fires `stop` in `run_query()` when the assistant turn ends without tool uses. Payload: `{event, stop_reason}`.
  - Fires `notification` (subtype `permission_prompt`) right before the `permission_prompt` callback on confirmation-required tool calls. Payload: `{event, notification_type, tool_name, reason}`.

Hook return values are **observational only** in this release. Exit-code-driven blocking/continuation semantics (Claude Code's exit-2 behavior) are deferred — intentional scope limit to keep the PR small and reviewable per CONTRIBUTING.md.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q` — 748 passed, 6 skipped
- [x] `cd frontend/terminal && npx tsc --noEmit` — not applicable, no frontend changes

## Notes

- Related issue: #169
- Follow-up work: `subagent_stop` is planned as a separate PR because it requires a generic `register_completion_listener` callback on `BackgroundTaskManager` plus `ToolExecutionContext` plumbing — more invasive than the three fire sites in this PR. I would prefer to land this first and follow up once reviewers are comfortable with the payload conventions.
- Payload convention: flat dicts with an `event` key, matching existing `pre_tool_use` / `post_tool_use` / `session_start` payloads. No `session_id`/`transcript_path` Claude-Code-parity fields in this PR — that would be a cross-cutting change best handled separately.

## Edge cases covered by tests

- `hook_executor is None` → no hook is fired (guarded at every new site, mirroring the existing `PRE_TOOL_USE` site).
- `stop` fires exactly once when the turn cleanly completes; does NOT fire on turns that contain tool_uses.
- `stop` does NOT fire from the empty-assistant `ErrorEvent` early-return path (different semantics; those turns are already represented by an error event).
- `notification` fires only on the `decision.requires_confirmation and context.permission_prompt is not None` branch — not on silently-denied permission decisions.
- Notification payload order: the hook fires before the `permission_prompt` callback is awaited, so listeners see the escalation before the UI is shown.