### PR TITLE
fix(mcp): isolate startup from failed servers

### DIFF
--- a/src/openharness/mcp/client.py
+++ b/src/openharness/mcp/client.py
@@ -75,6 +75,31 @@ class McpClientManager:
         """Return one configured server object if present."""
         return self._server_configs.get(name)
 
+    async def _close_failed_stack(self, stack: AsyncExitStack) -> None:
+        """Best-effort cleanup for a connection attempt that never finished."""
+        try:
+            await stack.aclose()
+        except BaseException as exc:
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+
+    def _mark_connection_failed(
+        self,
+        name: str,
+        config: object,
+        *,
+        auth_configured: bool,
+        exc: BaseException,
+    ) -> None:
+        """Record one MCP connection failure without aborting startup."""
+        self._statuses[name] = McpConnectionStatus(
+            name=name,
+            state="failed",
+            transport=getattr(config, "type", "unknown"),
+            auth_configured=auth_configured,
+            detail=str(exc) or exc.__class__.__name__,
+        )
+
     async def close(self) -> None:
         """Close all active MCP sessions."""
         for stack in list(self._stacks.values()):
@@ -173,14 +198,21 @@ class McpClientManager:
                 write_stream=write_stream,
                 auth_configured=bool(config.env),
             )
-        except Exception as exc:
-            await stack.aclose()
-            self._statuses[name] = McpConnectionStatus(
-                name=name,
-                state="failed",
-                transport=config.type,
+        except asyncio.CancelledError as exc:
+            await self._close_failed_stack(stack)
+            self._mark_connection_failed(
+                name,
+                config,
                 auth_configured=bool(config.env),
-                detail=str(exc),
+                exc=exc,
+            )
+        except Exception as exc:
+            await self._close_failed_stack(stack)
+            self._mark_connection_failed(
+                name,
+                config,
+                auth_configured=bool(config.env),
+                exc=exc,
             )
 
     async def _connect_http(self, name: str, config: McpHttpServerConfig) -> None:
@@ -200,14 +232,21 @@ class McpClientManager:
                 write_stream=write_stream,
                 auth_configured=bool(config.headers),
             )
-        except Exception as exc:
-            await stack.aclose()
-            self._statuses[name] = McpConnectionStatus(
-                name=name,
-                state="failed",
-                transport=config.type,
+        except asyncio.CancelledError as exc:
+            await self._close_failed_stack(stack)
+            self._mark_connection_failed(
+                name,
+                config,
                 auth_configured=bool(config.headers),
-                detail=str(exc),
+                exc=exc,
+            )
+        except Exception as exc:
+            await self._close_failed_stack(stack)
+            self._mark_connection_failed(
+                name,
+                config,
+                auth_configured=bool(config.headers),
+                exc=exc,
             )
 
     async def _register_connected_session(

--- a/tests/test_mcp/test_client_errors.py
+++ b/tests/test_mcp/test_client_errors.py
@@ -8,12 +8,24 @@ from contextlib import AsyncExitStack
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from exceptiongroup import BaseExceptionGroup
 
 from openharness.mcp.client import McpClientManager, McpServerNotConnectedError
 from openharness.mcp.types import McpConnectionStatus, McpStdioServerConfig, McpToolInfo
 from openharness.tools.base import ToolExecutionContext
 from openharness.tools.mcp_tool import McpToolAdapter
 from openharness.tools.read_mcp_resource_tool import ReadMcpResourceTool
+
+
+class _AsyncContextManager:
+    def __init__(self, value):
+        self._value = value
+
+    async def __aenter__(self):
+        return self._value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 # --- McpClientManager.call_tool ---
@@ -127,6 +139,56 @@ async def test_close_suppresses_cancelled_error_from_stdio_cleanup():
 
     assert manager._stacks == {}
     assert manager._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_close_failed_stack_suppresses_base_exception_group_cleanup_error():
+    manager = McpClientManager({})
+    stack = MagicMock()
+    stack.aclose = AsyncMock(
+        side_effect=BaseExceptionGroup(
+            "cleanup failed",
+            [asyncio.CancelledError()],
+        )
+    )
+
+    await manager._close_failed_stack(stack)
+
+
+@pytest.mark.asyncio
+async def test_connect_all_marks_http_server_failed_when_initialize_is_cancelled(monkeypatch):
+    import openharness.mcp.client as client_module
+    from openharness.mcp.types import McpHttpServerConfig
+
+    manager = McpClientManager(
+        {
+            "broken-http": McpHttpServerConfig(
+                url="http://127.0.0.1:9999/mcp",
+                headers={},
+            )
+        }
+    )
+
+    monkeypatch.setattr(
+        client_module.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _AsyncContextManager(AsyncMock()),
+    )
+    monkeypatch.setattr(
+        client_module,
+        "streamable_http_client",
+        lambda *args, **kwargs: _AsyncContextManager((object(), object(), AsyncMock())),
+    )
+    manager._register_connected_session = AsyncMock(
+        side_effect=asyncio.CancelledError("simulated cancellation")
+    )
+
+    await manager.connect_all()
+
+    status = manager.list_statuses()[0]
+    assert status.name == "broken-http"
+    assert status.state == "failed"
+    assert "simulated cancellation" in status.detail
 
 
 # --- McpToolAdapter catches error and returns ToolResult(is_error=True) ---


### PR DESCRIPTION
Treat per-server initialization cancellation as a connection failure instead of aborting overall startup, and suppress cleanup-time exception groups from half-open MCP sessions.

## Summary

- What problem does this PR solve?
fix #236 
- What changed?
核心修复在 client.py:78。现在每个 MCP server 的连接失败都会在本层被降级为 failed 状态，而不是把异常继续抛到 runtime.py:213 让整个系统初始化中断。
具体做了两件事：一是显式接住每个 server 连接阶段的 asyncio.CancelledError，二是把失败后清理半开连接时冒出的 cleanup 异常也吞掉，只保留 KeyboardInterrupt 和 SystemExit 这类真正应当终止进程的情况。对应的连接入口在 client.py:201 和 client.py:235。


回归测试补在 test_client_errors.py:145 和 test_client_errors.py:159。前者覆盖 failed cleanup 再抛 BaseExceptionGroup 的场景，后者覆盖这次真实命中的 initialize 期间 CancelledError 场景。


## Validation
$ oh 或 $ ohmo

## Notes

- Related issue:
- Follow-up work:
