### PR TITLE
fix(tools): prevent subprocess stderr pipe deadlocks in glob, grep, bash, and session_runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Fixed `glob` and `grep` tools hanging indefinitely when the `rg` subprocess produced enough stderr output to fill the OS pipe buffer. `stderr` is now redirected to `DEVNULL` so it is discarded rather than blocking the child process.
+- Fixed `bash_tool` hanging after a timed-out command when the subprocess stdout stream stayed open. `_read_remaining_output` now applies a 2-second `asyncio.wait_for` timeout so the tool always returns promptly.
+- Fixed `session_runner` background task deadlock caused by an unread `stderr=PIPE` stream. The subprocess now uses `stderr=STDOUT` so all output merges into the single readable stdout pipe.
 - React TUI prompt input now treats the raw DEL byte (`0x7f`) as backward delete while preserving true forward-delete escape sequences, fixing backspace failures seen in some macOS terminal environments.
 - `todo_write` tool now updates an existing unchecked item in-place when `checked=True` instead of appending a duplicate `[x]` line.
 

--- a/src/openharness/bridge/session_runner.py
+++ b/src/openharness/bridge/session_runner.py
@@ -41,6 +41,6 @@ async def spawn_session(
         command,
         cwd=resolved_cwd,
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
     )
     return SessionHandle(session_id=session_id, process=process, cwd=resolved_cwd)

--- a/src/openharness/tools/bash_tool.py
+++ b/src/openharness/tools/bash_tool.py
@@ -13,6 +13,9 @@ from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
 from openharness.utils.shell import create_shell_subprocess
 
 
+_READ_REMAINING_OUTPUT_TIMEOUT_SECONDS = 2.0
+
+
 class BashToolInput(BaseModel):
     """Arguments for the bash tool."""
 
@@ -100,7 +103,14 @@ async def _terminate_process(process: asyncio.subprocess.Process, *, force: bool
 async def _read_remaining_output(process: asyncio.subprocess.Process) -> bytearray:
     output_buffer = bytearray()
     if process.stdout is not None:
-        output_buffer.extend(await process.stdout.read())
+        try:
+            remaining = await asyncio.wait_for(
+                process.stdout.read(),
+                timeout=_READ_REMAINING_OUTPUT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            remaining = b""
+        output_buffer.extend(remaining)
     return output_buffer
 
 

--- a/src/openharness/tools/glob_tool.py
+++ b/src/openharness/tools/glob_tool.py
@@ -6,7 +6,7 @@ import asyncio
 import shutil
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
 
@@ -14,7 +14,10 @@ from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
 class GlobToolInput(BaseModel):
     """Arguments for the glob tool."""
 
-    pattern: str = Field(description="Glob pattern relative to the working directory")
+    pattern: str = Field(
+        description="Glob pattern relative to the working directory",
+        validation_alias=AliasChoices("pattern", "path"),
+    )
     root: str | None = Field(default=None, description="Optional search root")
     limit: int = Field(default=200, ge=1, le=5000)
 
@@ -62,6 +65,9 @@ def _looks_like_git_repo(path: Path) -> bool:
     return False
 
 
+_GLOB_RG_TIMEOUT_SECONDS = 30.0
+
+
 async def _glob(root: Path, pattern: str, *, limit: int) -> list[str]:
     """Fast glob implementation.
 
@@ -86,18 +92,19 @@ async def _glob(root: Path, pattern: str, *, limit: int) -> list[str]:
                 cmd,
                 cwd=root,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
             )
         else:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
                 cwd=str(root),
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
             )
 
         lines: list[str] = []
-        try:
+
+        async def _read_stdout() -> None:
             assert process.stdout is not None
             while len(lines) < limit:
                 raw = await process.stdout.readline()
@@ -106,10 +113,26 @@ async def _glob(root: Path, pattern: str, *, limit: int) -> list[str]:
                 line = raw.decode("utf-8", errors="replace").strip()
                 if line:
                     lines.append(line)
+
+        try:
+            try:
+                await asyncio.wait_for(_read_stdout(), timeout=_GLOB_RG_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                pass
         finally:
-            if len(lines) >= limit and process.returncode is None:
-                process.terminate()
-            await process.wait()
+            if process.returncode is None:
+                try:
+                    process.terminate()
+                except ProcessLookupError:
+                    pass
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    try:
+                        process.kill()
+                    except ProcessLookupError:
+                        pass
+                    await process.wait()
 
         # Sorting keeps unit tests and user output deterministic for small results.
         lines.sort()

--- a/src/openharness/tools/grep_tool.py
+++ b/src/openharness/tools/grep_tool.py
@@ -186,14 +186,14 @@ async def _rg_grep(
             cmd,
             cwd=root,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
         )
     else:
         process = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=str(root),
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
             limit=8 * 1024 * 1024,  # 8 MB per line — avoids LimitOverrunError on long lines
         )
 
@@ -254,14 +254,14 @@ async def _rg_grep_file(
             cmd,
             cwd=path.parent,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
         )
     else:
         process = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=str(path.parent),
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
             limit=8 * 1024 * 1024,  # 8 MB per line — avoids LimitOverrunError on long lines
         )
 

--- a/tests/test_bridge/test_core.py
+++ b/tests/test_bridge/test_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import asyncio
 
 import pytest
 
@@ -27,3 +28,34 @@ async def test_spawn_session_and_kill(tmp_path: Path):
     assert handle.process.returncode is None
     await handle.kill()
     assert handle.process.returncode is not None
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_merges_stderr_into_stdout(monkeypatch, tmp_path: Path):
+    seen_kwargs = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        def terminate(self):
+            pass
+
+        def kill(self):
+            pass
+
+        async def wait(self):
+            return 0
+
+    async def fake_create_shell_subprocess(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        "openharness.bridge.session_runner.create_shell_subprocess",
+        fake_create_shell_subprocess,
+    )
+
+    await spawn_session(session_id="s1", command="printf err >&2", cwd=tmp_path)
+
+    assert seen_kwargs["stdout"] is asyncio.subprocess.PIPE
+    assert seen_kwargs["stderr"] is asyncio.subprocess.STDOUT

--- a/tests/test_tools/test_bash_tool.py
+++ b/tests/test_tools/test_bash_tool.py
@@ -5,6 +5,7 @@ import pytest
 
 from openharness.tools.base import ToolExecutionContext
 from openharness.tools.bash_tool import BashTool, BashToolInput
+import openharness.tools.bash_tool as bash_tool_module
 
 
 class _FakeStdout:
@@ -63,6 +64,12 @@ class _FakeProcess:
     def kill(self):
         self.killed = True
         self.returncode = -9
+
+
+class _NeverClosingStdout:
+    async def read(self, _size: int = -1):
+        await asyncio.sleep(60)
+        return b""
 
 
 @pytest.mark.asyncio
@@ -179,3 +186,30 @@ async def test_bash_tool_uses_devnull_stdin_for_non_interactive_shell(monkeypatc
     assert result.is_error is False
     assert seen_kwargs["stdin"] == asyncio.subprocess.DEVNULL
     assert seen_kwargs["prefer_pty"] is True
+
+
+@pytest.mark.asyncio
+async def test_bash_tool_timeout_does_not_hang_when_stdout_stays_open(monkeypatch, tmp_path: Path):
+    process = _FakeProcess(stdout=_NeverClosingStdout())
+
+    async def fake_create_shell_subprocess(*args, **kwargs):
+        return process
+
+    monkeypatch.setattr("openharness.tools.bash_tool.create_shell_subprocess", fake_create_shell_subprocess)
+    monkeypatch.setattr(
+        bash_tool_module,
+        "_READ_REMAINING_OUTPUT_TIMEOUT_SECONDS",
+        0.05,
+        raising=False,
+    )
+
+    result = await asyncio.wait_for(
+        BashTool().execute(
+            BashToolInput(command="sleep 10", timeout_seconds=1),
+            ToolExecutionContext(cwd=tmp_path),
+        ),
+        timeout=2.0,
+    )
+
+    assert result.is_error is True
+    assert result.metadata["timed_out"] is True

--- a/tests/test_tools/test_core_tools.py
+++ b/tests/test_tools/test_core_tools.py
@@ -65,6 +65,10 @@ async def test_glob_and_grep(tmp_path: Path):
     glob_result = await GlobTool().execute(GlobToolInput(pattern="*.py"), context)
     assert glob_result.output.splitlines() == ["a.py", "b.py"]
 
+    aliased_input = GlobTool().input_model.model_validate({"path": "*.py"})
+    aliased_glob_result = await GlobTool().execute(aliased_input, context)
+    assert aliased_glob_result.output.splitlines() == ["a.py", "b.py"]
+
     grep_result = await GrepTool().execute(
         GrepToolInput(pattern=r"def\s+beta", file_glob="*.py"),
         context,

--- a/tests/test_tools/test_grep_tool.py
+++ b/tests/test_tools/test_grep_tool.py
@@ -92,3 +92,57 @@ async def test_grep_tool_uses_large_stream_limit_and_skips_valueerror(monkeypatc
     assert result.is_error is False
     assert result.output == "(no matches)"
     assert seen_kwargs["limit"] == 8 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_grep_tool_discards_rg_stderr_for_directory_search(monkeypatch, tmp_path: Path):
+    tool = GrepTool()
+    monkeypatch.setattr("openharness.tools.grep_tool.shutil.which", lambda _: "/usr/bin/rg")
+    fake_process = _FakeProcess(stdout=_ValueErrorThenEofStdout())
+    seen_kwargs = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        fake_process.returncode = 1
+        return fake_process
+
+    monkeypatch.setattr(
+        "openharness.tools.grep_tool.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await tool.execute(
+        GrepToolInput(pattern="foo"),
+        type("Ctx", (), {"cwd": tmp_path})(),
+    )
+
+    assert result.is_error is False
+    assert seen_kwargs["stderr"] is asyncio.subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_grep_tool_discards_rg_stderr_for_file_search(monkeypatch, tmp_path: Path):
+    tool = GrepTool()
+    monkeypatch.setattr("openharness.tools.grep_tool.shutil.which", lambda _: "/usr/bin/rg")
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("hello\n", encoding="utf-8")
+    fake_process = _FakeProcess(stdout=_ValueErrorThenEofStdout())
+    seen_kwargs = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        fake_process.returncode = 1
+        return fake_process
+
+    monkeypatch.setattr(
+        "openharness.tools.grep_tool.asyncio.create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await tool.execute(
+        GrepToolInput(pattern="foo", root=str(file_path)),
+        type("Ctx", (), {"cwd": tmp_path})(),
+    )
+
+    assert result.is_error is False
+    assert seen_kwargs["stderr"] is asyncio.subprocess.DEVNULL


### PR DESCRIPTION
## Summary

- **Problem:** When a subprocess (e.g. `rg`) wrote enough output to stderr to
  fill the OS pipe buffer, the child process blocked waiting for the buffer to
  drain. Because OpenHarness only consumed stdout, the stderr pipe was never
  read, causing the subprocess — and the tool call — to hang indefinitely and
  making background agent tasks unresponsive. The same issue existed in
  `session_runner.py`. A related hang in `bash_tool` occurred because
  `_read_remaining_output` called `stdout.read()` with no timeout.

- **Changes:**
  - `glob_tool.py` / `grep_tool.py`: changed `stderr=PIPE` → `stderr=DEVNULL`
    so the child's stderr is discarded rather than buffered; added a 30-second
    `asyncio.wait_for` guard around the rg stdout reader in `glob_tool`.
  - `bash_tool.py`: wrapped `_read_remaining_output`'s `stdout.read()` in a
    2-second `asyncio.wait_for` so the tool always exits promptly after a
    timeout.
  - `session_runner.py`: changed `stderr=PIPE` → `stderr=STDOUT` so stderr
    merges into the already-consumed stdout stream.
  - `glob_tool.py`: added `AliasChoices("pattern", "path")` to `GlobToolInput`
    so the legacy `path` key sent by some LLM prompts is accepted without error.
  - `CHANGELOG.md`: added entries under `[Unreleased] → Fixed`.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q` — all 24 affected tests pass

## Notes

- Related issue: Closes #204
- Follow-up work: none; the pipe-drain pattern is now consistent across all
  subprocess-spawning tools.