### PR TITLE
fix: catch re.error in _python_grep_files to prevent crash on invalid regex

### DIFF
--- a/src/openharness/tools/grep_tool.py
+++ b/src/openharness/tools/grep_tool.py
@@ -104,7 +104,7 @@ def _python_grep_files(
     try:
         compiled = re.compile(pattern, flags)
     except re.error as exc:
-        return f"(invalid regex pattern: {exc})"
+        return f"(invalid regex pattern '{pattern}': {exc})"
     collected: list[str] = []
 
     for path in paths:

--- a/src/openharness/tools/grep_tool.py
+++ b/src/openharness/tools/grep_tool.py
@@ -101,7 +101,10 @@ def _python_grep_files(
 ) -> str:
     # Python fallback (kept for portability).
     flags = 0 if case_sensitive else re.IGNORECASE
-    compiled = re.compile(pattern, flags)
+    try:
+        compiled = re.compile(pattern, flags)
+    except re.error as exc:
+        return f"(invalid regex pattern: {exc})"
     collected: list[str] = []
 
     for path in paths:


### PR DESCRIPTION
## Summary

Fix #218 

