### PR TITLE
fix: recover from dangling tool call history

### DIFF
--- a/src/openharness/api/codex_client.py
+++ b/src/openharness/api/codex_client.py
@@ -78,6 +78,17 @@ def _convert_messages_to_codex(messages: list[ConversationMessage]) -> list[dict
     result: list[dict[str, Any]] = []
     for msg in messages:
         if msg.role == "user":
+            # Responses API requires function_call_output items to appear before
+            # any following user input.  A ConversationMessage can contain both
+            # tool results and user text, so emit the tool outputs first to keep
+            # every prior function_call immediately satisfied.
+            for block in msg.content:
+                if isinstance(block, ToolResultBlock):
+                    result.append({
+                        "type": "function_call_output",
+                        "call_id": block.tool_use_id,
+                        "output": block.content,
+                    })
             user_content: list[dict[str, Any]] = []
             for block in msg.content:
                 if isinstance(block, TextBlock) and block.text.strip():
@@ -89,13 +100,6 @@ def _convert_messages_to_codex(messages: list[ConversationMessage]) -> list[dict
                     })
             if user_content:
                 result.append({"role": "user", "content": user_content})
-            for block in msg.content:
-                if isinstance(block, ToolResultBlock):
-                    result.append({
-                        "type": "function_call_output",
-                        "call_id": block.tool_use_id,
-                        "output": block.content,
-                    })
             continue
 
         assistant_text = "".join(block.text for block in msg.content if isinstance(block, TextBlock))

--- a/src/openharness/engine/query_engine.py
+++ b/src/openharness/engine/query_engine.py
@@ -8,7 +8,7 @@ from typing import AsyncIterator
 from openharness.api.client import SupportsStreamingMessages
 from openharness.engine.cost_tracker import CostTracker
 from openharness.coordinator.coordinator_mode import get_coordinator_user_context
-from openharness.engine.messages import ConversationMessage, TextBlock, ToolResultBlock
+from openharness.engine.messages import ConversationMessage, TextBlock, ToolResultBlock, sanitize_conversation_messages
 from openharness.engine.query import AskUserPrompt, PermissionPrompt, QueryContext, remember_user_goal, run_query
 from openharness.engine.stream_events import AssistantTurnComplete, StreamEvent
 from openharness.hooks import HookEvent, HookExecutor
@@ -153,6 +153,7 @@ class QueryEngine:
         )
         if user_message.text.strip() and not self._tool_metadata.pop("_suppress_next_user_goal", False):
             remember_user_goal(self._tool_metadata, user_message.text)
+        self._messages = sanitize_conversation_messages(self._messages)
         self._messages.append(user_message)
         if self._hook_executor is not None:
             await self._hook_executor.execute(

--- a/tests/test_api/test_codex_client.py
+++ b/tests/test_api/test_codex_client.py
@@ -100,6 +100,26 @@ def test_convert_messages_to_codex():
     }
 
 
+def test_convert_user_message_with_tool_result_before_text_to_codex():
+    messages = [
+        ConversationMessage(
+            role="user",
+            content=[
+                ToolResultBlock(tool_use_id="call_123", content="done", is_error=False),
+                TextBlock(text="next request"),
+            ],
+        )
+    ]
+
+    converted = _convert_messages_to_codex(messages)
+
+    assert converted == [
+        {"type": "function_call_output", "call_id": "call_123", "output": "done"},
+        {"role": "user", "content": [{"type": "input_text", "text": "next request"}]},
+    ]
+
+
+
 def test_convert_multimodal_user_message_to_codex():
     messages = [
         ConversationMessage(

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -1356,6 +1356,35 @@ async def test_query_engine_synthesizes_tool_result_when_parallel_tool_raises(tm
 
 
 @pytest.mark.asyncio
+async def test_query_engine_sanitizes_dangling_tool_use_before_new_prompt(tmp_path: Path):
+    engine = QueryEngine(
+        api_client=StaticApiClient("fresh reply"),
+        tool_registry=ToolRegistry(),
+        permission_checker=PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO)),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+    )
+    engine.load_messages([
+        ConversationMessage.from_user_text("previous request"),
+        ConversationMessage(
+            role="assistant",
+            content=[ToolUseBlock(id="call_missing_output", name="ok_tool", input={})],
+        ),
+    ])
+
+    events = [event async for event in engine.submit_message("new prompt")]
+
+    assert isinstance(events[-1], AssistantTurnComplete)
+    assert events[-1].message.text == "fresh reply"
+    assert not any(
+        isinstance(block, ToolUseBlock) and block.id == "call_missing_output"
+        for message in engine.messages
+        for block in message.content
+    )
+
+
+@pytest.mark.asyncio
 async def test_query_engine_offloads_large_tool_result_outputs(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("OPENHARNESS_TOOL_OUTPUT_INLINE_CHARS", "256")


### PR DESCRIPTION
## Summary
- sanitize conversation history before accepting a new prompt so dangling tool calls do not poison resumed sessions
- emit Codex Responses function_call_output items before any following user input in mixed user messages
- add regressions for dangling tool calls and mixed tool-result/user messages

## Tests
- PYTHONPATH=src pytest -q tests/test_api/test_openai_client.py tests/test_api/test_codex_client.py tests/test_engine/test_query_engine.py::test_query_engine_sanitizes_dangling_tool_use_before_new_prompt tests/test_engine/test_query_engine.py::test_query_engine_synthesizes_tool_result_when_parallel_tool_raises tests/test_engine/test_messages.py