### PR TITLE
feat(providers): add Qwen (DashScope) to default provider profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- Built-in `qwen` provider profile so `oh setup` offers Qwen (DashScope) as a first-class provider choice, with `dashscope_api_key` auth source, `qwen-plus` as the default model, and the DashScope OpenAI-compatible endpoint.
 - Plugin tool discovery: plugins can now provide `BaseTool` subclasses in a `<plugin>/tools/` directory and they are auto-discovered, instantiated, and registered in the tool registry at runtime. Add `tools_dir` to `plugin.json` (defaults to `"tools"`).
 - `oh --dry-run` safe preview mode for inspecting resolved runtime settings, auth state, prompt assembly, commands, skills, tools, and configured MCP servers without executing the model or tools.
 - Built-in `minimax` provider profile so `oh setup` offers MiniMax as a first-class provider choice, with `MINIMAX_API_KEY` auth source, `MiniMax-M2.7` as the default model, and `MiniMax-M2.7-highspeed` in the model picker.

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -240,6 +240,14 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             default_model="MiniMax-M2.7",
             base_url="https://api.minimax.io/v1",
         ),
+        "qwen": ProviderProfile(
+            label="Qwen (DashScope)",
+            provider="dashscope",
+            api_format="openai",
+            auth_source="dashscope_api_key",
+            default_model="qwen-plus",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        ),
     }
 
 

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -593,3 +593,80 @@ class TestMiniMaxProvider:
         assert materialized.model == "MiniMax-M2.7"
         assert materialized.provider == "minimax"
         assert materialized.api_format == "openai"
+
+
+class TestQwenProvider:
+    """Tests for Qwen (DashScope) provider profile and auth integration."""
+
+    def test_qwen_in_default_provider_profiles(self):
+        from openharness.config.settings import default_provider_profiles
+
+        profiles = default_provider_profiles()
+        assert "qwen" in profiles
+        profile = profiles["qwen"]
+        assert profile.provider == "dashscope"
+        assert profile.api_format == "openai"
+        assert profile.auth_source == "dashscope_api_key"
+        assert profile.default_model == "qwen-plus"
+        assert profile.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+    def test_auth_source_provider_name_qwen(self):
+        from openharness.config.settings import auth_source_provider_name
+
+        assert auth_source_provider_name("dashscope_api_key") == "dashscope"
+
+    def test_default_auth_source_for_qwen_provider(self):
+        from openharness.config.settings import default_auth_source_for_provider
+
+        assert default_auth_source_for_provider("dashscope") == "dashscope_api_key"
+
+    def test_resolve_auth_reads_qwen_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "dashscope-test-key")
+        settings = Settings(
+            active_profile="qwen",
+            profiles={
+                "qwen": ProviderProfile(
+                    label="Qwen (DashScope)",
+                    provider="dashscope",
+                    api_format="openai",
+                    auth_source="dashscope_api_key",
+                    default_model="qwen-plus",
+                    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                )
+            },
+        )
+        resolved = settings.resolve_auth()
+        assert resolved.value == "dashscope-test-key"
+        assert "DASHSCOPE_API_KEY" in resolved.source
+
+    def test_display_model_setting_for_qwen(self):
+        from openharness.config.settings import display_model_setting
+
+        profile = ProviderProfile(
+            label="Qwen (DashScope)",
+            provider="dashscope",
+            api_format="openai",
+            auth_source="dashscope_api_key",
+            default_model="qwen-plus",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        )
+        assert display_model_setting(profile) == "qwen-plus"
+
+    def test_materialize_active_profile_qwen(self):
+        settings = Settings(
+            active_profile="qwen",
+            profiles={
+                "qwen": ProviderProfile(
+                    label="Qwen (DashScope)",
+                    provider="dashscope",
+                    api_format="openai",
+                    auth_source="dashscope_api_key",
+                    default_model="qwen-plus",
+                    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+                )
+            },
+        )
+        materialized = settings.materialize_active_profile()
+        assert materialized.model == "qwen-plus"
+        assert materialized.provider == "dashscope"
+        assert materialized.api_format == "openai"


### PR DESCRIPTION
## Summary

Add Qwen (DashScope) as a first-class built-in provider so users can access it via `oh setup` and `oh provider use qwen`.

## Changes

- **`src/openharness/config/settings.py`**: Add `qwen` profile to `default_provider_profiles()` with:
  - Provider: `dashscope`
  - API format: `openai` (OpenAI-compatible endpoint)
  - Auth source: `dashscope_api_key` (`DASHSCOPE_API_KEY` env var)
  - Default model: `qwen-plus`
  - Base URL: `https://dashscope.aliyuncs.com/compatible-mode/v1`

- **`tests/test_config/test_settings.py`**: Add `TestQwenProvider` test class with 6 test cases covering:
  - Profile registration in default catalog
  - Auth source name resolution
  - Default auth source mapping
  - Environment variable auth resolution
  - Display model setting
  - Profile materialization

- **`CHANGELOG.md`**: Add entry under `[Unreleased]`

## Context

The `ProviderSpec` for dashscope already existed in `registry.py` (with Qwen keyword detection), but lacked a corresponding `ProviderProfile` in `default_provider_profiles()`. This meant Qwen was auto-detectable from model names/URLs but not directly selectable via `oh provider list/use`. This change completes the integration following the same pattern as existing providers (minimax, gemini, moonshot).