### PR TITLE
[security] fix(plugins): reject traversal names on uninstall

### DIFF
--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -870,7 +870,10 @@ def plugin_uninstall(
     """Uninstall a plugin."""
     from openharness.plugins.installer import uninstall_plugin
 
-    uninstall_plugin(name)
+    try:
+        uninstall_plugin(name)
+    except ValueError as exc:
+        raise typer.BadParameter("invalid plugin name") from exc
     print(f"Uninstalled plugin: {name}")
 
 

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -1051,7 +1051,11 @@ def create_default_command_registry(
             path = install_plugin_from_path(tokens[1])
             return CommandResult(message=f"Installed plugin to {path}")
         if tokens[0] == "uninstall" and len(tokens) == 2:
-            if uninstall_plugin(tokens[1]):
+            try:
+                removed = uninstall_plugin(tokens[1])
+            except ValueError:
+                return CommandResult(message=f"Invalid plugin name '{tokens[1]}'")
+            if removed:
                 return CommandResult(message=f"Uninstalled plugin '{tokens[1]}'")
             return CommandResult(message=f"Plugin '{tokens[1]}' not found")
         plugins = load_plugins(settings, context.cwd, extra_roots=context.extra_plugin_roots)

--- a/src/openharness/plugins/installer.py
+++ b/src/openharness/plugins/installer.py
@@ -8,6 +8,18 @@ from pathlib import Path
 from openharness.plugins.loader import get_user_plugins_dir
 
 
+def _resolve_user_plugin_dir(name: str) -> Path:
+    """Resolve a user plugin name to a direct child of the plugin directory."""
+    if not name or name != Path(name).name or "\\" in name:
+        raise ValueError("invalid plugin name")
+
+    plugins_dir = get_user_plugins_dir().resolve()
+    path = (plugins_dir / name).resolve()
+    if path.parent != plugins_dir:
+        raise ValueError("invalid plugin name")
+    return path
+
+
 def install_plugin_from_path(source: str | Path) -> Path:
     """Install a plugin directory into the user plugin directory."""
     src = Path(source).resolve()
@@ -20,7 +32,7 @@ def install_plugin_from_path(source: str | Path) -> Path:
 
 def uninstall_plugin(name: str) -> bool:
     """Remove a user plugin by directory name."""
-    path = get_user_plugins_dir() / name
+    path = _resolve_user_plugin_dir(name)
     if not path.exists():
         return False
     shutil.rmtree(path)

--- a/tests/test_commands/test_command_flows.py
+++ b/tests/test_commands/test_command_flows.py
@@ -151,3 +151,22 @@ async def test_plugin_command_lifecycle_flow(tmp_path: Path, monkeypatch):
     uninstall_command, uninstall_args = registry.lookup("/plugin uninstall fixture-plugin")
     uninstall_result = await uninstall_command.handler(uninstall_args, context)
     assert "Uninstalled plugin" in uninstall_result.message
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_rejects_traversal_uninstall_without_deleting_sibling(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    context = _build_context(tmp_path)
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "marker.txt").write_text("keep", encoding="utf-8")
+
+    uninstall_command, uninstall_args = registry.lookup("/plugin uninstall ../../victim")
+    uninstall_result = await uninstall_command.handler(uninstall_args, context)
+
+    assert "Invalid plugin name" in uninstall_result.message
+    assert victim.exists()
+    assert (victim / "marker.txt").read_text(encoding="utf-8") == "keep"

--- a/tests/test_plugins/test_lifecycle_flow.py
+++ b/tests/test_plugins/test_lifecycle_flow.py
@@ -92,3 +92,18 @@ async def test_plugin_install_load_and_uninstall_flow(tmp_path: Path, monkeypatc
 
     assert uninstall_plugin("fixture-plugin") is True
     assert load_plugins(load_settings(), project) == []
+
+
+def test_uninstall_plugin_rejects_traversal_name_without_deleting_sibling(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "marker.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid plugin name"):
+        uninstall_plugin("../../victim")
+
+    assert victim.exists()
+    assert (victim / "marker.txt").read_text(encoding="utf-8") == "keep"


### PR DESCRIPTION
## Summary
This PR hardens plugin uninstall path handling so plugin names are treated as identifiers rather than filesystem paths.

- Rejects traversal, nested path, absolute path, empty, and backslash-containing plugin names before deletion.
- Resolves the uninstall target and requires it to be a direct child of the user plugin directory.
- Adds direct installer and slash-command regressions that prove `../../victim` cannot delete a sibling directory.

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Plugin uninstall path traversal | A caller who can invoke plugin uninstall with an untrusted name could delete process-writable directories outside the OpenHarness user plugin directory. | High |

## Before this PR
- `uninstall_plugin()` joined `get_user_plugins_dir() / name` directly.
- A name such as `../../victim` could resolve outside the plugin directory.
- `shutil.rmtree()` then deleted the resolved external directory if it existed.
- The slash-command path returned a successful uninstall message for the traversal name.

## After this PR
- Plugin uninstall names must be direct plugin directory names, not paths.
- The resolved uninstall target must have the user plugin directory as its direct parent.
- Invalid names are rejected before `shutil.rmtree()` is reached.
- Slash-command and CLI entrypoints report invalid names instead of deleting outside the plugin root.

## Why this matters
Plugin management is a privileged local filesystem operation. The plugin name argument is a boundary between an identifier and a destructive path operation. Without direct-child validation immediately before deletion, an operator command, script, or exposed plugin-management path can turn a plugin name into an arbitrary directory deletion primitive for process-writable paths.

## Attack flow
```text
Caller passes plugin name "../../victim"
    -> uninstall_plugin() joins get_user_plugins_dir() / name
        -> path resolves outside the plugins directory
            -> shutil.rmtree() deletes an unrelated sibling directory
```

## Adjacent public context
PR #156 previously made plugin lifecycle commands local-only by default and fixed remote exposure of plugin lifecycle controls. This PR addresses a distinct remaining issue inside the plugin uninstall implementation itself: even for local/operator-controlled plugin management, the uninstall name must be validated as an identifier before reaching `shutil.rmtree()`.

## Affected code
| Issue | Files |
|-------|-------|
| Plugin uninstall path traversal | `src/openharness/plugins/installer.py`, `src/openharness/commands/registry.py`, `src/openharness/cli.py`, `tests/test_plugins/test_lifecycle_flow.py`, `tests/test_commands/test_command_flows.py` |

## Root cause
Issue 1: Plugin uninstall path traversal
- Direct cause: the uninstall path was constructed from raw plugin name input and passed to `shutil.rmtree()`.
- Boundary failure: a plugin identifier was treated as a path, and destructive filesystem action did not re-check containment immediately before deletion.

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Plugin uninstall path traversal | 7.1 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H` |

Rationale:
- The issue requires the ability to invoke plugin uninstall, so it is not unauthenticated remote code execution. The impact is high for integrity and availability because `shutil.rmtree()` can remove process-writable directories outside the intended plugin root.

## Safe reproduction steps
### 1. Plugin uninstall path traversal
1. Set `OPENHARNESS_CONFIG_DIR` to a temporary config directory.
2. Create a sibling directory named `victim` with a marker file.
3. Invoke plugin uninstall with name `../../victim`, or the slash command `/plugin uninstall ../../victim`.
4. On vulnerable code, observe the sibling `victim` directory is deleted and the command reports success.
5. With this PR, observe the command returns `Invalid plugin name` and the sibling directory remains intact.

## Expected vulnerable behavior
- Plugin uninstall should only delete a direct child of the OpenHarness user plugin directory.
- Pre-patch behavior allowed traversal-style names to delete outside that directory.

## Changes in this PR
- Adds `_resolve_user_plugin_dir()` to normalize and validate uninstall targets.
- Rejects empty names, path names, backslash-containing names, and any resolved target whose parent is not the plugin directory.
- Updates the slash-command plugin handler to return a bounded invalid-name message instead of propagating the raw delete path.
- Updates the CLI plugin uninstall command to surface invalid names as a `typer.BadParameter`.
- Adds direct installer and slash-command regression tests for `../../victim`.

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Plugin uninstall hardening | `src/openharness/plugins/installer.py` | Validates plugin names and direct-child containment before deletion. |
| Entrypoints | `src/openharness/commands/registry.py`, `src/openharness/cli.py` | Converts invalid names into user-facing errors. |
| Tests | `tests/test_plugins/test_lifecycle_flow.py`, `tests/test_commands/test_command_flows.py` | Adds direct and slash-command traversal deletion regressions. |

## Maintainer impact
- Scope is limited to plugin uninstall.
- Existing normal plugin uninstall behavior is preserved for direct plugin directory names.
- The invariant is explicit: plugin names are identifiers, not paths.

## Suggested fix rationale
- Direct-child validation is stricter than a broad `relative_to()` check and avoids accidentally supporting nested deletion paths.
- The containment check happens immediately before the destructive `rmtree()` operation.
- Slash-command coverage demonstrates the realistic operator-facing path, while the direct installer test protects the core helper.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Direct plugin uninstall traversal regression passes.
- [x] Slash-command plugin uninstall traversal regression passes.
- [x] Plugin and command tests pass.
- [x] Touched Python files compile.
- [x] Ruff check passes on touched files.
- [x] Git whitespace check passes.

Executed with:
- `PYTHONPATH=src:. uv run pytest tests/test_plugins/test_lifecycle_flow.py::test_uninstall_plugin_rejects_traversal_name_without_deleting_sibling tests/test_commands/test_command_flows.py::test_plugin_command_rejects_traversal_uninstall_without_deleting_sibling -q`
- `PYTHONPATH=src:. uv run pytest tests/test_plugins tests/test_commands -q`
- `PYTHONPATH=src:. uv run python -m py_compile src/openharness/plugins/installer.py src/openharness/commands/registry.py src/openharness/cli.py tests/test_plugins/test_lifecycle_flow.py tests/test_commands/test_command_flows.py`
- `PYTHONPATH=src:. uv run ruff check src/openharness/plugins/installer.py src/openharness/commands/registry.py src/openharness/cli.py tests/test_plugins/test_lifecycle_flow.py tests/test_commands/test_command_flows.py`
- `git diff --check`

## Token usage
- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact token totals were not available from the current tool/runtime telemetry; this PR follows the OSS vault token-usage template and marks usage as unknown rather than estimating.

## Disclosure notes
- This is framed as plugin-management path traversal/destructive filesystem hardening, not unauthenticated RCE.
- Claims are bounded to callers that can invoke plugin uninstall and files/directories writable by the OpenHarness process.
