### PR TITLE
fix(channels): add missing proxy field to TelegramConfig

### DIFF
--- a/src/openharness/config/schema.py
+++ b/src/openharness/config/schema.py
@@ -34,6 +34,7 @@ class BaseChannelConfig(_CompatModel):
 class TelegramConfig(BaseChannelConfig):
     token: str = ""
     chat_id: str | None = None
+    proxy: str | None = None
 
 
 class SlackConfig(BaseChannelConfig):


### PR DESCRIPTION
The proxy field is referenced in telegram.py (builder.proxy / get_updates_proxy) but was never declared in the TelegramConfig schema. This causes an AttributeError at runtime if the proxy code path is reached.

Introduced when channels were ported from nanobot in ab37aac.

## Summary

• What problem does this PR solve?  
  TelegramConfig is missing the proxy field that telegram.py already references. When the proxy code path in TelegramChannel.start() is reached (self.config.proxy), it raises AttributeError because the field was never declared in the schema. This also means there is no way to configure a proxy for Telegram bot connections through settings.

• What changed?  
  Added proxy: str | None = None to TelegramConfig in src/openharness/config/schema.py. The consuming code in telegram.py (.proxy() / .get_updates_proxy() on the application builder) was already in place but the config field was omitted when channels were ported from nanobot in ab37aac.

## Validation

• [x] uv run ruff check src tests scripts
• [ ] uv run pytest -q 
• [ ] cd frontend/terminal && npx tsc --noEmit 

## Notes

- Related issue: N/A
- Follow-up work: None

