### PR TITLE
feat(provider): add ModelScope inference API support

### DIFF
--- a/src/openharness/api/registry.py
+++ b/src/openharness/api/registry.py
@@ -124,6 +124,20 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         is_local=False,
         is_oauth=False,
     ),
+    # ModelScope: OpenAI-compatible inference API
+    ProviderSpec(
+        name="modelscope",
+        keywords=("modelscope",),
+        env_key="MODELSCOPE_API_KEY",
+        display_name="ModelScope",
+        backend_type="openai_compat",
+        default_base_url="https://api-inference.modelscope.cn/v1",
+        detect_by_key_prefix="",
+        detect_by_base_keyword="modelscope",
+        is_gateway=False,
+        is_local=False,
+        is_oauth=False,
+    ),
     # === Standard cloud providers (matched by model-name keyword) ============
     # Anthropic: native SDK for claude-* models
     ProviderSpec(

--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -37,6 +37,7 @@ _KNOWN_PROVIDERS = [
     "moonshot",
     "gemini",
     "minimax",
+    "modelscope",
 ]
 
 _AUTH_SOURCES = [
@@ -51,6 +52,7 @@ _AUTH_SOURCES = [
     "moonshot_api_key",
     "gemini_api_key",
     "minimax_api_key",
+    "modelscope_api_key",
 ]
 
 _PROFILE_BY_PROVIDER = {
@@ -62,6 +64,7 @@ _PROFILE_BY_PROVIDER = {
     "moonshot": "moonshot",
     "gemini": "gemini",
     "minimax": "minimax",
+    "modelscope": "modelscope",
 }
 
 
@@ -154,6 +157,15 @@ class AuthManager:
                 from openharness.api.copilot_auth import load_copilot_auth
 
                 if load_copilot_auth():
+                    configured = True
+                    origin = "file"
+                    state = "configured"
+            elif source == "modelscope_api_key":
+                if os.environ.get("MODELSCOPE_API_KEY"):
+                    configured = True
+                    origin = "env"
+                    state = "configured"
+                elif load_credential(storage_provider, "api_key"):
                     configured = True
                     origin = "file"
                     state = "configured"
@@ -250,6 +262,14 @@ class AuthManager:
                     configured = True
                     source = "env"
                 elif load_credential("minimax", "api_key"):
+                    configured = True
+                    source = "file"
+
+            elif provider == "modelscope":
+                if os.environ.get("MODELSCOPE_API_KEY"):
+                    configured = True
+                    source = "env"
+                elif load_credential("modelscope", "api_key"):
                     configured = True
                     source = "file"
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -1231,6 +1231,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "moonshot": "Moonshot (Kimi)",
     "gemini": "Google Gemini",
     "minimax": "MiniMax",
+    "modelscope": "ModelScope",
 }
 
 _AUTH_SOURCE_LABELS: dict[str, str] = {
@@ -1245,6 +1246,7 @@ _AUTH_SOURCE_LABELS: dict[str, str] = {
     "moonshot_api_key": "Moonshot API key",
     "gemini_api_key": "Gemini API key",
     "minimax_api_key": "MiniMax API key",
+    "modelscope_api_key": "ModelScope API key",
 }
 
 
@@ -1686,7 +1688,7 @@ def _login_provider(provider: str) -> None:
         _bind_external_provider(provider)
         return
 
-    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini", "minimax"):
+    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini", "minimax", "modelscope"):
         label = _PROVIDER_LABELS.get(provider, provider)
         flow = ApiKeyFlow(provider=provider, prompt_text=f"Enter your {label} API key")
         try:
@@ -1768,7 +1770,7 @@ def auth_login(
     """Interactively authenticate with a provider.
 
     Run without arguments to choose a provider from a menu.
-    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot, minimax.
+    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot, minimax, modelscope.
     """
     if provider is None:
         print("Select a provider to authenticate:", flush=True)

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -248,6 +248,14 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             default_model="qwen-plus",
             base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         ),
+        "modelscope": ProviderProfile(
+            label="ModelScope",
+            provider="modelscope",
+            api_format="openai",
+            auth_source="modelscope_api_key",
+            default_model="deepseek-ai/DeepSeek-V4-Flash",
+            base_url="https://api-inference.modelscope.cn/v1",
+        ),
     }
 
 
@@ -336,6 +344,7 @@ def auth_source_provider_name(auth_source: str) -> str:
         "moonshot_api_key": "moonshot",
         "gemini_api_key": "gemini",
         "minimax_api_key": "minimax",
+        "modelscope_api_key": "modelscope",
     }
     return mapping.get(auth_source, auth_source)
 
@@ -377,6 +386,8 @@ def default_auth_source_for_provider(provider: str, api_format: str | None = Non
         return "gemini_api_key"
     if provider == "minimax":
         return "minimax_api_key"
+    if provider == "modelscope":
+        return "modelscope_api_key"
     if provider == "openai" or api_format == "openai":
         return "openai_api_key"
     return "anthropic_api_key"
@@ -695,6 +706,7 @@ class Settings(BaseModel):
             "dashscope_api_key": "DASHSCOPE_API_KEY",
             "moonshot_api_key": "MOONSHOT_API_KEY",
             "minimax_api_key": "MINIMAX_API_KEY",
+            "modelscope_api_key": "MODELSCOPE_API_KEY",
         }.get(auth_source)
         if env_var:
             env_value = os.environ.get(env_var, "")

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -670,3 +670,67 @@ class TestQwenProvider:
         assert materialized.model == "qwen-plus"
         assert materialized.provider == "dashscope"
         assert materialized.api_format == "openai"
+
+
+class TestModelScopeProvider:
+    """Tests for ModelScope provider profile and auth integration."""
+
+    def test_modelscope_in_default_provider_profiles(self):
+        from openharness.config.settings import default_provider_profiles
+
+        profiles = default_provider_profiles()
+        assert "modelscope" in profiles
+        profile = profiles["modelscope"]
+        assert profile.provider == "modelscope"
+        assert profile.api_format == "openai"
+        assert profile.auth_source == "modelscope_api_key"
+        assert profile.default_model == "deepseek-ai/DeepSeek-V4-Flash"
+        assert profile.base_url == "https://api-inference.modelscope.cn/v1"
+
+    def test_auth_source_provider_name_modelscope(self):
+        from openharness.config.settings import auth_source_provider_name
+
+        assert auth_source_provider_name("modelscope_api_key") == "modelscope"
+
+    def test_default_auth_source_for_modelscope_provider(self):
+        from openharness.config.settings import default_auth_source_for_provider
+
+        assert default_auth_source_for_provider("modelscope") == "modelscope_api_key"
+
+    def test_resolve_auth_reads_modelscope_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("MODELSCOPE_API_KEY", "modelscope-test-key")
+        settings = Settings(
+            active_profile="modelscope",
+            profiles={
+                "modelscope": ProviderProfile(
+                    label="ModelScope",
+                    provider="modelscope",
+                    api_format="openai",
+                    auth_source="modelscope_api_key",
+                    default_model="deepseek-ai/DeepSeek-V4-Flash",
+                    base_url="https://api-inference.modelscope.cn/v1",
+                )
+            },
+        )
+        resolved = settings.resolve_auth()
+        assert resolved.value == "modelscope-test-key"
+        assert "MODELSCOPE_API_KEY" in resolved.source
+
+    def test_modelscope_profile_materializes_default_model(self):
+        settings = Settings(
+            active_profile="modelscope",
+            profiles={
+                "modelscope": ProviderProfile(
+                    label="ModelScope",
+                    provider="modelscope",
+                    api_format="openai",
+                    auth_source="modelscope_api_key",
+                    default_model="deepseek-ai/DeepSeek-V4-Flash",
+                    base_url="https://api-inference.modelscope.cn/v1",
+                )
+            },
+        )
+        materialized = settings.materialize_active_profile()
+        assert materialized.model == "deepseek-ai/DeepSeek-V4-Flash"
+        assert materialized.provider == "modelscope"
+        assert materialized.api_format == "openai"


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
- What changed?

## Validation

- [ ] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [ ] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

## Notes

- Related issue:
- Follow-up work:
