### PR TITLE
fix: default stdin to DEVNULL in create_shell_subprocess

### DIFF
--- a/src/openharness/utils/shell.py
+++ b/src/openharness/utils/shell.py
@@ -53,7 +53,7 @@ async def create_shell_subprocess(
     cwd: str | Path,
     settings: Settings | None = None,
     prefer_pty: bool = False,
-    stdin: int | None = None,
+    stdin: int | None = asyncio.subprocess.DEVNULL,
     stdout: int | None = None,
     stderr: int | None = None,
     env: Mapping[str, str] | None = None,

--- a/tests/test_utils/test_shell.py
+++ b/tests/test_utils/test_shell.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from openharness.utils.shell import resolve_shell_command
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from openharness.config.settings import Settings
+from openharness.utils.shell import create_shell_subprocess, resolve_shell_command
 
 
 def test_resolve_shell_command_prefers_bash_on_linux(monkeypatch):
@@ -78,3 +84,42 @@ def test_resolve_shell_command_linux_without_script_falls_back(monkeypatch):
     command = resolve_shell_command("echo hi", platform_name="linux", prefer_pty=True)
 
     assert command == ["/usr/bin/bash", "-lc", "echo hi"]
+
+
+@pytest.mark.asyncio
+async def test_create_shell_subprocess_defaults_stdin_to_devnull(monkeypatch, tmp_path: Path):
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+        class _FakeProcess:
+            returncode = 0
+
+            async def wait(self):
+                return 0
+
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "openharness.utils.shell.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "openharness.utils.shell.wrap_command_for_sandbox",
+        lambda argv, settings=None: (argv, None),
+    )
+    monkeypatch.setattr(
+        "openharness.utils.shell.shutil.which",
+        lambda name: "/usr/bin/bash" if name == "bash" else None,
+    )
+
+    await create_shell_subprocess(
+        "echo hi",
+        cwd=tmp_path,
+        settings=Settings(),
+    )
+
+    assert captured["args"] == ("/usr/bin/bash", "-lc", "echo hi")
+    assert captured["kwargs"]["stdin"] is asyncio.subprocess.DEVNULL


### PR DESCRIPTION
## Problem

On Windows, `BashTool` and other shell callers hang indefinitely inside the React/Ink TUI because `bash -lc` inherits the TUI's PTY stdin and blocks.

## Root Cause

`create_shell_subprocess` defaults `stdin=None`, which causes `asyncio.create_subprocess_exec` to inherit the parent's stdin. On Windows with Git Bash, the login shell (`bash -lc`) blocks on the inherited PTY stdin.

Four out of six callers don't pass `stdin` explicitly:
- `bridge/session_runner.py` — no stdin
- `hooks/executor.py` — no stdin  
- `services/cron_scheduler.py` — no stdin
- `tools/remote_trigger_tool.py` — no stdin

The two callers that do pass stdin explicitly are fine:
- `tools/bash_tool.py` — `stdin=DEVNULL` ✅
- `tasks/manager.py` — `stdin=PIPE` ✅

## Fix

Change the default value of `stdin` from `None` to `asyncio.subprocess.DEVNULL` in `create_shell_subprocess`. This ensures callers that don't need stdin never accidentally inherit the TTY. Callers that pipe input (e.g. task manager with `stdin=PIPE`) already override explicitly and are unaffected.

## Testing

Existing test `test_bash_tool_uses_devnull_stdin_for_non_interactive_shell` already validates that `stdin=DEVNULL` is passed through correctly.

Fixes #177