### PR TITLE
fix(tui): tab completion cursor, trailing space, and /quit alias (#183)

### DIFF
--- a/frontend/terminal/src/App.tsx
+++ b/frontend/terminal/src/App.tsx
@@ -297,7 +297,11 @@ function AppInner({config}: {config: FrontendConfig}): React.JSX.Element {
 			if (key.tab) {
 				const selected = commandHints[pickerIndex];
 				if (selected) {
-					setInput(selected + ' ');
+					// Complete to the selected command with no trailing space —
+					// the user can hit Enter immediately to run it, or keep
+					// typing to add args. The trailing space made it look like
+					// Tab was "committing" with a token, which broke the flow.
+					setInput(selected);
 				}
 				return;
 			}

--- a/frontend/terminal/src/components/PromptInput.tsx
+++ b/frontend/terminal/src/components/PromptInput.tsx
@@ -25,10 +25,28 @@ function MultilineTextInput({
 	const [cursorOffset, setCursorOffset] = useState(value.length);
 	const {internal_eventEmitter} = useStdin();
 	const lastSequenceRef = useRef('');
+	// Tracks the last value this component produced via onChange. If the
+	// incoming `value` prop diverges from this, the change came from outside
+	// (tab completion, history recall, programmatic clear) and we should
+	// move the cursor to the end — otherwise the cursor stays wherever the
+	// user had it, which puts subsequent keystrokes in the middle of the
+	// newly-completed text. See HKUDS/OpenHarness#183.
+	const lastInternalValueRef = useRef<string>(value);
 
 	useEffect(() => {
-		setCursorOffset((previous) => Math.min(previous, value.length));
+		if (value === lastInternalValueRef.current) {
+			// Self-authored update; cursor was already positioned by the
+			// handler that called onChange.
+			return;
+		}
+		lastInternalValueRef.current = value;
+		setCursorOffset(value.length);
 	}, [value]);
+
+	const commitValue = (nextValue: string): void => {
+		lastInternalValueRef.current = nextValue;
+		onChange(nextValue);
+	};
 
 	useEffect(() => {
 		if (!focus) {
@@ -59,7 +77,7 @@ function MultilineTextInput({
 				if (key.shift) {
 					const nextValue = value.slice(0, cursorOffset) + '\n' + value.slice(cursorOffset);
 					setCursorOffset(cursorOffset + 1);
-					onChange(nextValue);
+					commitValue(nextValue);
 					return;
 				}
 				onSubmit?.(value);
@@ -82,7 +100,7 @@ function MultilineTextInput({
 				}
 				const nextValue = value.slice(0, cursorOffset - 1) + value.slice(cursorOffset);
 				setCursorOffset(cursorOffset - 1);
-				onChange(nextValue);
+				commitValue(nextValue);
 				return;
 			}
 
@@ -96,7 +114,7 @@ function MultilineTextInput({
 					}
 					const nextValue = value.slice(0, cursorOffset - 1) + value.slice(cursorOffset);
 					setCursorOffset(cursorOffset - 1);
-					onChange(nextValue);
+					commitValue(nextValue);
 					return;
 				}
 
@@ -104,7 +122,7 @@ function MultilineTextInput({
 					return;
 				}
 				const nextValue = value.slice(0, cursorOffset) + value.slice(cursorOffset + 1);
-				onChange(nextValue);
+				commitValue(nextValue);
 				return;
 			}
 
@@ -114,7 +132,7 @@ function MultilineTextInput({
 
 			const nextValue = value.slice(0, cursorOffset) + input + value.slice(cursorOffset);
 			setCursorOffset(cursorOffset + input.length);
-			onChange(nextValue);
+			commitValue(nextValue);
 		},
 		{isActive: focus},
 	);

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -104,17 +104,26 @@ class SlashCommand:
     handler: CommandHandler
     remote_invocable: bool = True
     remote_admin_opt_in: bool = False
+    aliases: tuple[str, ...] = ()
 
 
 class CommandRegistry:
     """Map slash commands to handlers."""
 
     def __init__(self) -> None:
+        # Primary commands keyed by canonical name, plus aliases pointing at
+        # the same SlashCommand instance. We keep a separate set of canonical
+        # names so help/listing output doesn't duplicate aliased entries.
         self._commands: dict[str, SlashCommand] = {}
+        self._canonical_names: list[str] = []
 
     def register(self, command: SlashCommand) -> None:
-        """Register a command."""
+        """Register a command, plus any aliases pointing at the same handler."""
+        if command.name not in self._commands:
+            self._canonical_names.append(command.name)
         self._commands[command.name] = command
+        for alias in command.aliases:
+            self._commands[alias] = command
 
     def lookup(self, raw_input: str) -> tuple[SlashCommand, str] | None:
         """Parse a slash command and return its handler plus raw args."""
@@ -129,13 +138,14 @@ class CommandRegistry:
     def help_text(self) -> str:
         """Return a formatted summary of all registered commands."""
         lines = ["Available commands:"]
-        for command in sorted(self._commands.values(), key=lambda item: item.name):
+        commands = [self._commands[name] for name in self._canonical_names]
+        for command in sorted(commands, key=lambda item: item.name):
             lines.append(f"/{command.name:<12} {command.description}")
         return "\n".join(lines)
 
     def list_commands(self) -> list[SlashCommand]:
-        """Return commands in registration order."""
-        return list(self._commands.values())
+        """Return canonical commands in registration order (aliases omitted)."""
+        return [self._commands[name] for name in self._canonical_names]
 
 
 def _run_git_command(cwd: str, *args: str) -> tuple[bool, str]:
@@ -1810,7 +1820,9 @@ def create_default_command_registry(
         )
 
     registry.register(SlashCommand("help", "Show available commands", _help_handler))
-    registry.register(SlashCommand("exit", "Exit OpenHarness", _exit_handler))
+    registry.register(
+        SlashCommand("exit", "Exit OpenHarness", _exit_handler, aliases=("quit",))
+    )
     registry.register(SlashCommand("clear", "Clear conversation history", _clear_handler))
     registry.register(SlashCommand("version", "Show the installed OpenHarness version", _version_handler))
     registry.register(SlashCommand("status", "Show session status", _status_handler))

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -841,3 +841,27 @@ async def test_git_commands_report_repository_state(tmp_path: Path, monkeypatch)
     commit_command, commit_args = registry.lookup("/commit initial commit")
     commit_result = await commit_command.handler(commit_args, context)
     assert "commit" in commit_result.message.lower()
+
+
+def test_quit_is_alias_for_exit():
+    """Regression for #183: /quit should resolve to the same handler as /exit."""
+    reg = create_default_command_registry()
+
+    exit_cmd, _ = reg.lookup("/exit")
+    quit_cmd, _ = reg.lookup("/quit")
+
+    assert exit_cmd is quit_cmd
+    assert quit_cmd.name == "exit"
+
+
+def test_help_and_list_do_not_duplicate_aliases():
+    """Aliases share a SlashCommand object; help/listing must not repeat it."""
+    reg = create_default_command_registry()
+
+    names = [cmd.name for cmd in reg.list_commands()]
+    assert names.count("exit") == 1
+    assert "quit" not in names  # alias is resolvable via lookup, not listed
+
+    help_text = reg.help_text()
+    assert help_text.count("/exit ") == 1
+    assert "/quit" not in help_text


### PR DESCRIPTION
Fixes #183.

## Problems

Three bugs in the React TUI slash-command flow, all reported in the same issue.

### 1. Trailing space on Tab-completion

`App.tsx` completed `/exit` to `/exit ` (note the space), so hitting Enter right after Tab would submit `/exit<space>` with an empty arg instead of running `/exit` directly.

### 2. Cursor stuck after programmatic setInput

`MultilineTextInput` kept its `cursorOffset` across `value` prop changes and only clamped the cursor *down* via `Math.min(prev, value.length)`. After Tab-completion (which grows the value), the cursor stayed at the old offset instead of moving to the end of the completed text. Subsequent keystrokes landed in the middle — e.g. typing `X` after Tab-completing `/exit` produced `/eXxit`. Same class of bug for history recall (`↑`), which also changes value externally.

### 3. `/quit` not registered

`/quit` is the other obvious word for "exit" and users were surprised when it didn't work.

## Fixes

### `frontend/terminal/src/App.tsx`
Drop the trailing space from the completion path. Users who want to pass an argument can type the space themselves.

### `frontend/terminal/src/components/PromptInput.tsx`
Track the last internally-authored value via `lastInternalValueRef`. On each `useEffect([value])`, if the incoming value matches the ref, the change came from our own `onChange` and the cursor was already positioned correctly by the handler — do nothing. Otherwise the change is external (tab completion, history recall, esc-clear) and we snap the cursor to the end. Wrapped all internal `onChange(nextValue)` calls in a `commitValue` helper that updates the ref before delegating.

### `src/openharness/commands/registry.py`
Added `aliases: tuple[str, ...] = ()` to `SlashCommand`. `CommandRegistry.register` now installs each alias under its own key pointing at the same command object. `help_text` / `list_commands` dedupe via a separate `_canonical_names` list so aliases resolve via `lookup` without cluttering the listing.

Then: `SlashCommand(\"exit\", ..., aliases=(\"quit\",))`.

## Testing

New Python unit tests in `tests/test_commands/test_registry.py`:

- `test_quit_is_alias_for_exit` — \`/exit\` and \`/quit\` resolve to the same `SlashCommand` object.
- `test_help_and_list_do_not_duplicate_aliases` — `list_commands()` has exactly one `exit` entry; \`/quit\` does not appear in \`help_text()\` output.

Both pass locally (`python3.12 -m pytest tests/test_commands/test_registry.py::test_quit_is_alias_for_exit tests/test_commands/test_registry.py::test_help_and_list_do_not_duplicate_aliases`). Rest of `test_registry.py` is unaffected by this change (one pre-existing failure in `test_auth_feedback_and_project_context_commands` was already failing on `main` because the test reads a real API key from the host environment; unrelated to this PR).

I don't have a node toolchain on this machine so I couldn't run the ink-based `PromptInput.test.tsx` harness, but the cursor fix is local to one component and the change is straightforward.

## Before / After

**Before:**
- Type `/`, picker opens, Tab → `/exit ` (with space), Enter → runs `/exit ` with empty arg
- Type `/`, Tab → cursor stays at offset 1, typing `X` produces `/Xxit ` (or similar garbled output)
- Type `/quit`, Enter → `Unknown command: quit`

**After:**
- Tab completes to `/exit`, Enter runs it cleanly
- Tab moves cursor to end, subsequent typing appends normally
- `/quit` resolves to the same handler as `/exit`