### PR TITLE
fix(gateway): add Windows support for gateway process lifecycle

### DIFF
--- a/ohmo/gateway/service.py
+++ b/ohmo/gateway/service.py
@@ -13,6 +13,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+if sys.platform == "win32":
+    import ctypes
+
 from openharness.channels.bus.events import OutboundMessage
 from openharness.channels.bus.queue import MessageBus
 from openharness.channels.impl.manager import ChannelManager
@@ -205,7 +208,22 @@ def start_gateway_process(cwd: str | Path | None = None, workspace: str | Path |
     if existing_pythonpath:
         pythonpath_entries.append(existing_pythonpath)
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+
+    popen_kwargs: dict = {
+        "cwd": service._cwd,
+        "stdout": None,
+        "stderr": None,
+        "env": env,
+    }
+    if sys.platform == "win32":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+        popen_kwargs["stdin"] = subprocess.DEVNULL
+    else:
+        popen_kwargs["start_new_session"] = True
+
     with service.log_file.open("a", encoding="utf-8") as log_file:
+        popen_kwargs["stdout"] = log_file
+        popen_kwargs["stderr"] = log_file
         process = subprocess.Popen(
             [
                 sys.executable,
@@ -218,55 +236,91 @@ def start_gateway_process(cwd: str | Path | None = None, workspace: str | Path |
                 "--workspace",
                 str(get_workspace_root(workspace)),
             ],
-            cwd=service._cwd,
-            stdout=log_file,
-            stderr=log_file,
-            start_new_session=True,
-            env=env,
+            **popen_kwargs,
         )
     return process.pid
 
 
 def _pid_is_running(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
+    if sys.platform == "win32":
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return exit_code.value == 259  # STILL_ACTIVE
+            return False
+        finally:
+            kernel32.CloseHandle(handle)
+    else:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
 
 
 def _iter_workspace_gateway_pids(workspace: str | Path | None = None) -> list[int]:
     root = str(get_workspace_root(workspace))
-    try:
-        result = subprocess.run(
-            ["ps", "-eo", "pid=,args="],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except Exception:
-        return []
-
-    current_pid = os.getpid()
-    pids: list[int] = []
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
+    if sys.platform == "win32":
         try:
-            pid_text, args = line.split(None, 1)
-            pid = int(pid_text)
-        except ValueError:
-            continue
-        if pid == current_pid:
-            continue
-        if "-m ohmo gateway run" not in args:
-            continue
-        if f"--workspace {root}" not in args:
-            continue
-        if _pid_is_running(pid):
-            pids.append(pid)
-    return pids
+            result = subprocess.run(
+                ["wmic", "process", "where",
+                 f"commandline like '%-m ohmo gateway run%' and commandline like '%--workspace {root}%'",
+                 "get", "processid"],
+                capture_output=True, text=True, check=True,
+            )
+        except Exception:
+            return []
+        current_pid = os.getpid()
+        pids: list[int] = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line or line.lower() == "processid":
+                continue
+            try:
+                pid = int(line)
+            except ValueError:
+                continue
+            if pid == current_pid:
+                continue
+            if _pid_is_running(pid):
+                pids.append(pid)
+        return pids
+    else:
+        try:
+            result = subprocess.run(
+                ["ps", "-eo", "pid=,args="],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except Exception:
+            return []
+
+        current_pid = os.getpid()
+        pids = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                pid_text, args = line.split(None, 1)
+                pid = int(pid_text)
+            except ValueError:
+                continue
+            if pid == current_pid:
+                continue
+            if "-m ohmo gateway run" not in args:
+                continue
+            if f"--workspace {root}" not in args:
+                continue
+            if _pid_is_running(pid):
+                pids.append(pid)
+        return pids
 
 
 def stop_gateway_process(cwd: str | Path | None = None, workspace: str | Path | None = None) -> bool:
@@ -286,9 +340,18 @@ def stop_gateway_process(cwd: str | Path | None = None, workspace: str | Path | 
     if not unique_pids:
         service.pid_file.unlink(missing_ok=True)
         return False
-    for pid in unique_pids:
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(pid, signal.SIGTERM)
+    if sys.platform == "win32":
+        for pid in unique_pids:
+            with contextlib.suppress(Exception):
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(pid)],
+                    capture_output=True,
+                    check=False,
+                )
+    else:
+        for pid in unique_pids:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGTERM)
     service.pid_file.unlink(missing_ok=True)
     service.write_state(running=False)
     return True


### PR DESCRIPTION
The ohmo gateway process management (start, find, stop) only worked on Unix-like systems. On Windows, all three operations fail:

- start_gateway_process: uses start_new_session=True (no equivalent on Windows; also lacks stdin=DEVNULL which causes the subprocess to inherit the parent's console input)
- _pid_is_running: uses os.kill(pid, 0) which raises PermissionError for processes the caller doesn't own on Windows
- _iter_workspace_gateway_pids: shells out to `ps`, which doesn't exist on Windows
- stop_gateway_process: uses os.kill(pid, SIGTERM), which is not supported on Windows

Replace each with a Windows-compatible path guarded by sys.platform:

- Start: CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS, stdin=DEVNULL
- PID check: OpenProcess/GetExitCodeProcess via ctypes (STILL_ACTIVE)
- PID listing: wmic process where commandline like ... get processid
- Stop: taskkill /F /T /PID

The Unix paths remain unchanged.

## Summary

- What problem does this PR solve?  
  The ohmo gateway process lifecycle management (start_gateway_process, _pid_is_running, _iter_workspace_gateway_pids, stop_gateway_process) only works on Unix-like systems. On Windows, every operation fails:
  - start_gateway_process uses start_new_session=True which has no Windows equivalent, and the subprocess inherits the parent's console input (no stdin=DEVNULL)
  - _pid_is_running uses os.kill(pid, 0) which raises PermissionError on Windows for processes the caller doesn't own
  - _iter_workspace_gateway_pids shells out to ps, which doesn't exist on Windows
  - stop_gateway_process uses os.kill(pid, SIGTERM), which is not supported on Windows

- What changed?  
  Added Windows-compatible paths for each operation, guarded by sys.platform == "win32":
  - Start: CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS + stdin=DEVNULL
  - PID check: OpenProcess/GetExitCodeProcess via ctypes (checks STILL_ACTIVE = 259)
  - PID listing: wmic process where commandline like ... get processid
  - Stop: taskkill /F /T /PID
  
  The Unix paths remain completely unchanged.
## Validation

- [x] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q` *(pre-existing failures on Windows unrelated to this change; ohmo/ directory has no test suite)*
- [ ] `cd frontend/terminal && npx tsc --noEmit` *(frontend not touched)*

## Notes

- Related issue: N/A
- Follow-up work: N/A
