### PR TITLE
[security] fix(feishu): contain inbound attachment filenames

### DIFF
--- a/src/openharness/channels/impl/feishu.py
+++ b/src/openharness/channels/impl/feishu.py
@@ -15,6 +15,7 @@ from openharness.channels.bus.queue import MessageBus
 from openharness.channels.impl.base import BaseChannel
 from openharness.channels.impl.base import resolve_channel_media_dir
 from openharness.config.schema import FeishuConfig
+from openharness.utils.helpers import safe_filename
 
 import importlib.util
 import logging
@@ -749,10 +750,20 @@ class FeishuChannel(BaseChannel):
                     filename = f"{file_key[:16]}{ext}"
 
         if data and filename:
-            file_path = media_dir / filename
+            safe_name = safe_filename(filename)
+            if not safe_name:
+                logger.warning("Rejected %s download with unsafe filename %r", msg_type, filename)
+                return None, f"[{msg_type}: download failed]"
+
+            media_root = media_dir.resolve()
+            file_path = (media_root / safe_name).resolve()
+            if not file_path.is_relative_to(media_root):
+                logger.warning("Rejected %s download outside media directory: %r", msg_type, filename)
+                return None, f"[{msg_type}: download failed]"
+
             file_path.write_bytes(data)
             logger.debug("Downloaded %s to %s", msg_type, file_path)
-            return str(file_path), f"[{msg_type}: {filename}]"
+            return str(file_path), f"[{msg_type}: {safe_name}]"
 
         return None, f"[{msg_type}: download failed]"
 

--- a/tests/test_channels/test_feishu_security.py
+++ b/tests/test_channels/test_feishu_security.py
@@ -1,0 +1,72 @@
+"""Security regressions for Feishu/Lark channel media handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openharness.channels.bus.queue import MessageBus
+from openharness.channels.impl.feishu import FeishuChannel
+from openharness.config.schema import FeishuConfig
+
+
+@pytest.mark.asyncio
+async def test_feishu_inbound_file_attachment_cannot_escape_media_dir(tmp_path: Path, monkeypatch):
+    """Remote Feishu filenames are metadata and must not be trusted as paths."""
+    workspace = tmp_path / "ohmo"
+    workspace.mkdir()
+    protected_file = workspace / "soul.md"
+    protected_file.write_text("ORIGINAL", encoding="utf-8")
+    monkeypatch.setenv("OHMO_WORKSPACE", str(workspace))
+
+    channel = FeishuChannel(
+        FeishuConfig(allow_from=["user-open-id"], react_emoji="eyes"), MessageBus()
+    )
+
+    def fake_download(message_id: str, file_key: str, resource_type: str = "file"):
+        assert message_id == "message-id"
+        assert file_key == "file-key"
+        return b"ATTACKER_OVERWRITE", "../../soul.md"
+
+    async def fake_add_reaction(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(channel, "_download_file_sync", fake_download)
+    monkeypatch.setattr(channel, "_add_reaction", fake_add_reaction)
+    monkeypatch.setattr(
+        channel, "_resolve_sender_display_name_sync", lambda sender_id: "Allowed User"
+    )
+
+    forwarded = {}
+
+    async def fake_handle_message(**kwargs):
+        forwarded.update(kwargs)
+
+    monkeypatch.setattr(channel, "_handle_message", fake_handle_message)
+
+    event = SimpleNamespace(
+        sender=SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="user-open-id"),
+        ),
+        message=SimpleNamespace(
+            message_id="message-id",
+            chat_id="chat-id",
+            chat_type="p2p",
+            message_type="file",
+            content=json.dumps({"file_key": "file-key"}),
+        ),
+    )
+
+    await channel._on_message(SimpleNamespace(event=event))
+
+    media_dir = workspace / "attachments" / "feishu"
+    saved_paths = [Path(path).resolve() for path in forwarded["media"]]
+    assert protected_file.read_text(encoding="utf-8") == "ORIGINAL"
+    assert saved_paths == [(media_dir / "soul.md").resolve()]
+    assert saved_paths[0].read_bytes() == b"ATTACKER_OVERWRITE"
+    assert saved_paths[0].is_relative_to(media_dir.resolve())
+    assert "../../" not in forwarded["content"]


### PR DESCRIPTION
## Summary
This PR hardens the Feishu/Lark inbound attachment boundary so remote attachment filenames are treated as untrusted metadata rather than filesystem paths.

- Sanitizes Feishu/Lark download filenames before saving inbound media.
- Verifies the resolved write path remains inside the channel media directory.
- Adds a realistic inbound-message regression test that exercises `_on_message()` with attacker-controlled attachment metadata.

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Feishu/Lark attachment filename traversal | An allowed Feishu sender could cause an inbound attachment to be written outside `attachments/feishu`, potentially overwriting workspace files such as `soul.md` or `gateway.json` in deployments using `OHMO_WORKSPACE`. | High |

## Before this PR
- `FeishuChannel._download_and_save_media()` joined the SDK-provided filename directly with the channel media directory.
- A filename such as `../../soul.md` resolved outside `attachments/feishu`.
- There was no regression test covering attacker-controlled Feishu/Lark attachment filename metadata through the inbound message path.

## After this PR
- Feishu/Lark filenames are passed through `safe_filename()` before use.
- Empty or unsafe sanitized names are rejected before writing bytes.
- The final resolved path is checked to remain under the resolved media root.
- A regression test proves a hostile filename cannot overwrite a sibling workspace file.

## Why this matters
Inbound channel attachments cross a remote-to-local trust boundary. Feishu/Lark file metadata is not a safe path input: it is remote-controlled display metadata. Without basename/sanitization and resolved-path containment, an allowed remote sender can turn an attachment upload into a local workspace file write.

## Attack flow
```text
Allowed Feishu sender uploads an attachment named "../../soul.md"
    -> Feishu/Lark SDK returns response.file_name="../../soul.md"
        -> OpenHarness joins media_dir / filename
            -> write escapes attachments/feishu
                -> workspace file such as soul.md is overwritten
```

## Affected code
| Issue | Files |
|-------|-------|
| Feishu/Lark attachment filename traversal | `src/openharness/channels/impl/feishu.py`, `tests/test_channels/test_feishu_security.py` |

## Root cause
Issue 1: Feishu/Lark attachment filename traversal
- Direct cause: `_download_and_save_media()` trusted `response.file_name` as a filesystem path component.
- Boundary failure: remote attachment metadata was treated as a local path instead of an untrusted label that must be normalized and contained before I/O.

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Feishu/Lark attachment filename traversal | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H` |

Rationale:
- The vulnerable path is reachable by an allowed Feishu/Lark sender in a configured channel. Impact is bounded to files writable by the OpenHarness process, but workspace files can influence runtime behavior and availability.

## Safe reproduction steps
### 1. Feishu/Lark attachment filename traversal
1. Configure `OHMO_WORKSPACE` to a temporary workspace containing `soul.md` with safe marker content.
2. Simulate an allowed Feishu file message whose `file_key` is valid for processing.
3. Simulate the Feishu/Lark download response returning filename `../../soul.md` and bytes `ATTACKER_OVERWRITE`.
4. On vulnerable code, observe `<workspace>/soul.md` is overwritten.
5. With this PR, observe the saved file resolves under `<workspace>/attachments/feishu/soul.md` and the original workspace file remains unchanged.

## Expected vulnerable behavior
- Remote attachment filenames should never be able to select paths outside the channel media directory.
- Pre-patch behavior allowed traversal-style filenames to escape the media directory during `write_bytes()`.

## Changes in this PR
- Reuses the existing `safe_filename()` helper for Feishu/Lark inbound attachment names.
- Rejects empty/unsafe sanitized filenames before writing any media bytes.
- Resolves the final destination and enforces containment under the resolved Feishu media directory.
- Adds a regression test that drives `_on_message()` with a realistic Feishu file message and hostile filename metadata.

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Channel hardening | `src/openharness/channels/impl/feishu.py` | Sanitizes inbound filenames and enforces resolved-path containment before writing attachment bytes. |
| Tests | `tests/test_channels/test_feishu_security.py` | Adds an inbound Feishu file-message traversal regression test. |

## Maintainer impact
- Scope is limited to Feishu/Lark inbound media saving.
- Existing media download behavior is preserved for ordinary filenames.
- The test documents the security invariant: remote filenames are labels, not paths.

## Suggested fix rationale
- Sanitization prevents common path syntax from being interpreted as a path.
- The resolved containment check protects the actual write location immediately before I/O.
- The test uses the nearest practical public boundary (`_on_message()`), making the attack path easier to review than a helper-only test.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Feishu traversal regression test passes.
- [x] Channel and helper tests pass.
- [x] Touched Python files compile.
- [x] Ruff check passes on touched files.
- [x] Git whitespace check passes.

Executed with:
- `PYTHONPATH=src:. uv run pytest tests/test_channels/test_feishu_security.py::test_feishu_inbound_file_attachment_cannot_escape_media_dir -q`
- `PYTHONPATH=src:. uv run pytest tests/test_channels tests/test_utils/test_helpers.py -q`
- `PYTHONPATH=src:. uv run python -m py_compile src/openharness/channels/impl/feishu.py tests/test_channels/test_feishu_security.py`
- `PYTHONPATH=src:. uv run ruff check src/openharness/channels/impl/feishu.py tests/test_channels/test_feishu_security.py`
- `git diff --check`

## Token usage
- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact token totals were not available from the current tool/runtime telemetry; this PR follows the OSS vault token-usage template and marks usage as unknown rather than estimating.

## Disclosure notes
- Claims are bounded to Feishu/Lark inbound attachment filename handling and local files writable by the OpenHarness process.
- No unrelated channel or frontend behavior is changed.
