### PR TITLE
[security] fix(commands): keep config auth commands local-only

### DIFF
--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -233,7 +233,10 @@ class OpenAICompatibleClient:
     """
 
     def __init__(self, api_key: str, *, base_url: str | None = None, timeout: float | None = None) -> None:
-        kwargs: dict[str, Any] = {"api_key": api_key}
+        kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "default_headers": {"Authorization": f"Bearer {api_key}"},
+        }
         normalized_base_url = _normalize_openai_base_url(base_url)
         if normalized_base_url:
             kwargs["base_url"] = normalized_base_url

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -222,6 +222,47 @@ def _rewind_turns(messages: list[ConversationMessage], turns: int) -> list[Conve
     return updated
 
 
+
+_SECRET_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "auth_token",
+    "access_token",
+    "refresh_token",
+    "token",
+    "secret",
+    "password",
+    "authorization",
+    "credential",
+    "private_key",
+)
+
+_REDACTED = "[REDACTED]"
+
+
+def _is_secret_key(key: object) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return any(part in normalized for part in _SECRET_KEY_PARTS)
+
+
+def _redact_config_value(value: object, *, key: object | None = None) -> object:
+    if key is not None and _is_secret_key(key):
+        return _REDACTED
+    if isinstance(value, dict):
+        return {item_key: _redact_config_value(item_value, key=item_key) for item_key, item_value in value.items()}
+    if isinstance(value, list):
+        return [_redact_config_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_config_value(item) for item in value]
+    if isinstance(value, str) and value.lower().startswith(("bearer ", "basic ")):
+        return _REDACTED
+    return value
+
+
+def _settings_json_for_display(settings: Settings) -> str:
+    return json.dumps(_redact_config_value(settings.model_dump()), indent=2, default=str)
+
+
 def _coerce_setting_value(settings: Settings, key: str, raw: str):
     field = Settings.model_fields.get(key)
     if field is None:
@@ -778,7 +819,7 @@ def create_default_command_registry(
         settings = load_settings()
         tokens = args.split(maxsplit=2)
         if not tokens or tokens[0] == "show":
-            return CommandResult(message=settings.model_dump_json(indent=2))
+            return CommandResult(message=_settings_json_for_display(settings))
         if tokens[0] == "set" and len(tokens) == 3:
             key, value = tokens[1], tokens[2]
             if key not in Settings.model_fields:
@@ -1989,13 +2030,45 @@ def create_default_command_registry(
             remote_admin_opt_in=True,
         )
     )
-    registry.register(SlashCommand("login", "Show auth status or store an API key", _login_handler))
-    registry.register(SlashCommand("logout", "Clear the stored API key", _logout_handler))
+    registry.register(
+        SlashCommand(
+            "login",
+            "Show auth status or store an API key",
+            _login_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "logout",
+            "Clear the stored API key",
+            _logout_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("feedback", "Save CLI feedback to the local feedback log", _feedback_handler))
     registry.register(SlashCommand("onboarding", "Show the quickstart guide", _onboarding_handler))
     registry.register(SlashCommand("skills", "List or show available skills", _skills_handler))
-    registry.register(SlashCommand("config", "Show or update configuration", _config_handler))
-    registry.register(SlashCommand("mcp", "Show MCP status", _mcp_handler))
+    registry.register(
+        SlashCommand(
+            "config",
+            "Show or update configuration",
+            _config_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "mcp",
+            "Show MCP status",
+            _mcp_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(
         SlashCommand(
             "plugin",
@@ -2038,8 +2111,24 @@ def create_default_command_registry(
     registry.register(SlashCommand("turns", "Show or update maximum agentic turn count", _turns_handler))
     registry.register(SlashCommand("continue", "Continue the previous tool loop if it was interrupted", _continue_handler))
     registry.register(SlashCommand("stop", "Interrupt the running turn from TUI/ohmo channels", _stop_handler))
-    registry.register(SlashCommand("provider", "Show or switch provider profiles", _provider_handler))
-    registry.register(SlashCommand("model", "Show, switch, or manage profile models", _model_handler))
+    registry.register(
+        SlashCommand(
+            "provider",
+            "Show or switch provider profiles",
+            _provider_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "model",
+            "Show, switch, or manage profile models",
+            _model_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("theme", "List, set, show or preview TUI themes", _theme_handler))
     registry.register(SlashCommand("output-style", "Show or update output style", _output_style_handler))
     registry.register(SlashCommand("keybindings", "Show resolved keybindings", _keybindings_handler))
@@ -2059,7 +2148,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("subagents", "Show subagent usage and inspect worker tasks", _agents_handler))
     registry.register(SlashCommand("tasks", "Manage background tasks", _tasks_handler))
     registry.register(SlashCommand("autopilot", "Manage repo autopilot intake and context", _autopilot_handler))
-    registry.register(SlashCommand("ship", "Queue and execute an ohmo-driven repo task", _ship_handler))
+    registry.register(
+        SlashCommand(
+            "ship",
+            "Queue and execute an ohmo-driven repo task",
+            _ship_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
 
     for plugin_command in plugin_commands or ():
         if not plugin_command.user_invocable:

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -161,6 +161,76 @@ async def test_bridge_command_supports_explicit_remote_admin_opt_in(tmp_path: Pa
     assert getattr(command, "remote_admin_opt_in", False) is True
 
 
+
+@pytest.mark.asyncio
+async def test_sensitive_control_plane_commands_are_local_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+
+    for payload in (
+        "/config show",
+        "/login TEST_KEY",
+        "/logout",
+        "/mcp",
+        "/provider",
+        "/model show",
+        "/ship",
+    ):
+        command, _ = registry.lookup(payload)
+        assert command is not None
+        assert command.remote_invocable is False, payload
+        assert command.remote_admin_opt_in is True, payload
+
+
+@pytest.mark.asyncio
+async def test_config_show_redacts_nested_mcp_and_vision_secrets(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    settings = Settings(
+        api_key="TOP_LEVEL_FAKE_SECRET",
+        mcp_servers={
+            "internal-http": McpHttpServerConfig(
+                url="https://mcp.internal",
+                headers={
+                    "Authorization": "Bearer MCP_FAKE_SECRET",
+                    "X-Token": "RAW_FAKE_TOKEN",
+                    "X-Public": "non-secret-value",
+                },
+            ),
+            "local-stdio": McpStdioServerConfig(
+                command="server",
+                env={
+                    "MCP_AUTH_TOKEN": "STDIO_FAKE_SECRET",
+                    "SAFE_SETTING": "visible",
+                },
+            ),
+        },
+        vision={
+            "model": "vision-test",
+            "api_key": "VISION_FAKE_SECRET",
+            "base_url": "https://vision.example",
+        },
+    )
+    monkeypatch.setattr(registry_module, "load_settings", lambda: settings)
+
+    registry = create_default_command_registry()
+    command, args = registry.lookup("/config show")
+    assert command is not None
+
+    result = await command.handler(args, CommandContext(engine=_make_engine(tmp_path), cwd=str(tmp_path)))
+
+    for secret in (
+        "TOP_LEVEL_FAKE_SECRET",
+        "MCP_FAKE_SECRET",
+        "RAW_FAKE_TOKEN",
+        "STDIO_FAKE_SECRET",
+        "VISION_FAKE_SECRET",
+    ):
+        assert secret not in result.message
+    assert "[REDACTED]" in result.message
+    assert "non-secret-value" in result.message
+    assert "visible" in result.message
+
+
 @pytest.mark.asyncio
 async def test_memory_show_rejects_path_traversal(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -567,6 +567,71 @@ async def test_runtime_pool_blocks_registered_bridge_spawn_without_shelling_out(
     assert marker.exists() is False
 
 
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_registered_config_show_without_leaking_secrets(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/config show")
+
+    assert command is not None
+    assert command.name == "config"
+    assert command.remote_invocable is False
+
+    fake_settings = Settings(
+        mcp_servers={
+            "internal-http": {
+                "type": "http",
+                "url": "https://mcp.internal",
+                "headers": {"Authorization": "Bearer MCP_FAKE_SECRET"},
+            },
+        },
+        vision={"model": "vision-test", "api_key": "VISION_FAKE_SECRET"},
+    )
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(tmp_path),
+            session_id="sess123",
+            current_settings=lambda: fake_settings,
+            commands=registry,
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+    message = InboundMessage(channel="slack", sender_id="U_ATTACKER", chat_id="C_SHARED", content="/config show")
+    updates = [u async for u in pool.stream_message(message, "slack:C_SHARED:U_ATTACKER")]
+
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "/config is only available in the local OpenHarness UI."
+    assert "MCP_FAKE_SECRET" not in updates[-1].text
+    assert "VISION_FAKE_SECRET" not in updates[-1].text
+
+
 @pytest.mark.asyncio
 async def test_runtime_pool_memory_command_uses_ohmo_personal_memory(tmp_path, monkeypatch):
     workspace = tmp_path / ".ohmo-home"


### PR DESCRIPTION
## Summary

This PR hardens remote slash-command handling for local control-plane commands.

- keeps config/auth/model/provider/MCP/ship commands local-only by default
- preserves explicit remote-admin opt-in for operators who intentionally allow those commands
- redacts nested secret-bearing settings from `/config show` even for local display
- adds registry and gateway regression tests proving remote `/config show` is denied and fake secrets are not returned
- includes a small CI compatibility fix so the OpenAI-compatible client preserves bearer authorization headers explicitly

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Sensitive control-plane commands remained remotely invocable by default | An allowed gateway sender could read or mutate local config/auth state from Slack/Telegram/other channels | High |
| `/config show` serialized nested secret values | MCP headers/env values and vision API keys could be returned in command output | High |

## Before this PR

- `/config`, `/login`, `/logout`, `/mcp`, `/provider`, `/model`, and `/ship` inherited `remote_invocable=True`.
- A remote channel message such as `/config show` could reach the command handler through `OhmoSessionRuntimePool.stream_message()`.
- `/config show` emitted `settings.model_dump_json(indent=2)`, including nested MCP HTTP headers, MCP stdio env values, and vision API keys.

## After this PR

- Sensitive config/auth/control-plane commands are registered with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Remote callers receive the existing local-only denial unless an operator explicitly enables the command in remote-admin config.
- `/config show` uses a redacted display serializer before returning settings JSON.
- Tests cover both command metadata and the remote gateway path.

## Attack flow

```text
remote chat message: /config show
    -> ohmo gateway slash-command parser
        -> default-remote SlashCommand registration
            -> settings JSON returned to chat with MCP/vision secrets
```

## Affected code

| Area | Files |
| --- | --- |
| Slash command registry and redaction | `src/openharness/commands/registry.py` |
| OpenAI-compatible API client CI fix | `src/openharness/api/openai_client.py` |
| Command metadata/redaction tests | `tests/test_commands/test_registry.py` |
| Gateway regression coverage | `tests/test_ohmo/test_gateway.py` |

## Root cause

- Sensitive commands relied on the `SlashCommand.remote_invocable=True` default instead of explicitly opting out.
- `/config show` only masked selected top-level auth display elsewhere; the config command directly serialized the full settings model.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
| --- | --- | --- |
| Remote config/auth command exposure with nested secret disclosure | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

The score assumes an allowed remote channel/gateway user. Impact is bounded to the OpenHarness process user's configured secrets and local control-plane settings; this PR does not claim unauthenticated internet reachability.

## Safe reproduction steps

Using fake secrets only, the vulnerable base produced:

```text
CONFIG_REMOTE_INVOCABLE True
DIRECT_HAS_MCP_FAKE_SECRET True
DIRECT_HAS_STDIO_FAKE_SECRET True
DIRECT_HAS_VISION_FAKE_SECRET True
REMOTE_FINAL_HAS_MCP_FAKE_SECRET True
REMOTE_FINAL_HAS_VISION_FAKE_SECRET True
```

After this PR:

```text
CONFIG_REMOTE_INVOCABLE False
DIRECT_HAS_MCP_FAKE_SECRET False
DIRECT_HAS_STDIO_FAKE_SECRET False
DIRECT_HAS_VISION_FAKE_SECRET False
FINAL_TEXT_PREFIX /config is only available in the local OpenHarness UI.
REMOTE_FINAL_HAS_MCP_FAKE_SECRET False
REMOTE_FINAL_HAS_VISION_FAKE_SECRET False
```

## Changes in this PR

- Adds a recursive settings display redactor for secret-like keys and bearer/basic auth values.
- Switches `/config show` to the redacted display serializer.
- Marks `/config`, `/login`, `/logout`, `/mcp`, `/provider`, `/model`, and `/ship` local-only by default.
- Adds tests for command metadata, nested config redaction, and remote gateway denial.
- Preserves the OpenAI-compatible client bearer authorization header via explicit default headers, matching the existing API client regression test.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Runtime fix | `src/openharness/commands/registry.py` | local-only sensitive command registrations and redacted config output |
| CI compatibility fix | `src/openharness/api/openai_client.py` | preserve explicit bearer authorization header for OpenAI-compatible client construction |
| Unit tests | `tests/test_commands/test_registry.py` | command metadata and nested fake-secret redaction tests |
| Gateway tests | `tests/test_ohmo/test_gateway.py` | remote `/config show` denial regression |

## Maintainer impact

- The default remote channel behavior becomes safer for local config/auth commands.
- Operators who intentionally permit remote admin commands can still opt in through the existing remote-admin mechanism.
- Local `/config show` remains available but no longer prints raw nested secret values.

## Adjacent public context

This is a residual hardening follow-up to the remote slash-command boundary introduced by earlier security work. It does not re-report `/permissions`, `/bridge`, plugin management, or memory path traversal; it covers remaining config/auth/MCP/model/provider commands and nested secret redaction.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation
- [ ] Refactor

## Test plan

- [x] `PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q`
- [x] `PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py tests/test_api/test_openai_client.py::test_openai_client_uses_bearer_authorization_header -q`
- [x] `PYTHONPATH=src:. uv run python -m compileall -q src/openharness/api/openai_client.py src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py`
- [x] `git diff --check`
- [x] `uv run ruff check src/openharness/api/openai_client.py src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py`
- [x] safe repro harness run against vulnerable `origin/main` and this patched branch with fake secrets only

## Token usage

- Discovery tokens: partial/unknown
- Validation tokens: partial/unknown
- Duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- Total tokens: partial/unknown
- Notes: token telemetry was not available in this terminal workflow.

## Disclosure notes

- No production secrets were used or exposed.
- Reproduction used fake MCP, vision, and top-level API-key values only.
- Claims are limited to allowed remote gateway senders unless a deployment independently exposes broader channel access.

