### PR TITLE
fix(api): strip <think>…</think> blocks from OpenAI-compatible streaming responses

### DIFF
--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from typing import Any, AsyncIterator
 from urllib.parse import urlsplit, urlunsplit
 
@@ -298,6 +299,8 @@ class OpenAICompatibleClient:
         collected_tool_calls: dict[int, dict[str, Any]] = {}
         finish_reason: str | None = None
         usage_data: dict[str, int] = {}
+        # Buffer to strip inline <think>…</think> blocks across streaming chunks.
+        _think_buf = ""
 
         stream = await self._client.chat.completions.create(**params)
         async for chunk in stream:
@@ -321,10 +324,13 @@ class OpenAICompatibleClient:
             if reasoning_piece:
                 collected_reasoning += reasoning_piece
 
-            # Stream text content to user
+            # Stream text content to user, stripping inline <think> blocks
             if delta.content:
-                collected_content += delta.content
-                yield ApiTextDeltaEvent(text=delta.content)
+                _think_buf += delta.content
+                visible, _think_buf = _strip_think_blocks(_think_buf)
+                if visible:
+                    collected_content += visible
+                    yield ApiTextDeltaEvent(text=visible)
 
             # Accumulate tool calls
             if delta.tool_calls:
@@ -406,3 +412,25 @@ class OpenAICompatibleClient:
         if status == 429:
             return RateLimitFailure(msg)
         return RequestFailure(msg)
+
+
+# Matches complete <think>…</think> blocks (DOTALL so newlines are included).
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
+
+
+def _strip_think_blocks(buf: str) -> tuple[str, str]:
+    """Strip complete ``<think>…</think>`` blocks and return ``(visible_text, leftover)``.
+
+    Complete pairs are removed via regex.  An unclosed ``<think>`` is held in
+    *leftover* so it can be re-evaluated once the closing tag arrives in the
+    next streaming chunk.
+    """
+    # Remove fully-closed blocks.
+    cleaned = _THINK_RE.sub("", buf)
+
+    # Hold back any unclosed <think> for the next chunk.
+    open_idx = cleaned.find("<think>")
+    if open_idx != -1:
+        return cleaned[:open_idx], cleaned[open_idx:]
+
+    return cleaned, ""

--- a/tests/test_api/test_openai_client.py
+++ b/tests/test_api/test_openai_client.py
@@ -14,6 +14,7 @@ from openharness.api.openai_client import (
     _convert_messages_to_openai,
     _convert_tools_to_openai,
     _normalize_openai_base_url,
+    _strip_think_blocks,
     _token_limit_param_for_model,
 )
 from openharness.engine.messages import (
@@ -350,3 +351,57 @@ class TestStreamMessageTokenParams:
         assert fake_sdk.chat.completions.last_kwargs is not None
         assert "max_tokens" in fake_sdk.chat.completions.last_kwargs
         assert "max_completion_tokens" not in fake_sdk.chat.completions.last_kwargs
+
+
+class TestStripThinkBlocks:
+    """Unit tests for the _strip_think_blocks streaming helper."""
+
+    def test_no_think_tags_passthrough(self):
+        visible, leftover = _strip_think_blocks("Hello world")
+        assert visible == "Hello world"
+        assert leftover == ""
+
+    def test_complete_think_block_removed(self):
+        visible, leftover = _strip_think_blocks("<think>internal reasoning</think>answer")
+        assert visible == "answer"
+        assert leftover == ""
+
+    def test_multiline_think_block_removed(self):
+        buf = "<think>\nstep 1\nstep 2\n</think>final answer"
+        visible, leftover = _strip_think_blocks(buf)
+        assert visible == "final answer"
+        assert leftover == ""
+
+    def test_unclosed_think_held_in_leftover(self):
+        # Streaming chunk ends before </think> arrives
+        visible, leftover = _strip_think_blocks("prefix<think>partial reasoning")
+        assert visible == "prefix"
+        assert leftover == "<think>partial reasoning"
+
+    def test_empty_string(self):
+        visible, leftover = _strip_think_blocks("")
+        assert visible == ""
+        assert leftover == ""
+
+    def test_only_think_block(self):
+        visible, leftover = _strip_think_blocks("<think>all hidden</think>")
+        assert visible == ""
+        assert leftover == ""
+
+    def test_multiple_think_blocks(self):
+        buf = "<think>a</think>text1<think>b</think>text2"
+        visible, leftover = _strip_think_blocks(buf)
+        assert visible == "text1text2"
+        assert leftover == ""
+
+    def test_text_before_unclosed_think(self):
+        visible, leftover = _strip_think_blocks("before<think>unclosed")
+        assert visible == "before"
+        assert leftover == "<think>unclosed"
+
+    def test_closed_then_unclosed(self):
+        # One complete block followed by a new unclosed one (cross-chunk scenario)
+        buf = "<think>done</think>visible<think>still open"
+        visible, leftover = _strip_think_blocks(buf)
+        assert visible == "visible"
+        assert leftover == "<think>still open"


### PR DESCRIPTION
Closes #173

## Problem

Some reasoning-capable providers (e.g. DeepSeek, MiniMax) embed chain-of-thought content inside `<think>…</think>` tags in `delta.content` of streaming chunks instead of using a dedicated `reasoning_content` field. Without filtering, `OpenAICompatibleClient` leaks these internal blocks into the user-visible output.

## Change

**`src/openharness/api/openai_client.py`**

- Add `import re` (stdlib, no new dependency).
- Add `_THINK_RE` compiled pattern: `re.compile(r'<think>.*?</think>', re.DOTALL)`.
- Add `_strip_think_blocks(buf) -> (visible, leftover)` helper:
  - Removes fully-closed pairs via regex.
  - Holds back any unclosed `<think>` in *leftover* so cross-chunk tags are handled safely.
- In `_stream_response()`: route `delta.content` through `_strip_think_blocks` via a `_think_buf` accumulator before yielding `ApiTextDeltaEvent`.

## Verification

```bash
uv run pytest tests/test_api/test_openai_client.py -q
# 31 passed
uv run ruff check src/openharness/api/openai_client.py tests/test_api/test_openai_client.py
# All checks passed
```

9 new unit tests (`TestStripThinkBlocks`) cover:
- No-op passthrough (no tags)
- Single and multiple complete blocks
- Multiline block
- Only a think block (empty visible output)
- Unclosed tag held in leftover
- Text before unclosed tag
- Complete block followed by unclosed (cross-chunk scenario)