### PR TITLE
feat(tui): add /quit alias and fix slash command Tab completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- `/quit` command alias for `/exit` in the TUI slash command registry.
+- Tab completion hint added to the CommandPicker footer in the React TUI.
 - `oh --dry-run` safe preview mode for inspecting resolved runtime settings, auth state, prompt assembly, commands, skills, tools, and configured MCP servers without executing the model or tools.
 - Built-in `minimax` provider profile so `oh setup` offers MiniMax as a first-class provider choice, with `MINIMAX_API_KEY` auth source, `MiniMax-M2.7` as the default model, and `MiniMax-M2.7-highspeed` in the model picker.
 - Docker as an alternative sandbox backend (`sandbox.backend = "docker"`) for stronger execution isolation with configurable resource limits, network isolation, and automatic image management.
@@ -25,6 +27,8 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- React TUI Tab completion for slash commands now resets the cursor to end-of-input after selecting a command. Previously, completing a command via Tab left the cursor at position 0, making further edits confusing.
+- Tab completion no longer appends a trailing space after the completed command.
 - React TUI prompt input now treats the raw DEL byte (`0x7f`) as backward delete while preserving true forward-delete escape sequences, fixing backspace failures seen in some macOS terminal environments.
 - `todo_write` tool now updates an existing unchecked item in-place when `checked=True` instead of appending a duplicate `[x]` line.
 

--- a/frontend/terminal/src/App.tsx
+++ b/frontend/terminal/src/App.tsx
@@ -61,6 +61,7 @@ function AppInner({config}: {config: FrontendConfig}): React.JSX.Element {
 	const {exit} = useApp();
 	const {theme, setThemeName} = useTheme();
 	const [input, setInput] = useState('');
+	const [completionKey, setCompletionKey] = useState(0);
 	const [modalInput, setModalInput] = useState('');
 	const [history, setHistory] = useState<string[]>([]);
 	const [historyIndex, setHistoryIndex] = useState(-1);
@@ -297,7 +298,8 @@ function AppInner({config}: {config: FrontendConfig}): React.JSX.Element {
 			if (key.tab) {
 				const selected = commandHints[pickerIndex];
 				if (selected) {
-					setInput(selected + ' ');
+					setInput(selected);
+					setCompletionKey((k) => k + 1);
 				}
 				return;
 			}
@@ -448,6 +450,7 @@ function AppInner({config}: {config: FrontendConfig}): React.JSX.Element {
 					toolName={session.busy ? currentToolName : undefined}
 					statusLabel={session.busy ? (session.busyLabel ?? (currentToolName ? `Running ${currentToolName}...` : 'Running agent loop...')) : undefined}
 					suppressSubmit={showPicker}
+					inputKey={completionKey}
 				/>
 			)}
 

--- a/frontend/terminal/src/components/CommandPicker.tsx
+++ b/frontend/terminal/src/components/CommandPicker.tsx
@@ -27,7 +27,7 @@ function CommandPickerInner({
 					</Box>
 				);
 			})}
-			<Text dimColor> {'\u2191\u2193'} navigate{'  '}{'\u23CE'} select{'  '}esc dismiss</Text>
+			<Text dimColor> {'\u2191\u2193'} navigate{'  '}{'\u23CE'} select{'  '}tab complete{'  '}esc dismiss</Text>
 		</Box>
 	);
 }

--- a/frontend/terminal/src/components/PromptInput.tsx
+++ b/frontend/terminal/src/components/PromptInput.tsx
@@ -164,6 +164,7 @@ export function PromptInput({
 	toolName,
 	suppressSubmit,
 	statusLabel,
+	inputKey,
 }: {
 	busy: boolean;
 	input: string;
@@ -172,6 +173,7 @@ export function PromptInput({
 	toolName?: string;
 	suppressSubmit?: boolean;
 	statusLabel?: string;
+	inputKey?: number;
 }): React.JSX.Element {
 	const {theme} = useTheme();
 	const promptPrefix = busy ? '… ' : '> ';
@@ -186,6 +188,7 @@ export function PromptInput({
 				</Box>
 			) : null}
 			<MultilineTextInput
+				key={inputKey}
 				value={input}
 				onChange={setInput}
 				onSubmit={suppressSubmit || busy ? noop : onSubmit}

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -1811,6 +1811,7 @@ def create_default_command_registry(
 
     registry.register(SlashCommand("help", "Show available commands", _help_handler))
     registry.register(SlashCommand("exit", "Exit OpenHarness", _exit_handler))
+    registry.register(SlashCommand("quit", "Exit OpenHarness", _exit_handler))
     registry.register(SlashCommand("clear", "Clear conversation history", _clear_handler))
     registry.register(SlashCommand("version", "Show the installed OpenHarness version", _version_handler))
     registry.register(SlashCommand("status", "Show session status", _status_handler))


### PR DESCRIPTION
## Summary

Fix two UX issues with Tab completion for slash commands in the React TUI, and add `/quit` as a recognized alias for `/exit`.

Closes #183

## Motivation

When users press Tab to complete a slash command from the CommandPicker, the `MultilineTextInput` component retains its `cursorOffset` state from before the completion. Since the component's value changed externally but the component was not remounted, the cursor stays at offset 0. Any character typed after Tab is then inserted at the beginning of the completed text rather than at the end.

Additionally, a trailing space was unconditionally appended to the completed command, preventing immediate submission with Enter.

## Changes Made

- **`src/openharness/commands/registry.py`**: Register `/quit` as an alias for `/exit` using the same handler.
- **`frontend/terminal/src/App.tsx`**: Add a `completionKey` counter state. Increment it on every Tab completion and pass it to `PromptInput` as `inputKey`. Remove the trailing space from the completed command string.
- **`frontend/terminal/src/components/PromptInput.tsx`**: Accept and forward `inputKey` as the React `key` prop on `MultilineTextInput`, forcing a remount so `cursorOffset` resets to `value.length` after each Tab completion.
- **`frontend/terminal/src/components/CommandPicker.tsx`**: Add "tab complete" hint to the picker footer so users discover the shortcut.

## Testing

- [x] `uv run pytest -q` — 777 passed, 6 skipped
- [x] `uv run ruff check src tests scripts` — all checks passed
- [x] `npx tsc --noEmit` inside `frontend/terminal` — no type errors
- [x] Manual verification: Tab completion sets cursor at end, no trailing space, `/quit` recognized as a valid slash command.

## Breaking Changes

None.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Documentation updated (`CHANGELOG.md`)
- [x] No sensitive data included