### PR TITLE
feat(memory): add automatic durable memory write support

### DIFF
--- a/ohmo/gateway/runtime.py
+++ b/ohmo/gateway/runtime.py
@@ -13,6 +13,7 @@ import string
 
 from openharness.channels.bus.events import InboundMessage
 from openharness.commands import CommandContext, CommandResult, lookup_skill_slash_command
+from openharness.config.paths import use_memory_store_dir
 from openharness.engine.messages import (
     ConversationMessage,
     ImageBlock,
@@ -152,172 +153,174 @@ class OhmoSessionRuntimePool:
     ) -> RuntimeBundle:
         """Return an existing bundle or create a new one."""
         session_cwd = str(Path(cwd or self._cwd).expanduser().resolve())
-        bundle = self._bundles.get(session_key)
-        if bundle is not None:
-            bundle_cwd = str(Path(getattr(bundle, "cwd", self._cwd)).resolve())
-            if bundle_cwd != session_cwd:
-                logger.info(
-                    "ohmo runtime recreating session for cwd change session_key=%s old_cwd=%s new_cwd=%s",
-                    session_key,
-                    bundle_cwd,
-                    session_cwd,
-                )
-                await close_runtime(bundle)
-                self._bundles.pop(session_key, None)
-            else:
-                logger.info(
-                    "ohmo runtime reusing session session_key=%s session_id=%s prompt=%r",
-                    session_key,
-                    bundle.session_id,
-                    _content_snippet(latest_user_prompt or ""),
-                )
-                bundle.engine.set_system_prompt(self._runtime_system_prompt(bundle, latest_user_prompt))
-                return bundle
+        with use_memory_store_dir(get_memory_dir(self._workspace), shared_root=True):
+            bundle = self._bundles.get(session_key)
+            if bundle is not None:
+                bundle_cwd = str(Path(getattr(bundle, "cwd", self._cwd)).resolve())
+                if bundle_cwd != session_cwd:
+                    logger.info(
+                        "ohmo runtime recreating session for cwd change session_key=%s old_cwd=%s new_cwd=%s",
+                        session_key,
+                        bundle_cwd,
+                        session_cwd,
+                    )
+                    await close_runtime(bundle)
+                    self._bundles.pop(session_key, None)
+                else:
+                    logger.info(
+                        "ohmo runtime reusing session session_key=%s session_id=%s prompt=%r",
+                        session_key,
+                        bundle.session_id,
+                        _content_snippet(latest_user_prompt or ""),
+                    )
+                    bundle.engine.set_system_prompt(self._runtime_system_prompt(bundle, latest_user_prompt))
+                    return bundle
 
-        snapshot = self._session_backend.load_latest_for_session_key(session_key)
-        logger.info(
-            "ohmo runtime creating session session_key=%s restored=%s prompt=%r",
-            session_key,
-            bool(snapshot),
-            _content_snippet(latest_user_prompt or ""),
-        )
-        bundle = await build_runtime(
-            cwd=session_cwd,
-            model=self._model,
-            max_turns=self._max_turns,
-            system_prompt=build_ohmo_system_prompt(session_cwd, workspace=self._workspace, extra_prompt=None),
-            active_profile=self._provider_profile,
-            session_backend=self._session_backend,
-            enforce_max_turns=self._max_turns is not None,
-            restore_messages=_sanitize_snapshot_messages(snapshot.get("messages") if snapshot else None),
-            restore_tool_metadata=_sanitize_group_command_metadata(snapshot.get("tool_metadata") if snapshot else None),
-            extra_skill_dirs=(str(get_skills_dir(self._workspace)),),
-            extra_plugin_roots=(str(get_plugins_dir(self._workspace)),),
-            memory_backend=create_memory_command_backend(self._workspace),
-            include_project_memory=False,
-            autodream_context={
-                "memory_dir": str(get_memory_dir(self._workspace)),
-                "session_dir": str(get_sessions_dir(self._workspace)),
-                "app_label": "ohmo personal memory",
-                "runner_module": "ohmo",
-            },
-        )
-        if snapshot and snapshot.get("session_id"):
-            bundle.session_id = str(snapshot["session_id"])
-        self._register_gateway_tools(bundle)
-        await start_runtime(bundle)
-        bundle.engine.set_system_prompt(self._runtime_system_prompt(bundle, latest_user_prompt))
-        logger.info(
-            "ohmo runtime started session_key=%s session_id=%s restored_messages=%s",
-            session_key,
-            bundle.session_id,
-            len(snapshot.get("messages") or []) if snapshot else 0,
-        )
-        self._bundles[session_key] = bundle
-        return bundle
+            snapshot = self._session_backend.load_latest_for_session_key(session_key)
+            logger.info(
+                "ohmo runtime creating session session_key=%s restored=%s prompt=%r",
+                session_key,
+                bool(snapshot),
+                _content_snippet(latest_user_prompt or ""),
+            )
+            bundle = await build_runtime(
+                cwd=session_cwd,
+                model=self._model,
+                max_turns=self._max_turns,
+                system_prompt=build_ohmo_system_prompt(session_cwd, workspace=self._workspace, extra_prompt=None),
+                active_profile=self._provider_profile,
+                session_backend=self._session_backend,
+                enforce_max_turns=self._max_turns is not None,
+                restore_messages=_sanitize_snapshot_messages(snapshot.get("messages") if snapshot else None),
+                restore_tool_metadata=_sanitize_group_command_metadata(snapshot.get("tool_metadata") if snapshot else None),
+                extra_skill_dirs=(str(get_skills_dir(self._workspace)),),
+                extra_plugin_roots=(str(get_plugins_dir(self._workspace)),),
+                memory_backend=create_memory_command_backend(self._workspace),
+                include_project_memory=False,
+                autodream_context={
+                    "memory_dir": str(get_memory_dir(self._workspace)),
+                    "session_dir": str(get_sessions_dir(self._workspace)),
+                    "app_label": "ohmo personal memory",
+                    "runner_module": "ohmo",
+                },
+            )
+            if snapshot and snapshot.get("session_id"):
+                bundle.session_id = str(snapshot["session_id"])
+            self._register_gateway_tools(bundle)
+            await start_runtime(bundle)
+            bundle.engine.set_system_prompt(self._runtime_system_prompt(bundle, latest_user_prompt))
+            logger.info(
+                "ohmo runtime started session_key=%s session_id=%s restored_messages=%s",
+                session_key,
+                bundle.session_id,
+                len(snapshot.get("messages") or []) if snapshot else 0,
+            )
+            self._bundles[session_key] = bundle
+            return bundle
 
     async def stream_message(self, message: InboundMessage, session_key: str):
         """Submit an inbound channel message and yield progress + final reply updates."""
-        user_message = _build_inbound_user_message(message)
-        user_prompt = user_message.text
-        command_prompt = (message.content or "").strip()
-        session_cwd = self._cwd_for_message(message)
-        bundle = await self.get_bundle(session_key, latest_user_prompt=user_prompt, cwd=session_cwd)
-        logger.info(
-            "ohmo runtime processing start channel=%s chat_id=%s session_key=%s session_id=%s content=%r",
-            message.channel,
-            message.chat_id,
-            session_key,
-            bundle.session_id,
-            _content_snippet(user_prompt),
-        )
-
-        command_context: CommandContext | None = None
-
-        def get_command_context() -> CommandContext:
-            nonlocal command_context
-            if command_context is None:
-                command_context = CommandContext(
-                    engine=bundle.engine,
-                    hooks_summary=getattr(bundle, "hook_summary", lambda: "")(),
-                    mcp_summary=getattr(bundle, "mcp_summary", lambda: "")(),
-                    plugin_summary=getattr(bundle, "plugin_summary", lambda: "")(),
-                    cwd=getattr(bundle, "cwd", str(self._cwd)),
-                    tool_registry=getattr(bundle, "tool_registry", None),
-                    app_state=getattr(bundle, "app_state", None),
-                    session_backend=getattr(bundle, "session_backend", self._session_backend),
-                    session_id=getattr(bundle, "session_id", None),
-                    extra_skill_dirs=getattr(bundle, "extra_skill_dirs", ()),
-                    extra_plugin_roots=getattr(bundle, "extra_plugin_roots", ()),
-                    memory_backend=create_memory_command_backend(self._workspace),
-                    include_project_memory=False,
-                )
-            return command_context
-
-        parsed = bundle.commands.lookup(command_prompt)
-        if parsed is None and not message.media:
-            parsed = lookup_skill_slash_command(command_prompt, get_command_context())
-        if parsed is not None and not message.media:
-            command, args = parsed
-            command_name = str(getattr(command, "name", "") or "")
-            gateway_result = self._handle_gateway_scoped_command(command_name, args)
-            if gateway_result is not None:
-                message_text, refresh_runtime = gateway_result
-                result = CommandResult(message=message_text, refresh_runtime=refresh_runtime)
-                async for update in self._stream_command_result(
-                    bundle=bundle,
-                    message=message,
-                    session_key=session_key,
-                    user_prompt=user_prompt,
-                    result=result,
-                ):
-                    yield update
-                return
-            remote_allowed = getattr(command, "remote_invocable", True)
-            if not remote_allowed and self._remote_admin_allowed(command):
-                remote_allowed = True
-                logger.warning(
-                    "ohmo gateway remote administrative command accepted channel=%s chat_id=%s sender_id=%s command=%s",
-                    message.channel,
-                    message.chat_id,
-                    message.sender_id,
-                    command_name,
-                )
-            if not remote_allowed:
-                result = CommandResult(
-                    message=f"/{command_name} is only available in the local OpenHarness UI."
-                )
-                async for update in self._stream_command_result(
-                    bundle=bundle,
-                    message=message,
-                    session_key=session_key,
-                    user_prompt=user_prompt,
-                    result=result,
-                ):
-                    yield update
-                return
-            result = await command.handler(
-                args,
-                get_command_context(),
+        with use_memory_store_dir(get_memory_dir(self._workspace), shared_root=True):
+            user_message = _build_inbound_user_message(message)
+            user_prompt = user_message.text
+            command_prompt = (message.content or "").strip()
+            session_cwd = self._cwd_for_message(message)
+            bundle = await self.get_bundle(session_key, latest_user_prompt=user_prompt, cwd=session_cwd)
+            logger.info(
+                "ohmo runtime processing start channel=%s chat_id=%s session_key=%s session_id=%s content=%r",
+                message.channel,
+                message.chat_id,
+                session_key,
+                bundle.session_id,
+                _content_snippet(user_prompt),
             )
-            async for update in self._stream_command_result(
+
+            command_context: CommandContext | None = None
+
+            def get_command_context() -> CommandContext:
+                nonlocal command_context
+                if command_context is None:
+                    command_context = CommandContext(
+                        engine=bundle.engine,
+                        hooks_summary=getattr(bundle, "hook_summary", lambda: "")(),
+                        mcp_summary=getattr(bundle, "mcp_summary", lambda: "")(),
+                        plugin_summary=getattr(bundle, "plugin_summary", lambda: "")(),
+                        cwd=getattr(bundle, "cwd", str(self._cwd)),
+                        tool_registry=getattr(bundle, "tool_registry", None),
+                        app_state=getattr(bundle, "app_state", None),
+                        session_backend=getattr(bundle, "session_backend", self._session_backend),
+                        session_id=getattr(bundle, "session_id", None),
+                        extra_skill_dirs=getattr(bundle, "extra_skill_dirs", ()),
+                        extra_plugin_roots=getattr(bundle, "extra_plugin_roots", ()),
+                        memory_backend=create_memory_command_backend(self._workspace),
+                        include_project_memory=False,
+                    )
+                return command_context
+
+            parsed = bundle.commands.lookup(command_prompt)
+            if parsed is None and not message.media:
+                parsed = lookup_skill_slash_command(command_prompt, get_command_context())
+            if parsed is not None and not message.media:
+                command, args = parsed
+                command_name = str(getattr(command, "name", "") or "")
+                gateway_result = self._handle_gateway_scoped_command(command_name, args)
+                if gateway_result is not None:
+                    message_text, refresh_runtime = gateway_result
+                    result = CommandResult(message=message_text, refresh_runtime=refresh_runtime)
+                    async for update in self._stream_command_result(
+                        bundle=bundle,
+                        message=message,
+                        session_key=session_key,
+                        user_prompt=user_prompt,
+                        result=result,
+                    ):
+                        yield update
+                    return
+                remote_allowed = getattr(command, "remote_invocable", True)
+                if not remote_allowed and self._remote_admin_allowed(command):
+                    remote_allowed = True
+                    logger.warning(
+                        "ohmo gateway remote administrative command accepted channel=%s chat_id=%s sender_id=%s command=%s",
+                        message.channel,
+                        message.chat_id,
+                        message.sender_id,
+                        command_name,
+                    )
+                if not remote_allowed:
+                    result = CommandResult(
+                        message=f"/{command_name} is only available in the local OpenHarness UI."
+                    )
+                    async for update in self._stream_command_result(
+                        bundle=bundle,
+                        message=message,
+                        session_key=session_key,
+                        user_prompt=user_prompt,
+                        result=result,
+                    ):
+                        yield update
+                    return
+                result = await command.handler(
+                    args,
+                    get_command_context(),
+                )
+                async for update in self._stream_command_result(
+                    bundle=bundle,
+                    message=message,
+                    session_key=session_key,
+                    user_prompt=user_prompt,
+                    result=result,
+                ):
+                    yield update
+                return
+
+            async for update in self._stream_engine_message(
                 bundle=bundle,
                 message=message,
                 session_key=session_key,
                 user_prompt=user_prompt,
-                result=result,
+                user_message=user_message,
             ):
                 yield update
-            return
-
-        async for update in self._stream_engine_message(
-            bundle=bundle,
-            message=message,
-            session_key=session_key,
-            user_prompt=user_prompt,
-            user_message=user_message,
-        ):
-            yield update
 
     async def _stream_command_result(
         self,
@@ -640,43 +643,44 @@ class OhmoSessionRuntimePool:
         bundle: RuntimeBundle,
         latest_user_prompt: str | None,
     ) -> RuntimeBundle:
-        snapshot = sanitize_conversation_messages(list(bundle.engine.messages))
-        prior_session_id = bundle.session_id
-        bundle_cwd = str(Path(getattr(bundle, "cwd", self._cwd)).resolve())
-        await close_runtime(bundle)
-        refreshed = await build_runtime(
-            cwd=bundle_cwd,
-            model=self._model,
-            max_turns=self._max_turns,
-            system_prompt=build_ohmo_system_prompt(bundle_cwd, workspace=self._workspace, extra_prompt=None),
-            active_profile=self._provider_profile,
-            session_backend=self._session_backend,
-            enforce_max_turns=self._max_turns is not None,
-            restore_messages=[message.model_dump(mode="json") for message in _sanitize_group_command_prompts(snapshot)],
-            restore_tool_metadata=_sanitize_group_command_metadata(getattr(bundle.engine, "tool_metadata", {}) or {}),
-            extra_skill_dirs=(str(get_skills_dir(self._workspace)),),
-            extra_plugin_roots=(str(get_plugins_dir(self._workspace)),),
-            memory_backend=create_memory_command_backend(self._workspace),
-            include_project_memory=False,
-            autodream_context={
-                "memory_dir": str(get_memory_dir(self._workspace)),
-                "session_dir": str(get_sessions_dir(self._workspace)),
-                "app_label": "ohmo personal memory",
-                "runner_module": "ohmo",
-            },
-        )
-        refreshed.session_id = prior_session_id
-        self._register_gateway_tools(refreshed)
-        await start_runtime(refreshed)
-        refreshed.engine.set_system_prompt(self._runtime_system_prompt(refreshed, latest_user_prompt))
-        self._bundles[session_key] = refreshed
-        logger.info(
-            "ohmo runtime refreshed session_key=%s session_id=%s message_count=%s",
-            session_key,
-            refreshed.session_id,
-            len(refreshed.engine.messages),
-        )
-        return refreshed
+        with use_memory_store_dir(get_memory_dir(self._workspace), shared_root=True):
+            snapshot = sanitize_conversation_messages(list(bundle.engine.messages))
+            prior_session_id = bundle.session_id
+            bundle_cwd = str(Path(getattr(bundle, "cwd", self._cwd)).resolve())
+            await close_runtime(bundle)
+            refreshed = await build_runtime(
+                cwd=bundle_cwd,
+                model=self._model,
+                max_turns=self._max_turns,
+                system_prompt=build_ohmo_system_prompt(bundle_cwd, workspace=self._workspace, extra_prompt=None),
+                active_profile=self._provider_profile,
+                session_backend=self._session_backend,
+                enforce_max_turns=self._max_turns is not None,
+                restore_messages=[message.model_dump(mode="json") for message in _sanitize_group_command_prompts(snapshot)],
+                restore_tool_metadata=_sanitize_group_command_metadata(getattr(bundle.engine, "tool_metadata", {}) or {}),
+                extra_skill_dirs=(str(get_skills_dir(self._workspace)),),
+                extra_plugin_roots=(str(get_plugins_dir(self._workspace)),),
+                memory_backend=create_memory_command_backend(self._workspace),
+                include_project_memory=False,
+                autodream_context={
+                    "memory_dir": str(get_memory_dir(self._workspace)),
+                    "session_dir": str(get_sessions_dir(self._workspace)),
+                    "app_label": "ohmo personal memory",
+                    "runner_module": "ohmo",
+                },
+            )
+            refreshed.session_id = prior_session_id
+            self._register_gateway_tools(refreshed)
+            await start_runtime(refreshed)
+            refreshed.engine.set_system_prompt(self._runtime_system_prompt(refreshed, latest_user_prompt))
+            self._bundles[session_key] = refreshed
+            logger.info(
+                "ohmo runtime refreshed session_key=%s session_id=%s message_count=%s",
+                session_key,
+                refreshed.session_id,
+                len(refreshed.engine.messages),
+            )
+            return refreshed
 
     def _runtime_system_prompt(self, bundle: RuntimeBundle, latest_user_prompt: str | None) -> str:
         bundle_cwd = str(Path(getattr(bundle, "cwd", self._cwd)).resolve())

--- a/ohmo/prompts.py
+++ b/ohmo/prompts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from openharness.config.paths import use_memory_store_dir
 from openharness.memory import load_memory_prompt as load_project_memory_prompt
 from openharness.prompts.system_prompt import get_base_system_prompt
 
@@ -11,6 +12,7 @@ from ohmo.memory import load_memory_prompt as load_ohmo_memory_prompt
 from ohmo.workspace import (
     get_bootstrap_path,
     get_identity_path,
+    get_memory_dir,
     get_soul_path,
     get_user_path,
     get_workspace_root,
@@ -67,7 +69,8 @@ def build_ohmo_system_prompt(
         sections.append(ohmo_memory)
 
     if include_project_memory:
-        project_memory = load_project_memory_prompt(cwd)
+        with use_memory_store_dir(get_memory_dir(root), shared_root=True):
+            project_memory = load_project_memory_prompt(cwd)
         if project_memory:
             sections.append(project_memory)
 

--- a/ohmo/runtime.py
+++ b/ohmo/runtime.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from openharness.api.client import SupportsStreamingMessages
+from openharness.config.paths import use_memory_store_dir
 from openharness.engine.stream_events import AssistantTextDelta, AssistantTurnComplete, CompactProgressEvent, ErrorEvent, StatusEvent
 from openharness.ui.backend_host import run_backend_host
 from openharness.ui.runtime import build_runtime, close_runtime, handle_line, start_runtime
@@ -42,28 +43,29 @@ async def run_ohmo_backend(
     cwd_path = str(Path(cwd or Path.cwd()).resolve())
     workspace_root = initialize_workspace(workspace)
     extra_skill_dirs, extra_plugin_roots = _ohmo_extra_roots(workspace_root)
-    return await run_backend_host(
-        cwd=cwd_path,
-        model=model,
-        max_turns=max_turns,
-        system_prompt=build_ohmo_system_prompt(cwd_path, workspace=workspace_root),
-        active_profile=provider_profile,
-        api_client=api_client,
-        restore_messages=restore_messages,
-        restore_tool_metadata=restore_tool_metadata,
-        enforce_max_turns=max_turns is not None,
-        session_backend=OhmoSessionBackend(workspace_root),
-        extra_skill_dirs=extra_skill_dirs,
-        extra_plugin_roots=extra_plugin_roots,
-        memory_backend=create_memory_command_backend(workspace_root),
-        include_project_memory=False,
-        autodream_context={
-            "memory_dir": str(get_memory_dir(workspace_root)),
-            "session_dir": str(get_sessions_dir(workspace_root)),
-            "app_label": "ohmo personal memory",
-            "runner_module": "ohmo",
-        },
-    )
+    with use_memory_store_dir(get_memory_dir(workspace_root), shared_root=True):
+        return await run_backend_host(
+            cwd=cwd_path,
+            model=model,
+            max_turns=max_turns,
+            system_prompt=build_ohmo_system_prompt(cwd_path, workspace=workspace_root),
+            active_profile=provider_profile,
+            api_client=api_client,
+            restore_messages=restore_messages,
+            restore_tool_metadata=restore_tool_metadata,
+            enforce_max_turns=max_turns is not None,
+            session_backend=OhmoSessionBackend(workspace_root),
+            extra_skill_dirs=extra_skill_dirs,
+            extra_plugin_roots=extra_plugin_roots,
+            memory_backend=create_memory_command_backend(workspace_root),
+            include_project_memory=False,
+            autodream_context={
+                "memory_dir": str(get_memory_dir(workspace_root)),
+                "session_dir": str(get_sessions_dir(workspace_root)),
+                "app_label": "ohmo personal memory",
+                "runner_module": "ohmo",
+            },
+        )
 
 
 def build_ohmo_backend_command(
@@ -160,59 +162,60 @@ async def run_ohmo_print_mode(
     previous_cwd = Path.cwd()
     os.chdir(cwd_path)
     try:
-        bundle = await build_runtime(
-            model=model,
-            max_turns=max_turns,
-            system_prompt=build_ohmo_system_prompt(cwd_path, workspace=workspace_root),
-            active_profile=provider_profile,
-            session_backend=OhmoSessionBackend(workspace_root),
-            enforce_max_turns=max_turns is not None,
-            extra_skill_dirs=extra_skill_dirs,
-            extra_plugin_roots=extra_plugin_roots,
-            memory_backend=create_memory_command_backend(workspace_root),
-            include_project_memory=False,
-            autodream_context={
-                "memory_dir": str(get_memory_dir(workspace_root)),
-                "session_dir": str(get_sessions_dir(workspace_root)),
-                "app_label": "ohmo personal memory",
-                "runner_module": "ohmo",
-            },
-        )
-        await start_runtime(bundle)
+        with use_memory_store_dir(get_memory_dir(workspace_root), shared_root=True):
+            bundle = await build_runtime(
+                model=model,
+                max_turns=max_turns,
+                system_prompt=build_ohmo_system_prompt(cwd_path, workspace=workspace_root),
+                active_profile=provider_profile,
+                session_backend=OhmoSessionBackend(workspace_root),
+                enforce_max_turns=max_turns is not None,
+                extra_skill_dirs=extra_skill_dirs,
+                extra_plugin_roots=extra_plugin_roots,
+                memory_backend=create_memory_command_backend(workspace_root),
+                include_project_memory=False,
+                autodream_context={
+                    "memory_dir": str(get_memory_dir(workspace_root)),
+                    "session_dir": str(get_sessions_dir(workspace_root)),
+                    "app_label": "ohmo personal memory",
+                    "runner_module": "ohmo",
+                },
+            )
+            await start_runtime(bundle)
 
-        async def _print_system(message: str) -> None:
-            print(message, file=sys.stderr)
+            async def _print_system(message: str) -> None:
+                print(message, file=sys.stderr)
 
-        saw_error = False
+            saw_error = False
 
-        async def _render_event(event) -> None:
-            nonlocal saw_error
-            if isinstance(event, AssistantTextDelta):
-                sys.stdout.write(event.text)
-                sys.stdout.flush()
-            elif isinstance(event, AssistantTurnComplete):
-                sys.stdout.write("\n")
-                sys.stdout.flush()
-            elif isinstance(event, ErrorEvent):
-                saw_error = True
-                print(event.message, file=sys.stderr)
-            elif isinstance(event, CompactProgressEvent):
-                if event.message:
+            async def _render_event(event) -> None:
+                nonlocal saw_error
+                if isinstance(event, AssistantTextDelta):
+                    sys.stdout.write(event.text)
+                    sys.stdout.flush()
+                elif isinstance(event, AssistantTurnComplete):
+                    sys.stdout.write("\n")
+                    sys.stdout.flush()
+                elif isinstance(event, ErrorEvent):
+                    saw_error = True
                     print(event.message, file=sys.stderr)
-            elif isinstance(event, StatusEvent):
-                print(event.message, file=sys.stderr)
+                elif isinstance(event, CompactProgressEvent):
+                    if event.message:
+                        print(event.message, file=sys.stderr)
+                elif isinstance(event, StatusEvent):
+                    print(event.message, file=sys.stderr)
 
-        async def _clear_output() -> None:
-            return None
+            async def _clear_output() -> None:
+                return None
 
-        await handle_line(
-            bundle,
-            prompt,
-            print_system=_print_system,
-            render_event=_render_event,
-            clear_output=_clear_output,
-        )
-        await close_runtime(bundle)
-        return 1 if saw_error else 0
+            await handle_line(
+                bundle,
+                prompt,
+                print_system=_print_system,
+                render_event=_render_event,
+                clear_output=_clear_output,
+            )
+            await close_runtime(bundle)
+            return 1 if saw_error else 0
     finally:
         os.chdir(previous_cwd)

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -23,18 +23,28 @@ from openharness.config.paths import (
     get_project_config_dir,
     get_project_issue_file,
     get_project_pr_comments_file,
+    get_project_settings_file,
 )
 from openharness.bridge import get_bridge_manager
 from openharness.bridge.types import WorkSecret
 from openharness.bridge.work_secret import build_sdk_url, decode_work_secret, encode_work_secret
 from openharness.api.provider import auth_status, detect_provider
-from openharness.config.settings import Settings, display_model_setting, load_settings, save_settings
+from openharness.config.settings import (
+    Settings,
+    display_model_setting,
+    load_project_settings_overrides,
+    load_settings,
+    load_settings_for_project,
+    save_settings,
+    set_project_memory_provider,
+)
 from openharness.engine.messages import ConversationMessage, sanitize_conversation_messages
 from openharness.engine.query_engine import QueryEngine
 from openharness.memory import (
     add_memory_entry,
     get_memory_entrypoint,
     get_project_memory_dir,
+    list_memory_provider_names,
     list_memory_files,
     remove_memory_entry,
 )
@@ -646,15 +656,92 @@ def create_default_command_registry(
         backend = _memory_backend_for_context(context)
         tokens = args.split(maxsplit=1)
         if not tokens:
+            settings = load_settings_for_project(context.cwd)
+            overrides = load_project_settings_overrides(context.cwd)
+            memory_overrides = overrides.get("memory")
+            provider_source = "project" if isinstance(memory_overrides, dict) and memory_overrides.get("provider") else "global/default"
             return CommandResult(
                 message=(
                     f"Memory store: {backend.label}\n"
                     f"Memory directory: {backend.get_memory_dir()}\n"
-                    f"Entrypoint: {backend.get_entrypoint()}"
+                    f"Entrypoint: {backend.get_entrypoint()}\n"
+                    f"Backend: {settings.memory.provider} [{provider_source}]"
                 )
             )
         action = tokens[0]
         rest = tokens[1] if len(tokens) == 2 else ""
+        if action == "backend":
+            settings = load_settings_for_project(context.cwd)
+            overrides = load_project_settings_overrides(context.cwd)
+            memory_overrides = overrides.get("memory")
+            project_provider = (
+                str(memory_overrides.get("provider", "")).strip()
+                if isinstance(memory_overrides, dict)
+                else ""
+            )
+            backend_tokens = rest.split(maxsplit=1)
+            backend_action = backend_tokens[0] if backend_tokens else "show"
+            backend_arg = backend_tokens[1].strip() if len(backend_tokens) == 2 else ""
+            project_settings_path = get_project_settings_file(context.cwd)
+            available = list_memory_provider_names()
+
+            if backend_action in {"show", "status"}:
+                source = "project" if project_provider else "global/default"
+                return CommandResult(
+                    message=(
+                        f"Memory backend: {settings.memory.provider}\n"
+                        f"Source: {source}\n"
+                        f"Project settings: {project_settings_path}"
+                    )
+                )
+            if backend_action == "list":
+                lines = ["Available memory backends:"]
+                for name in available:
+                    labels: list[str] = []
+                    if name == settings.memory.provider:
+                        labels.append("active")
+                    if name == project_provider:
+                        labels.append("project")
+                    suffix = f" [{' '.join(labels)}]" if labels else ""
+                    lines.append(f"- {name}{suffix}")
+                return CommandResult(message="\n".join(lines))
+
+            target = ""
+            if backend_action == "set" and backend_arg:
+                target = backend_arg
+            elif backend_action in {"default", "reset", "clear"} and not backend_arg:
+                target = ""
+            elif backend_action not in {"set", "default", "reset", "clear"} and not backend_arg:
+                target = backend_action
+            else:
+                return CommandResult(message="Usage: /memory backend [show|list|set NAME|default]")
+
+            if not target:
+                if not project_provider:
+                    return CommandResult(
+                        message=f"Memory backend already using {settings.memory.provider} [global/default]."
+                    )
+                set_project_memory_provider(context.cwd, None)
+                effective = load_settings_for_project(context.cwd).memory.provider
+                return CommandResult(
+                    message=f"Reset project memory backend override. Effective backend: {effective}",
+                    refresh_runtime=True,
+                )
+
+            if target not in available:
+                return CommandResult(
+                    message=(
+                        f"Unknown memory backend: {target}\n"
+                        f"Available: {', '.join(available)}"
+                    )
+                )
+            if project_provider == target:
+                return CommandResult(message=f"Project memory backend already set to {target}.")
+            set_project_memory_provider(context.cwd, target)
+            return CommandResult(
+                message=f"Project memory backend set to {target}",
+                refresh_runtime=True,
+            )
         if action == "list":
             memory_files = backend.list_files()
             if not memory_files:
@@ -680,7 +767,9 @@ def create_default_command_registry(
             if backend.remove_entry(rest.strip()):
                 return CommandResult(message=f"Removed memory entry {rest.strip()}")
             return CommandResult(message=f"Memory entry not found: {rest.strip()}")
-        return CommandResult(message="Usage: /memory [list|show NAME|add TITLE :: CONTENT|remove NAME]")
+        return CommandResult(
+            message="Usage: /memory [backend ...|list|show NAME|add TITLE :: CONTENT|remove NAME]"
+        )
 
     async def _hooks_handler(_: str, context: CommandContext) -> CommandResult:
         return CommandResult(message=context.hooks_summary or "No hooks configured.")
@@ -912,6 +1001,10 @@ def create_default_command_registry(
             (
                 project_dir / "memory" / "MEMORY.md",
                 "# Project Memory\n\nAdd reusable project knowledge here.\n",
+            ),
+            (
+                project_dir / "memory" / "entries" / ".gitkeep",
+                "",
             ),
             (
                 project_dir / "plugins" / ".gitkeep",
@@ -2402,23 +2495,26 @@ def _resolve_memory_entry_path(memory_dir: Path, candidate: str) -> tuple[Path |
     """Resolve a memory entry path while enforcing containment under ``memory_dir``."""
 
     base = memory_dir.resolve()
-    resolved, invalid = _resolve_memory_candidate(base, candidate)
-    if invalid:
-        return None, True
-    if resolved is not None and resolved.exists():
-        return resolved, False
-    fallback, invalid = _resolve_memory_candidate(base, f"{candidate}.md")
-    if invalid:
-        return None, True
-    if fallback is not None and fallback.exists():
-        return fallback, False
-    slug = re.sub(r"[^a-zA-Z0-9]+", "_", candidate.strip().lower()).strip("_")
-    if slug and slug != candidate:
-        slugged, invalid = _resolve_memory_candidate(base, f"{slug}.md")
+    search_roots = (base, base / "entries")
+    for root in search_roots:
+        resolved, invalid = _resolve_memory_candidate(root, candidate)
         if invalid:
             return None, True
-        if slugged is not None and slugged.exists():
-            return slugged, False
+        if resolved is not None and resolved.exists():
+            return resolved, False
+        fallback, invalid = _resolve_memory_candidate(root, f"{candidate}.md")
+        if invalid:
+            return None, True
+        if fallback is not None and fallback.exists():
+            return fallback, False
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", candidate.strip().lower()).strip("_")
+    if slug and slug != candidate:
+        for root in search_roots:
+            slugged, invalid = _resolve_memory_candidate(root, f"{slug}.md")
+            if invalid:
+                return None, True
+            if slugged is not None and slugged.exists():
+                return slugged, False
     return None, False
 
 

--- a/src/openharness/config/__init__.py
+++ b/src/openharness/config/__init__.py
@@ -8,6 +8,7 @@ from openharness.config.paths import (
     get_config_file_path,
     get_data_dir,
     get_logs_dir,
+    get_project_settings_file,
 )
 from openharness.config.settings import (
     ProviderProfile,
@@ -15,8 +16,12 @@ from openharness.config.settings import (
     auth_source_provider_name,
     default_auth_source_for_provider,
     default_provider_profiles,
+    load_project_settings_overrides,
     load_settings,
+    load_settings_for_project,
     save_settings,
+    save_project_settings_overrides,
+    set_project_memory_provider,
 )
 
 __all__ = [
@@ -29,6 +34,11 @@ __all__ = [
     "get_config_file_path",
     "get_data_dir",
     "get_logs_dir",
+    "get_project_settings_file",
     "load_settings",
+    "load_project_settings_overrides",
+    "load_settings_for_project",
     "save_settings",
+    "save_project_settings_overrides",
+    "set_project_memory_provider",
 ]

--- a/src/openharness/config/paths.py
+++ b/src/openharness/config/paths.py
@@ -5,11 +5,16 @@ Follows XDG-like conventions with ~/.openharness/ as the default base directory.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 import os
 from pathlib import Path
 
 _DEFAULT_BASE_DIR = ".openharness"
 _CONFIG_FILE_NAME = "settings.json"
+_memory_dir_override: ContextVar[str | None] = ContextVar("openharness_memory_dir_override", default=None)
+_memory_root_is_shared: ContextVar[bool] = ContextVar("openharness_memory_root_is_shared", default=False)
 
 
 def get_config_dir() -> Path:
@@ -34,6 +39,11 @@ def get_config_file_path() -> Path:
     return get_config_dir() / _CONFIG_FILE_NAME
 
 
+def get_project_settings_file(cwd: str | Path) -> Path:
+    """Return the per-project settings override file."""
+    return Path(cwd).resolve() / _DEFAULT_BASE_DIR / _CONFIG_FILE_NAME
+
+
 def get_data_dir() -> Path:
     """Return the data directory for caches, history, etc.
 
@@ -49,6 +59,52 @@ def get_data_dir() -> Path:
 
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir
+
+
+def get_memory_store_dir() -> Path:
+    """Return the durable project memory root directory.
+
+    Resolution order:
+    1. Active override from ``use_memory_store_dir``
+    2. OPENHARNESS_MEMORY_DIR environment variable
+    3. OHMO_WORKSPACE/memory when running inside ohmo
+    4. ~/.openharness/data/memory/
+    """
+    override_dir = _memory_dir_override.get()
+    if override_dir:
+        memory_dir = Path(override_dir)
+    else:
+        env_dir = os.environ.get("OPENHARNESS_MEMORY_DIR")
+        if env_dir:
+            memory_dir = Path(env_dir)
+        else:
+            ohmo_workspace = os.environ.get("OHMO_WORKSPACE")
+            if ohmo_workspace:
+                memory_dir = Path(ohmo_workspace).expanduser() / "memory"
+            else:
+                memory_dir = get_data_dir() / "memory"
+
+    memory_dir = memory_dir.expanduser().resolve()
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    return memory_dir
+
+
+@contextmanager
+def use_memory_store_dir(path: str | Path, *, shared_root: bool = False) -> Iterator[Path]:
+    """Temporarily route durable project memory into a specific root directory."""
+    resolved = Path(path).expanduser().resolve()
+    token = _memory_dir_override.set(str(resolved))
+    shared_token = _memory_root_is_shared.set(shared_root)
+    try:
+        yield resolved
+    finally:
+        _memory_root_is_shared.reset(shared_token)
+        _memory_dir_override.reset(token)
+
+
+def memory_store_uses_shared_root() -> bool:
+    """Return whether the active memory store should use a shared root entrypoint."""
+    return _memory_root_is_shared.get()
 
 
 def get_logs_dir() -> Path:

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -3,8 +3,9 @@
 Settings are resolved with the following precedence (highest first):
 1. CLI arguments
 2. Environment variables (ANTHROPIC_API_KEY, OPENHARNESS_MODEL, etc.)
-3. Config file (~/.openharness/settings.json)
-4. Defaults
+3. Project config file (.openharness/settings.json)
+4. Global config file (~/.openharness/settings.json)
+5. Defaults
 """
 
 from __future__ import annotations
@@ -61,6 +62,7 @@ class MemorySettings(BaseModel):
     """Memory system configuration."""
 
     enabled: bool = True
+    provider: str = "file"
     max_files: int = 5
     max_entrypoint_lines: int = 200
     context_window_tokens: int | None = None
@@ -68,6 +70,12 @@ class MemorySettings(BaseModel):
     auto_dream_enabled: bool = False
     auto_dream_min_hours: float = 24.0
     auto_dream_min_sessions: int = 5
+    auto_write_enabled: bool = True
+    review_after_response: bool = True
+    review_interval_turns: int = 3
+    review_max_messages: int = 8
+    repeat_prompt_threshold: int = 2
+    session_fact_sync_enabled: bool = True
 
 
 class SandboxNetworkSettings(BaseModel):
@@ -444,9 +452,12 @@ def _profile_from_flat_settings(settings: "Settings") -> tuple[str, ProviderProf
     ) and (
         existing.base_url == settings.base_url
     ):
+        explicit_last_model = settings.model or None
+        if explicit_last_model == existing.default_model:
+            explicit_last_model = existing.last_model
         profile = existing.model_copy(
             update={
-                "last_model": settings.model or existing.resolved_model,
+                "last_model": explicit_last_model,
             }
         )
         return name, profile
@@ -963,6 +974,62 @@ def _parse_bool_env(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _load_settings_raw(config_path: Path) -> dict[str, Any]:
+    if not config_path.exists():
+        return {}
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Settings file must contain a JSON object: {config_path}")
+    return raw
+
+
+def _merge_settings_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = _merge_settings_dicts(current, value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _materialize_loaded_settings(
+    raw: dict[str, Any],
+    *,
+    override_raw: dict[str, Any] | None = None,
+) -> Settings:
+    settings = Settings.model_validate(raw)
+    if "profiles" not in raw or "active_profile" not in raw:
+        profile_name, profile = _profile_from_flat_settings(settings)
+        merged_profiles = settings.merged_profiles()
+        merged_profiles[profile_name] = profile
+        settings = settings.model_copy(
+            update={
+                "active_profile": profile_name,
+                "profiles": merged_profiles,
+            }
+        )
+
+    if override_raw:
+        if "active_profile" in override_raw:
+            settings = settings.model_copy(update={"active_profile": override_raw["active_profile"]})
+        flat_override_keys = {
+            "api_key",
+            "api_format",
+            "base_url",
+            "context_window_tokens",
+            "auto_compact_threshold_tokens",
+            "model",
+            "provider",
+        }
+        flat_updates = {key: override_raw[key] for key in flat_override_keys if key in override_raw}
+        if flat_updates:
+            settings = settings.model_copy(update=flat_updates).sync_active_profile_from_flat_fields()
+
+    return settings.materialize_active_profile()
+
+
 def load_settings(config_path: Path | None = None) -> Settings:
     """Load settings from config file, merging with defaults.
 
@@ -976,30 +1043,94 @@ def load_settings(config_path: Path | None = None) -> Settings:
         from openharness.config.paths import get_config_file_path
 
         config_path = get_config_file_path()
+    return _apply_env_overrides(_materialize_loaded_settings(_load_settings_raw(config_path)))
 
-    if config_path.exists():
-        raw = json.loads(config_path.read_text(encoding="utf-8"))
-        settings = Settings.model_validate(raw)
-        env_profile = os.environ.get("OPENHARNESS_PROFILE")
-        if env_profile:
-            settings = settings.model_copy(update={"active_profile": env_profile.strip()})
-        if "profiles" not in raw or "active_profile" not in raw:
-            profile_name, profile = _profile_from_flat_settings(settings)
-            merged_profiles = settings.merged_profiles()
-            merged_profiles[profile_name] = profile
-            settings = settings.model_copy(
-                update={
-                    "active_profile": profile_name,
-                    "profiles": merged_profiles,
-                }
-            )
-        return _apply_env_overrides(settings.materialize_active_profile())
 
-    settings = Settings()
-    env_profile = os.environ.get("OPENHARNESS_PROFILE")
-    if env_profile:
-        settings = settings.model_copy(update={"active_profile": env_profile.strip()})
-    return _apply_env_overrides(settings.materialize_active_profile())
+def load_project_settings_overrides(
+    cwd: str | Path,
+    project_config_path: Path | None = None,
+) -> dict[str, Any]:
+    """Load raw project-scoped settings overrides for one workspace."""
+    if project_config_path is None:
+        from openharness.config.paths import get_project_settings_file
+
+        project_config_path = get_project_settings_file(cwd)
+
+    return _load_settings_raw(project_config_path)
+
+
+def save_project_settings_overrides(
+    cwd: str | Path,
+    overrides: dict[str, Any],
+    project_config_path: Path | None = None,
+) -> Path:
+    """Persist raw project-scoped settings overrides for one workspace."""
+    if project_config_path is None:
+        from openharness.config.paths import get_project_settings_file
+
+        project_config_path = get_project_settings_file(cwd)
+
+    lock_path = project_config_path.with_suffix(project_config_path.suffix + ".lock")
+    with exclusive_file_lock(lock_path):
+        if not overrides:
+            if project_config_path.exists():
+                project_config_path.unlink()
+            return project_config_path
+        project_config_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(
+            project_config_path,
+            json.dumps(overrides, indent=2) + "\n",
+        )
+    return project_config_path
+
+
+def set_project_memory_provider(
+    cwd: str | Path,
+    provider_name: str | None,
+    project_config_path: Path | None = None,
+) -> Path:
+    """Persist or clear the project-scoped memory backend override."""
+    if project_config_path is None:
+        from openharness.config.paths import get_project_settings_file
+
+        project_config_path = get_project_settings_file(cwd)
+
+    overrides = load_project_settings_overrides(cwd, project_config_path=project_config_path)
+    memory_overrides = overrides.get("memory")
+    next_memory_overrides = dict(memory_overrides) if isinstance(memory_overrides, dict) else {}
+    normalized_provider = (provider_name or "").strip()
+    if normalized_provider:
+        next_memory_overrides["provider"] = normalized_provider
+        overrides["memory"] = next_memory_overrides
+    else:
+        next_memory_overrides.pop("provider", None)
+        if next_memory_overrides:
+            overrides["memory"] = next_memory_overrides
+        else:
+            overrides.pop("memory", None)
+
+    return save_project_settings_overrides(cwd, overrides, project_config_path=project_config_path)
+
+
+def load_settings_for_project(
+    cwd: str | Path,
+    config_path: Path | None = None,
+    project_config_path: Path | None = None,
+) -> Settings:
+    """Load global settings merged with project-scoped overrides."""
+    if config_path is None:
+        from openharness.config.paths import get_config_file_path
+
+        config_path = get_config_file_path()
+    if project_config_path is None:
+        from openharness.config.paths import get_project_settings_file
+
+        project_config_path = get_project_settings_file(cwd)
+
+    global_raw = _load_settings_raw(config_path)
+    project_raw = _load_settings_raw(project_config_path)
+    merged_raw = _merge_settings_dicts(global_raw, project_raw)
+    return _apply_env_overrides(_materialize_loaded_settings(merged_raw, override_raw=project_raw))
 
 
 def save_settings(settings: Settings, config_path: Path | None = None) -> None:

--- a/src/openharness/engine/query_engine.py
+++ b/src/openharness/engine/query_engine.py
@@ -2,20 +2,50 @@
 
 from __future__ import annotations
 
+import logging
+import re
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, cast
 
 from openharness.api.client import SupportsStreamingMessages
-from openharness.engine.cost_tracker import CostTracker
+from openharness.config.settings import PermissionSettings, Settings
 from openharness.coordinator.coordinator_mode import get_coordinator_user_context
+from openharness.engine.cost_tracker import CostTracker
 from openharness.engine.messages import ConversationMessage, TextBlock, ToolResultBlock, sanitize_conversation_messages
 from openharness.engine.query import AskUserPrompt, PermissionPrompt, QueryContext, remember_user_goal, run_query
-from openharness.engine.stream_events import AssistantTurnComplete, StreamEvent
-from openharness.config.settings import Settings
+from openharness.engine.stream_events import AssistantTurnComplete, ErrorEvent, StreamEvent, ToolExecutionCompleted
 from openharness.hooks import HookEvent, HookExecutor
+from openharness.memory.auto_write import AUTO_MEMORY_REVIEW_SYSTEM_PROMPT, build_turn_memory_review_messages
 from openharness.permissions.checker import PermissionChecker
+from openharness.permissions.modes import PermissionMode
 from openharness.services.autodream.service import schedule_auto_dream
 from openharness.tools.base import ToolRegistry
+
+log = logging.getLogger(__name__)
+
+_MAX_TRACKED_REPEAT_PROMPTS = 24
+_REPEAT_PROMPT_SUMMARY_LIMIT = 240
+
+
+def _normalize_repeat_prompt(text: str) -> str:
+    normalized = " ".join(text.split()).casefold()
+    if not normalized:
+        return ""
+    normalized = re.sub(r"[^\w\s]", " ", normalized)
+    normalized = " ".join(normalized.split())
+    return normalized[:_REPEAT_PROMPT_SUMMARY_LIMIT]
+
+
+def _summarize_repeat_prompt(text: str) -> str:
+    summary = " ".join(text.split()).strip()
+    return summary[:_REPEAT_PROMPT_SUMMARY_LIMIT]
+
+
+def _repeat_prompt_sort_key(item: dict[str, Any]) -> tuple[int, str]:
+    count = item.get("count", 0)
+    prompt = item.get("prompt", "")
+    count_value = int(count) if isinstance(count, (int, float)) else 0
+    return (-count_value, str(prompt))
 
 
 class QueryEngine:
@@ -33,6 +63,11 @@ class QueryEngine:
         max_tokens: int = 4096,
         context_window_tokens: int | None = None,
         auto_compact_threshold_tokens: int | None = None,
+        memory_auto_write_enabled: bool = True,
+        memory_review_after_response: bool = True,
+        memory_review_interval_turns: int = 3,
+        memory_review_max_messages: int = 8,
+        memory_repeat_prompt_threshold: int = 2,
         max_turns: int | None = 8,
         permission_prompt: PermissionPrompt | None = None,
         ask_user_prompt: AskUserPrompt | None = None,
@@ -49,6 +84,11 @@ class QueryEngine:
         self._max_tokens = max_tokens
         self._context_window_tokens = context_window_tokens
         self._auto_compact_threshold_tokens = auto_compact_threshold_tokens
+        self._memory_auto_write_enabled = memory_auto_write_enabled
+        self._memory_review_after_response = memory_review_after_response
+        self._memory_review_interval_turns = max(1, int(memory_review_interval_turns))
+        self._memory_review_max_messages = max(1, int(memory_review_max_messages))
+        self._memory_repeat_prompt_threshold = max(0, int(memory_repeat_prompt_threshold))
         self._max_turns = max_turns
         self._permission_prompt = permission_prompt
         self._ask_user_prompt = ask_user_prompt
@@ -57,6 +97,206 @@ class QueryEngine:
         self._settings = settings
         self._messages: list[ConversationMessage] = []
         self._cost_tracker = CostTracker()
+
+    def _memory_review_state(self) -> dict[str, int]:
+        state = self._tool_metadata.setdefault(
+            "memory_review_state",
+            {
+                "turns_since_review": 0,
+                "turns_since_write": 0,
+                "reviews": 0,
+                "writes": 0,
+            },
+        )
+        if not isinstance(state, dict):
+            state = {
+                "turns_since_review": 0,
+                "turns_since_write": 0,
+                "reviews": 0,
+                "writes": 0,
+            }
+            self._tool_metadata["memory_review_state"] = state
+        for key in ("turns_since_review", "turns_since_write", "reviews", "writes"):
+            value = state.get(key, 0)
+            state[key] = int(value) if isinstance(value, (int, float)) else 0
+        return state
+
+    def _build_memory_review_registry(self) -> ToolRegistry | None:
+        tool = self._tool_registry.get("memory_write")
+        if tool is None:
+            return None
+        registry = ToolRegistry()
+        registry.register(tool)
+        return registry
+
+    def _repeat_prompt_state(self) -> dict[str, Any]:
+        state = cast(
+            dict[str, Any],
+            self._tool_metadata.setdefault(
+                "memory_repeat_prompt_state",
+                {"prompts": {}},
+            ),
+        )
+        if not isinstance(state, dict):
+            state = {"prompts": {}}
+            self._tool_metadata["memory_repeat_prompt_state"] = state
+        prompts = state.get("prompts")
+        if not isinstance(prompts, dict):
+            prompts = {}
+            state["prompts"] = prompts
+        return state
+
+    def _note_user_prompt(self, prompt: str) -> None:
+        if self._memory_repeat_prompt_threshold <= 0:
+            return
+        normalized = _normalize_repeat_prompt(prompt)
+        summary = _summarize_repeat_prompt(prompt)
+        if not normalized or len(normalized) < 12 or not summary:
+            return
+        state = self._repeat_prompt_state()
+        prompts = state.get("prompts")
+        if not isinstance(prompts, dict):
+            prompts = {}
+            state["prompts"] = prompts
+        record = prompts.get(normalized)
+        if not isinstance(record, dict):
+            record = {
+                "count": 0,
+                "latest_prompt": summary,
+                "reviewed_stage": 0,
+            }
+        count = record.get("count", 0)
+        record["count"] = int(count) + 1 if isinstance(count, (int, float)) else 1
+        record["latest_prompt"] = summary
+        reviewed_stage = record.get("reviewed_stage", 0)
+        record["reviewed_stage"] = int(reviewed_stage) if isinstance(reviewed_stage, (int, float)) else 0
+        prompts.pop(normalized, None)
+        prompts[normalized] = record
+        while len(prompts) > _MAX_TRACKED_REPEAT_PROMPTS:
+            oldest_key = next(iter(prompts))
+            if oldest_key == normalized and len(prompts) == 1:
+                break
+            prompts.pop(oldest_key, None)
+
+    def _repeat_prompt_candidates(self) -> list[dict[str, object]]:
+        if self._memory_repeat_prompt_threshold <= 0:
+            return []
+        state = self._repeat_prompt_state()
+        prompts = state.get("prompts")
+        if not isinstance(prompts, dict):
+            return []
+        candidates: list[dict[str, Any]] = []
+        for normalized_prompt, record in prompts.items():
+            if not isinstance(record, dict):
+                continue
+            count = record.get("count", 0)
+            reviewed_stage = record.get("reviewed_stage", 0)
+            prompt_text = str(record.get("latest_prompt") or "").strip()
+            count_value = int(count) if isinstance(count, (int, float)) else 0
+            reviewed_stage_value = int(reviewed_stage) if isinstance(reviewed_stage, (int, float)) else 0
+            current_stage = count_value // self._memory_repeat_prompt_threshold
+            if current_stage <= reviewed_stage_value or not prompt_text:
+                continue
+            candidates.append(
+                {
+                    "count": count_value,
+                    "prompt": prompt_text,
+                    "normalized_prompt": str(normalized_prompt),
+                }
+            )
+        candidates.sort(key=_repeat_prompt_sort_key)
+        return candidates[:5]
+
+    def _mark_repeat_prompt_candidates_reviewed(self) -> None:
+        if self._memory_repeat_prompt_threshold <= 0:
+            return
+        state = self._repeat_prompt_state()
+        prompts = state.get("prompts")
+        if not isinstance(prompts, dict):
+            return
+        for record in prompts.values():
+            if not isinstance(record, dict):
+                continue
+            count = record.get("count", 0)
+            count_value = int(count) if isinstance(count, (int, float)) else 0
+            record["reviewed_stage"] = count_value // self._memory_repeat_prompt_threshold
+
+    def _metadata_paths(self, key: str) -> tuple[str, ...]:
+        value = self._tool_metadata.get(key)
+        if not isinstance(value, (list, tuple, set)):
+            return ()
+        return tuple(str(item) for item in value if isinstance(item, (str, Path)))
+
+    def _note_memory_write(self) -> None:
+        state = self._memory_review_state()
+        state["turns_since_review"] = 0
+        state["turns_since_write"] = 0
+        state["writes"] += 1
+
+    def _should_run_memory_review(self, *, memory_tool_used: bool) -> bool:
+        if not self._memory_auto_write_enabled:
+            return False
+        if memory_tool_used:
+            self._note_memory_write()
+            return False
+        if not self._memory_review_after_response:
+            return False
+        if self._build_memory_review_registry() is None:
+            return False
+        state = self._memory_review_state()
+        state["turns_since_review"] += 1
+        state["turns_since_write"] += 1
+        if self._repeat_prompt_candidates():
+            return True
+        return state["turns_since_review"] >= self._memory_review_interval_turns
+
+    def _complete_memory_review(self, *, memory_written: bool) -> None:
+        state = self._memory_review_state()
+        state["turns_since_review"] = 0
+        state["reviews"] += 1
+        self._mark_repeat_prompt_candidates_reviewed()
+        if memory_written:
+            state["turns_since_write"] = 0
+            state["writes"] += 1
+
+    async def _run_turn_memory_review(self) -> bool:
+        registry = self._build_memory_review_registry()
+        if registry is None:
+            return False
+        review_messages = build_turn_memory_review_messages(
+            self._messages,
+            self._cwd,
+            max_messages=self._memory_review_max_messages,
+            extra_skill_dirs=self._metadata_paths("extra_skill_dirs"),
+            extra_plugin_roots=self._metadata_paths("extra_plugin_roots"),
+            repeat_prompt_candidates=self._repeat_prompt_candidates(),
+        )
+        if not review_messages:
+            return False
+        review_context = QueryContext(
+            api_client=self._api_client,
+            tool_registry=registry,
+            permission_checker=PermissionChecker(PermissionSettings(mode=PermissionMode.FULL_AUTO)),
+            cwd=self._cwd,
+            model=self._model,
+            system_prompt=AUTO_MEMORY_REVIEW_SYSTEM_PROMPT,
+            max_tokens=min(self._max_tokens, 1024),
+            max_turns=3,
+            tool_metadata=self._tool_metadata,
+        )
+        memory_written = False
+        try:
+            async for event, usage in run_query(review_context, review_messages):
+                if usage is not None:
+                    self._cost_tracker.add(usage)
+                if isinstance(event, ToolExecutionCompleted) and event.tool_name == "memory_write" and not event.is_error:
+                    memory_written = True
+                if isinstance(event, ErrorEvent):
+                    return False
+        except Exception:
+            log.exception("Automatic memory review failed")
+            return False
+        return memory_written
 
     @property
     def messages(self) -> list[ConversationMessage]:
@@ -169,8 +409,10 @@ class QueryEngine:
             if isinstance(prompt, ConversationMessage)
             else ConversationMessage.from_user_text(prompt)
         )
-        if user_message.text.strip() and not self._tool_metadata.pop("_suppress_next_user_goal", False):
-            remember_user_goal(self._tool_metadata, user_message.text)
+        if user_message.text.strip():
+            self._note_user_prompt(user_message.text)
+            if not self._tool_metadata.pop("_suppress_next_user_goal", False):
+                remember_user_goal(self._tool_metadata, user_message.text)
         self._messages = sanitize_conversation_messages(self._messages)
         self._messages.append(user_message)
         if self._hook_executor is not None:
@@ -201,15 +443,22 @@ class QueryEngine:
         coordinator_context = self._build_coordinator_context_message()
         if coordinator_context is not None:
             query_messages.append(coordinator_context)
+        completed_turn = False
+        memory_tool_used = False
         try:
             async for event, usage in run_query(context, query_messages):
                 if isinstance(event, AssistantTurnComplete):
                     self._messages = list(query_messages)
+                    completed_turn = True
+                elif isinstance(event, ToolExecutionCompleted) and event.tool_name == "memory_write" and not event.is_error:
+                    memory_tool_used = True
                 if usage is not None:
                     self._cost_tracker.add(usage)
                 yield event
         finally:
             self._schedule_auto_dream()
+        if completed_turn and not self.has_pending_continuation() and self._should_run_memory_review(memory_tool_used=memory_tool_used):
+            self._complete_memory_review(memory_written=await self._run_turn_memory_review())
 
     async def continue_pending(self, *, max_turns: int | None = None) -> AsyncIterator[StreamEvent]:
         """Continue an interrupted tool loop without appending a new user message."""
@@ -229,7 +478,15 @@ class QueryEngine:
             hook_executor=self._hook_executor,
             tool_metadata=self._tool_metadata,
         )
+        completed_turn = False
+        memory_tool_used = False
         async for event, usage in run_query(context, self._messages):
+            if isinstance(event, AssistantTurnComplete):
+                completed_turn = True
+            elif isinstance(event, ToolExecutionCompleted) and event.tool_name == "memory_write" and not event.is_error:
+                memory_tool_used = True
             if usage is not None:
                 self._cost_tracker.add(usage)
             yield event
+        if completed_turn and not self.has_pending_continuation() and self._should_run_memory_review(memory_tool_used=memory_tool_used):
+            self._complete_memory_review(memory_written=await self._run_turn_memory_review())

--- a/src/openharness/memory/__init__.py
+++ b/src/openharness/memory/__init__.py
@@ -1,18 +1,50 @@
 """Memory exports."""
 
 from openharness.memory.memdir import load_memory_prompt
-from openharness.memory.manager import add_memory_entry, list_memory_files, remove_memory_entry
-from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.memory.manager import add_memory_entry, list_memory_files, remove_memory_entry, upsert_memory_entry
+from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir, get_project_memory_entries_dir
+from openharness.memory.provider import (
+    configure_memory_provider,
+    create_memory_provider,
+    FileMemoryStoreProvider,
+    list_memory_provider_names,
+    MemoryProviderFactory,
+    MemoryStoreProvider,
+    get_default_memory_provider,
+    get_memory_provider,
+    register_memory_provider_factory,
+    register_memory_provider,
+    reset_memory_provider_registry,
+    set_default_memory_provider,
+    unregister_memory_provider_factory,
+    unregister_memory_provider,
+)
 from openharness.memory.scan import scan_memory_files
 from openharness.memory.search import find_relevant_memories
 
 __all__ = [
     "add_memory_entry",
+    "configure_memory_provider",
+    "create_memory_provider",
+    "FileMemoryStoreProvider",
     "find_relevant_memories",
+    "get_default_memory_provider",
     "get_memory_entrypoint",
+    "get_memory_provider",
+    "get_project_memory_entries_dir",
     "get_project_memory_dir",
     "list_memory_files",
+    "list_memory_provider_names",
     "load_memory_prompt",
+    "MemoryProviderFactory",
+    "MemoryStoreProvider",
+    "register_memory_provider_factory",
+    "register_memory_provider",
     "remove_memory_entry",
+    "reset_memory_provider_registry",
     "scan_memory_files",
+    "set_default_memory_provider",
+    "unregister_memory_provider_factory",
+    "unregister_memory_provider",
+    "upsert_memory_entry",
 ]

--- a/src/openharness/memory/auto_write.py
+++ b/src/openharness/memory/auto_write.py
@@ -1,0 +1,221 @@
+"""Helpers for automatic durable memory writes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from openharness.engine.messages import ConversationMessage, TextBlock, ToolResultBlock, ToolUseBlock
+from openharness.memory.manager import upsert_memory_entry
+from openharness.memory.memdir import load_memory_review_snapshot
+from openharness.personalization.extractor import extract_facts_from_text
+from openharness.skills.loader import load_skill_registry, strip_skill_frontmatter
+
+MEMORY_POLICY_SKILL_NAME = "durable-memory-policy"
+MEMORY_REVIEW_SKILL_NAME = "durable-memory-reviewer"
+
+AUTO_MEMORY_REVIEW_SYSTEM_PROMPT = """You are OpenHarness's internal durable-memory reviewer.
+
+Your operating procedure is provided by the loaded durable-memory-policy and durable-memory-reviewer skills.
+Follow that skill when deciding whether the completed turn should update persistent memory.
+If no memory update is needed, reply with exactly NO_MEMORY_UPDATE.
+After finishing all required writes, reply with exactly MEMORY_REVIEW_COMPLETE."""
+
+
+def _truncate(text: str, limit: int) -> str:
+    cleaned = text.strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[:limit] + "..."
+
+
+def _message_text(message: ConversationMessage) -> str:
+    chunks: list[str] = []
+    for block in message.content:
+        if isinstance(block, TextBlock) and block.text.strip():
+            chunks.append(block.text.strip())
+        elif isinstance(block, ToolResultBlock) and block.content.strip():
+            chunks.append(f"[tool_result]\n{block.content.strip()}")
+        elif isinstance(block, ToolUseBlock):
+            chunks.append(f"[tool_use] {block.name}")
+    return "\n\n".join(chunk for chunk in chunks if chunk)
+
+
+def _load_memory_skill_contents(
+    cwd: str | Path,
+    *,
+    extra_skill_dirs: Iterable[str | Path] | None = None,
+    extra_plugin_roots: Iterable[str | Path] | None = None,
+    settings=None,
+) -> dict[str, str]:
+    registry = load_skill_registry(
+        cwd,
+        extra_skill_dirs=extra_skill_dirs,
+        extra_plugin_roots=extra_plugin_roots,
+        settings=settings,
+    )
+    contents: dict[str, str] = {}
+    for skill_name in (MEMORY_POLICY_SKILL_NAME, MEMORY_REVIEW_SKILL_NAME):
+        skill = registry.get(skill_name)
+        contents[skill_name] = strip_skill_frontmatter(skill.content).strip() if skill is not None else ""
+    return contents
+
+
+def load_memory_policy_skill_content(
+    cwd: str | Path,
+    *,
+    extra_skill_dirs: Iterable[str | Path] | None = None,
+    extra_plugin_roots: Iterable[str | Path] | None = None,
+    settings=None,
+) -> str:
+    """Load the shared durable-memory policy skill content."""
+    return _load_memory_skill_contents(
+        cwd,
+        extra_skill_dirs=extra_skill_dirs,
+        extra_plugin_roots=extra_plugin_roots,
+        settings=settings,
+    ).get(MEMORY_POLICY_SKILL_NAME, "")
+
+
+def load_memory_review_skill_content(
+    cwd: str | Path,
+    *,
+    extra_skill_dirs: Iterable[str | Path] | None = None,
+    extra_plugin_roots: Iterable[str | Path] | None = None,
+) -> str:
+    """Load the durable-memory-reviewer skill content.
+
+    This makes automatic memory review follow the same skill loading path as the
+    interactive runtime, so bundled, user, or plugin overrides can replace the
+    default reviewer instructions.
+    """
+    return _load_memory_skill_contents(
+        cwd,
+        extra_skill_dirs=extra_skill_dirs,
+        extra_plugin_roots=extra_plugin_roots,
+    ).get(MEMORY_REVIEW_SKILL_NAME, "")
+
+
+def build_turn_memory_review_prompt(
+    messages: list[ConversationMessage],
+    cwd: str | Path,
+    *,
+    max_messages: int = 8,
+    repeat_prompt_candidates: list[dict[str, object]] | None = None,
+) -> str:
+    """Build the transcript payload for one automatic memory review pass."""
+    recent_messages = messages[-max_messages:]
+    rendered_messages: list[str] = []
+    extracted_text_parts: list[str] = []
+
+    for message in recent_messages:
+        rendered = _message_text(message)
+        if not rendered:
+            continue
+        extracted_text_parts.append(rendered)
+        rendered_messages.append(f"## {message.role.title()}\n{_truncate(rendered, 1600)}")
+
+    lines = ["# Completed Conversation Turn", ""]
+    if rendered_messages:
+        lines.extend(rendered_messages)
+    else:
+        lines.append("(No textual content to review.)")
+
+    fact_candidates = extract_facts_from_text("\n".join(extracted_text_parts))
+    if fact_candidates:
+        lines.extend(["", "# Deterministic Fact Candidates"])
+        for fact in fact_candidates:
+            lines.append(f"- {fact['key']} -> {fact['value']}")
+
+    memory_snapshot = load_memory_review_snapshot(cwd, max_entries=12)
+    if memory_snapshot:
+        lines.extend(["", memory_snapshot])
+
+    if repeat_prompt_candidates:
+        lines.extend(["", "# Repeated User Prompt Candidates"])
+        for candidate in repeat_prompt_candidates:
+            prompt_text = str(candidate.get("prompt") or "").strip()
+            count = candidate.get("count", 0)
+            count_value = int(count) if isinstance(count, (int, float)) else 0
+            if not prompt_text or count_value <= 0:
+                continue
+            lines.append(f"- Asked {count_value} times this session: {prompt_text}")
+        lines.extend(
+            [
+                "",
+                "Repeated prompts can indicate a stable workflow preference or default tool choice when they are likely to matter in future sessions.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "# Review Instruction",
+            "Write memory only when the value is clearly durable across future sessions.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_turn_memory_review_messages(
+    messages: list[ConversationMessage],
+    cwd: str | Path,
+    *,
+    max_messages: int = 8,
+    extra_skill_dirs: Iterable[str | Path] | None = None,
+    extra_plugin_roots: Iterable[str | Path] | None = None,
+    repeat_prompt_candidates: list[dict[str, object]] | None = None,
+) -> list[ConversationMessage]:
+    """Build the full message list for one automatic memory review pass."""
+    review_prompt = build_turn_memory_review_prompt(
+        messages,
+        cwd,
+        max_messages=max_messages,
+        repeat_prompt_candidates=repeat_prompt_candidates,
+    )
+    if not review_prompt.strip():
+        return []
+
+    review_messages: list[ConversationMessage] = []
+    skill_contents = _load_memory_skill_contents(
+        cwd,
+        extra_skill_dirs=extra_skill_dirs,
+        extra_plugin_roots=extra_plugin_roots,
+    )
+    policy_content = skill_contents.get(MEMORY_POLICY_SKILL_NAME, "")
+    reviewer_content = skill_contents.get(MEMORY_REVIEW_SKILL_NAME, "")
+    if policy_content:
+        review_messages.append(ConversationMessage.from_user_text(policy_content))
+    if reviewer_content:
+        review_messages.append(ConversationMessage.from_user_text(reviewer_content))
+    review_messages.append(ConversationMessage.from_user_text(review_prompt))
+    return review_messages
+
+
+def sync_fact_memories(cwd: str | Path, facts: list[dict]) -> int:
+    """Persist extracted durable facts into project memory as keyed entries."""
+    changed = 0
+    for fact in facts:
+        key = str(fact.get("key") or "").strip()
+        value = str(fact.get("value") or "").strip()
+        label = str(fact.get("label") or fact.get("type") or "Fact").strip()
+        fact_type = str(fact.get("type") or "environment").strip()
+        if not key or not value:
+            continue
+        title = f"{label}: {value}"
+        description = f"Auto-captured durable fact for {label.lower()}"
+        content = (
+            f"{label}: `{value}`\n\n"
+            f"Captured automatically from conversation history as durable {fact_type.replace('_', ' ')} context."
+        )
+        _, status = upsert_memory_entry(
+            cwd,
+            key=key,
+            title=title,
+            description=description,
+            memory_type=fact_type,
+            content=content,
+        )
+        if status != "unchanged":
+            changed += 1
+    return changed

--- a/src/openharness/memory/manager.py
+++ b/src/openharness/memory/manager.py
@@ -2,57 +2,393 @@
 
 from __future__ import annotations
 
+from hashlib import sha1
 from pathlib import Path
+import re
 from re import sub
 
-from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.memory.provider import get_memory_provider
+from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir, get_project_memory_entries_dir
+from openharness.memory.scan import _parse_memory_file, scan_memory_files_in_file_store, write_memory_index
+from openharness.memory.types import MemoryHeader
 from openharness.utils.file_lock import exclusive_file_lock
 from openharness.utils.fs import atomic_write_text
 
 
+_MAX_MEMORY_FILENAME_CHARS = 72
+_GENERIC_MEMORY_FILENAME_STEMS = {"", "memory", "entry"}
+_MEMORY_TYPE_GROUPS = {
+	"guardrail": "guardrail_family",
+	"forbidden_command": "guardrail_family",
+	"protected_path": "guardrail_family",
+	"style_rule": "style_rule_family",
+	"naming_rule": "style_rule_family",
+	"validation_rule": "style_rule_family",
+	"retry_rule": "style_rule_family",
+}
+
+
 def _memory_lock_path(cwd: str | Path) -> Path:
-    return get_project_memory_dir(cwd) / ".memory.lock"
+	return get_project_memory_dir(cwd) / ".memory.lock"
+
+
+def list_memory_files_in_file_store(cwd: str | Path) -> list[Path]:
+	"""List memory markdown files for the project."""
+	return [header.path for header in scan_memory_files_in_file_store(cwd, max_files=None)]
+
+
+def _slugify_english_memory_name(
+	value: str,
+	*,
+	max_length: int = _MAX_MEMORY_FILENAME_CHARS,
+	fallback: str = "memory",
+) -> str:
+	normalized = " ".join(value.split()).strip().lower()
+	normalized = normalized.replace("/", " ").replace("\\", " ").replace(":", " ")
+	slug = sub(r"[^a-z0-9]+", "_", normalized)
+	slug = sub(r"_+", "_", slug).strip("._ ")
+	if len(slug) <= max_length:
+		return slug or fallback
+	tokens = [token for token in slug.split("_") if token]
+	kept: list[str] = []
+	kept_len = 0
+	for token in tokens:
+		extra = len(token) + (1 if kept else 0)
+		if kept_len + extra > max_length - 9:
+			break
+		kept.append(token)
+		kept_len += extra
+	shortened = "_".join(kept).strip("._ ")
+	if not shortened:
+		shortened = slug[: max_length - 9].rstrip("._ ")
+	suffix = sha1(slug.encode("utf-8")).hexdigest()[:8]
+	return f"{shortened}_{suffix}" if shortened else f"{fallback}_{suffix}"
+
+
+def _ascii_tokens(text: str) -> list[str]:
+	return re.findall(r"[A-Za-z0-9]+", text)
+
+
+def _first_memory_content_line(content: str) -> str:
+	for line in content.splitlines():
+		stripped = line.strip()
+		if stripped:
+			return sub(r"[。！？.!?].*$", "", stripped)[:120]
+	return ""
+
+
+def _memory_filename_stem(title: str, description: str, content: str, key: str, memory_type: str) -> str:
+	key_slug = _slugify_english_memory_name(key, fallback="")
+	if key_slug not in _GENERIC_MEMORY_FILENAME_STEMS:
+		return key_slug
+	for candidate in (title, description, _first_memory_content_line(content)):
+		tokens = _ascii_tokens(candidate)
+		if tokens:
+			slug = _slugify_english_memory_name(" ".join(tokens), fallback="")
+			if slug not in _GENERIC_MEMORY_FILENAME_STEMS:
+				return slug
+	type_slug = _slugify_english_memory_name(memory_type, fallback="")
+	if type_slug not in _GENERIC_MEMORY_FILENAME_STEMS:
+		suffix = sha1(f"{title}\n{description}\n{content}".encode("utf-8")).hexdigest()[:8]
+		return f"{type_slug}_{suffix}"
+	return f"memory_{sha1((key or title or content).encode('utf-8')).hexdigest()[:8]}"
+
+
+def _normalize_frontmatter_value(value: str) -> str:
+	cleaned = " ".join(value.split()).strip()
+	return cleaned.replace('"', "'")
+
+
+def _normalize_semantic_value(value: str) -> str:
+	return " ".join(value.split()).strip().casefold()
+
+
+def _default_description(content: str) -> str:
+	for line in content.splitlines():
+		stripped = line.strip()
+		if stripped:
+			return stripped[:200]
+	return ""
+
+
+def _render_memory_document(
+	*,
+	key: str,
+	title: str,
+	content: str,
+	description: str,
+	memory_type: str,
+) -> str:
+	frontmatter = ["---", f"key: {_normalize_frontmatter_value(key)}", f"name: {_normalize_frontmatter_value(title)}"]
+	normalized_description = _normalize_frontmatter_value(description)
+	if normalized_description:
+		frontmatter.append(f"description: {normalized_description}")
+	normalized_type = _normalize_frontmatter_value(memory_type)
+	if normalized_type:
+		frontmatter.append(f"type: {normalized_type}")
+	frontmatter.extend(["---", ""])
+	return "\n".join(frontmatter) + content.strip() + "\n"
+
+
+def _find_memory_file_by_key(headers: list[MemoryHeader], key: str) -> Path | None:
+	normalized = key.strip()
+	if not normalized:
+		return None
+	for header in headers:
+		if header.memory_key == normalized:
+			return header.path
+	return None
+
+
+def _memory_type_group(value: str) -> str:
+	normalized = _normalize_semantic_value(value)
+	return _MEMORY_TYPE_GROUPS.get(normalized, normalized)
+
+
+def _memory_types_are_compatible(existing_type: str, incoming_type: str) -> bool:
+	existing = _normalize_semantic_value(existing_type)
+	incoming = _normalize_semantic_value(incoming_type)
+	if not existing or not incoming or existing == incoming:
+		return True
+	return _memory_type_group(existing) == _memory_type_group(incoming)
+
+
+def _find_semantic_duplicate_paths(headers: list[MemoryHeader], title: str, memory_type: str) -> list[Path]:
+	normalized_title = _normalize_semantic_value(title)
+	if not normalized_title:
+		return []
+
+	matches = [
+		header
+		for header in headers
+		if _normalize_semantic_value(header.title) == normalized_title
+		and _memory_types_are_compatible(header.memory_type, memory_type)
+	]
+	matches.sort(key=lambda header: header.modified_at, reverse=True)
+	return [header.path for header in matches]
+
+
+def _replace_memory_header(
+	headers: list[MemoryHeader],
+	*,
+	path: Path,
+	rendered: str,
+	removed_paths: list[Path],
+) -> list[MemoryHeader]:
+	remaining = [header for header in headers if header.path != path and header.path not in removed_paths]
+	remaining.append(_parse_memory_file(path, rendered))
+	remaining.sort(key=lambda header: header.modified_at, reverse=True)
+	return remaining
+
+
+def _memory_relative_path(entrypoint: Path, path: Path) -> str:
+	return path.relative_to(entrypoint.parent).as_posix()
+
+
+def _allocate_memory_path(
+	cwd: str | Path,
+	title: str,
+	key: str,
+	description: str = "",
+	content: str = "",
+	memory_type: str = "",
+) -> Path:
+	entries_dir = get_project_memory_entries_dir(cwd)
+	slug = _memory_filename_stem(title, description, content, key, memory_type)
+	candidate = entries_dir / f"{slug}.md"
+	if not candidate.exists():
+		return candidate
+	suffix_source = key.strip() or f"{title}\n{description}\n{content}"
+	suffix = sha1(suffix_source.encode("utf-8")).hexdigest()[:8]
+	if suffix and candidate.stem != f"{slug}_{suffix}":
+		alt = entries_dir / f"{slug}_{suffix}.md"
+		if not alt.exists():
+			return alt
+	counter = 2
+	while True:
+		alt = entries_dir / f"{slug}_{counter}.md"
+		if not alt.exists():
+			return alt
+		counter += 1
+
+
+def _sync_memory_index(entrypoint: Path, *, path: Path, title: str) -> None:
+	relative_path = _memory_relative_path(entrypoint, path)
+	entry_line = f"- [{title}]({relative_path})"
+	existing_lines = entrypoint.read_text(encoding="utf-8").splitlines() if entrypoint.exists() else ["# Memory Index"]
+	replaced = False
+	updated_lines: list[str] = []
+	for line in existing_lines:
+		if f"({relative_path})" in line:
+			updated_lines.append(entry_line)
+			replaced = True
+		else:
+			updated_lines.append(line)
+	if not replaced:
+		updated_lines.append(entry_line)
+	atomic_write_text(entrypoint, "\n".join(updated_lines).rstrip() + "\n")
+
+
+def _prune_memory_index_paths(entrypoint: Path, paths: list[Path]) -> None:
+	if not paths or not entrypoint.exists():
+		return
+	removed_names = {_memory_relative_path(entrypoint, path) for path in paths}
+	updated_lines = [
+		line
+		for line in entrypoint.read_text(encoding="utf-8").splitlines()
+		if not any(f"({name})" in line for name in removed_names)
+	]
+	atomic_write_text(entrypoint, "\n".join(updated_lines).rstrip() + "\n")
+
+
+def upsert_memory_entry_in_file_store(
+	cwd: str | Path,
+	*,
+	key: str,
+	title: str,
+	content: str,
+	description: str = "",
+	memory_type: str = "",
+) -> tuple[Path, str]:
+	"""Create or update a structured memory entry keyed by durable identity."""
+	normalized_key = key.strip()
+	if not normalized_key:
+		raise ValueError("Memory key must not be empty")
+	normalized_title = title.strip() or normalized_key
+	normalized_content = content.strip()
+	if not normalized_content:
+		raise ValueError("Memory content must not be empty")
+	normalized_description = description.strip() or _default_description(normalized_content)
+	normalized_type = memory_type.strip()
+
+	with exclusive_file_lock(_memory_lock_path(cwd)):
+		headers = scan_memory_files_in_file_store(cwd, max_files=None)
+		path = _find_memory_file_by_key(headers, normalized_key)
+		semantic_matches = _find_semantic_duplicate_paths(headers, normalized_title, normalized_type)
+		duplicate_paths: list[Path] = []
+		if path is None:
+			if semantic_matches:
+				path = semantic_matches[0]
+				duplicate_paths = semantic_matches[1:]
+		else:
+			duplicate_paths = [candidate for candidate in semantic_matches if candidate != path]
+		status = "created"
+		if path is None:
+			path = _allocate_memory_path(
+				cwd,
+				normalized_title,
+				normalized_key,
+				normalized_description,
+				normalized_content,
+				normalized_type,
+			)
+		else:
+			status = "updated"
+
+		rendered = _render_memory_document(
+			key=normalized_key,
+			title=normalized_title,
+			content=normalized_content,
+			description=normalized_description,
+			memory_type=normalized_type,
+		)
+		if path.exists() and path.read_text(encoding="utf-8") == rendered:
+			status = "unchanged"
+		else:
+			atomic_write_text(path, rendered)
+
+		for duplicate_path in duplicate_paths:
+			if duplicate_path.exists() and duplicate_path != path:
+				duplicate_path.unlink()
+
+		entrypoint = get_memory_entrypoint(cwd)
+		_prune_memory_index_paths(entrypoint, duplicate_paths)
+		_sync_memory_index(entrypoint, path=path, title=normalized_title)
+		write_memory_index(
+			cwd,
+			_replace_memory_header(headers, path=path, rendered=rendered, removed_paths=duplicate_paths),
+		)
+		if duplicate_paths and status == "unchanged":
+			status = "updated"
+	return path, status
+
+
+def add_memory_entry_in_file_store(cwd: str | Path, title: str, content: str) -> Path:
+	"""Create a memory file and append it to MEMORY.md."""
+	with exclusive_file_lock(_memory_lock_path(cwd)):
+		headers = scan_memory_files_in_file_store(cwd, max_files=None)
+		path = _allocate_memory_path(
+			cwd,
+			title.strip(),
+			"",
+			_default_description(content),
+			content,
+			"",
+		)
+		atomic_write_text(path, content.strip() + "\n")
+		_sync_memory_index(get_memory_entrypoint(cwd), path=path, title=title.strip() or path.stem)
+		write_memory_index(cwd, _replace_memory_header(headers, path=path, rendered=content.strip() + "\n", removed_paths=[]))
+	return path
+
+
+def remove_memory_entry_in_file_store(cwd: str | Path, name: str) -> bool:
+	"""Delete a memory file and remove its index entry."""
+	identifier = name.strip()
+	with exclusive_file_lock(_memory_lock_path(cwd)):
+		headers = scan_memory_files_in_file_store(cwd, max_files=None)
+		entrypoint = get_memory_entrypoint(cwd)
+		matches = [
+			header.path
+			for header in headers
+			if header.path.stem == identifier
+			or header.path.name == identifier
+			or _memory_relative_path(entrypoint, header.path) == identifier
+		]
+		path = matches[0] if matches else _find_memory_file_by_key(headers, identifier)
+		if path is None:
+			return False
+		if path.exists():
+			path.unlink()
+
+		if entrypoint.exists():
+			_prune_memory_index_paths(entrypoint, [path])
+		write_memory_index(cwd, [header for header in headers if header.path != path])
+	return True
 
 
 def list_memory_files(cwd: str | Path) -> list[Path]:
-    """List memory markdown files for the project."""
-    memory_dir = get_project_memory_dir(cwd)
-    return sorted(path for path in memory_dir.glob("*.md"))
+	"""List memory markdown files from the active memory provider."""
+	return get_memory_provider(cwd).list_memory_files(cwd)
+
+
+def upsert_memory_entry(
+	cwd: str | Path,
+	*,
+	key: str,
+	title: str,
+	content: str,
+	description: str = "",
+	memory_type: str = "",
+) -> tuple[Path, str]:
+	"""Create or update a structured memory entry via the active provider."""
+	return get_memory_provider(cwd).upsert_memory_entry(
+		cwd,
+		key=key,
+		title=title,
+		content=content,
+		description=description,
+		memory_type=memory_type,
+	)
 
 
 def add_memory_entry(cwd: str | Path, title: str, content: str) -> Path:
-    """Create a memory file and append it to MEMORY.md."""
-    memory_dir = get_project_memory_dir(cwd)
-    slug = sub(r"[^a-zA-Z0-9]+", "_", title.strip().lower()).strip("_") or "memory"
-    path = memory_dir / f"{slug}.md"
-    with exclusive_file_lock(_memory_lock_path(cwd)):
-        atomic_write_text(path, content.strip() + "\n")
-
-        entrypoint = get_memory_entrypoint(cwd)
-        existing = entrypoint.read_text(encoding="utf-8") if entrypoint.exists() else "# Memory Index\n"
-        if path.name not in existing:
-            existing = existing.rstrip() + f"\n- [{title}]({path.name})\n"
-            atomic_write_text(entrypoint, existing)
-    return path
+	"""Create a memory entry via the active provider."""
+	return get_memory_provider(cwd).add_memory_entry(cwd, title, content)
 
 
 def remove_memory_entry(cwd: str | Path, name: str) -> bool:
-    """Delete a memory file and remove its index entry."""
-    memory_dir = get_project_memory_dir(cwd)
-    matches = [path for path in memory_dir.glob("*.md") if path.stem == name or path.name == name]
-    if not matches:
-        return False
-    path = matches[0]
-    with exclusive_file_lock(_memory_lock_path(cwd)):
-        if path.exists():
-            path.unlink()
+	"""Delete a memory entry via the active provider."""
+	return get_memory_provider(cwd).remove_memory_entry(cwd, name)
 
-        entrypoint = get_memory_entrypoint(cwd)
-        if entrypoint.exists():
-            lines = [
-                line
-                for line in entrypoint.read_text(encoding="utf-8").splitlines()
-                if path.name not in line
-            ]
-            atomic_write_text(entrypoint, "\n".join(lines).rstrip() + "\n")
-    return True
+
+__all__ = ["add_memory_entry", "list_memory_files", "remove_memory_entry", "upsert_memory_entry"]

--- a/src/openharness/memory/memdir.py
+++ b/src/openharness/memory/memdir.py
@@ -4,18 +4,30 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir, get_project_memory_entries_dir
+from openharness.memory.scan import scan_memory_files
+
+
+def _truncate(text: str, limit: int) -> str:
+    cleaned = " ".join(text.split()).strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[:limit].rstrip() + "..."
 
 
 def load_memory_prompt(cwd: str | Path, *, max_entrypoint_lines: int = 200) -> str | None:
     """Return the memory prompt section for the current project."""
     memory_dir = get_project_memory_dir(cwd)
+    entries_dir = get_project_memory_entries_dir(cwd)
     entrypoint = get_memory_entrypoint(cwd)
     lines = [
         "# Memory",
         f"- Persistent memory directory: {memory_dir}",
+        f"- Child memory entries directory: {entries_dir}",
         "- Use this directory to store durable user or project context that should survive future sessions.",
-        "- Prefer concise topic files plus an index entry in MEMORY.md.",
+        "- Prefer concise English child-memory files under entries/ plus an index entry in MEMORY.md.",
+        "- Treat MEMORY.md as the default index. Do not preload linked child memory files into context.",
+        "- When a user asks about a linked memory entry or you need its details, read that child file on demand via the path in MEMORY.md.",
     ]
 
     if entrypoint.exists():
@@ -30,5 +42,28 @@ def load_memory_prompt(cwd: str | Path, *, max_entrypoint_lines: int = 200) -> s
                 "(not created yet)",
             ]
         )
+
+    return "\n".join(lines)
+
+
+def load_memory_review_snapshot(cwd: str | Path, *, max_entries: int = 12) -> str | None:
+    """Return a compact memory summary tailored for turn-level review prompts."""
+    headers = scan_memory_files(cwd, max_files=None)
+    if not headers:
+        return None
+
+    lines = ["# Current Durable Memories", f"- Total entries: {len(headers)}"]
+    for header in headers[:max_entries]:
+        identity = header.memory_key or header.path.stem
+        detail_parts = [identity]
+        if header.memory_type:
+            detail_parts.append(header.memory_type)
+        detail_parts.append(_truncate(header.title, 120))
+        if header.description:
+            detail_parts.append(_truncate(header.description, 140))
+        lines.append(f"- {' | '.join(part for part in detail_parts if part)}")
+
+    if len(headers) > max_entries:
+        lines.append(f"- ... {len(headers) - max_entries} more entries in MEMORY.md")
 
     return "\n".join(lines)

--- a/src/openharness/memory/paths.py
+++ b/src/openharness/memory/paths.py
@@ -2,21 +2,144 @@
 
 from __future__ import annotations
 
+import contextlib
 from hashlib import sha1
 from pathlib import Path
+import re
 
-from openharness.config.paths import get_data_dir
+from openharness.config.paths import get_data_dir, get_memory_store_dir, memory_store_uses_shared_root
+from openharness.utils.fs import atomic_write_text
+
+
+_MEMORY_INDEX_LINE_RE = re.compile(r"^\s*-\s*\[(?P<title>[^\]]+)\]\((?P<target>[^)]+)\)\s*$")
+
+
+def _project_memory_leaf(path: Path) -> str:
+    digest = sha1(str(path).encode("utf-8")).hexdigest()[:12]
+    return f"{path.name}-{digest}"
+
+
+def _append_index_entry(entrypoint: Path, *, title: str, relative_path: str) -> None:
+    entry_line = f"- [{title}]({relative_path})"
+    existing_lines = entrypoint.read_text(encoding="utf-8").splitlines() if entrypoint.exists() else ["# Memory Index"]
+    for index, line in enumerate(existing_lines):
+        if f"({relative_path})" in line:
+            existing_lines[index] = entry_line
+            break
+    else:
+        existing_lines.append(entry_line)
+    atomic_write_text(entrypoint, "\n".join(existing_lines).rstrip() + "\n")
+
+
+def _iter_legacy_memory_files(legacy_dir: Path) -> list[tuple[Path, str]]:
+    entrypoint = legacy_dir / "MEMORY.md"
+    indexed: list[tuple[Path, str]] = []
+    seen: set[Path] = set()
+    if entrypoint.exists():
+        for line in entrypoint.read_text(encoding="utf-8").splitlines():
+            match = _MEMORY_INDEX_LINE_RE.match(line)
+            if match is None:
+                continue
+            path = (legacy_dir / match.group("target").strip()).resolve()
+            if path.name == "MEMORY.md" or not path.exists() or path in seen:
+                continue
+            indexed.append((path, match.group("title").strip() or path.stem))
+            seen.add(path)
+
+    for path in legacy_dir.rglob("*.md"):
+        resolved = path.resolve()
+        if path.name == "MEMORY.md" or resolved in seen:
+            continue
+        indexed.append((resolved, path.stem))
+        seen.add(resolved)
+    return indexed
+
+
+def _allocate_merged_legacy_path(memory_root: Path, source_path: Path) -> Path:
+    entries_dir = memory_root / "entries"
+    entries_dir.mkdir(parents=True, exist_ok=True)
+    candidate = entries_dir / source_path.name
+    if not candidate.exists():
+        return candidate
+    stem = source_path.stem
+    suffix = source_path.suffix
+    counter = 2
+    while True:
+        alt = entries_dir / f"{stem}_{counter}{suffix}"
+        if not alt.exists():
+            return alt
+        counter += 1
+
+
+def _merge_single_legacy_project_memory_dir(legacy_dir: Path, memory_root: Path) -> None:
+    if not legacy_dir.exists() or legacy_dir == memory_root:
+        return
+
+    target_entrypoint = memory_root / "MEMORY.md"
+    for source_path, title in _iter_legacy_memory_files(legacy_dir):
+        destination = _allocate_merged_legacy_path(memory_root, source_path)
+        destination.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+        source_path.unlink(missing_ok=True)
+        _append_index_entry(
+            target_entrypoint,
+            title=title,
+            relative_path=destination.relative_to(memory_root).as_posix(),
+        )
+
+    for child in sorted(legacy_dir.rglob("*"), reverse=True):
+        if child.is_file():
+            child.unlink(missing_ok=True)
+        elif child.is_dir():
+            with contextlib.suppress(OSError):
+                child.rmdir()
+    with contextlib.suppress(OSError):
+        legacy_dir.rmdir()
+
+
+def _merge_legacy_project_memory_dir(path: Path, memory_root: Path) -> None:
+    leaf = _project_memory_leaf(path)
+    candidates = [memory_root / leaf, get_data_dir() / "memory" / leaf]
+    seen: set[Path] = set()
+    for legacy_dir in candidates:
+        resolved = legacy_dir.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        _merge_single_legacy_project_memory_dir(legacy_dir, memory_root)
 
 
 def get_project_memory_dir(cwd: str | Path) -> Path:
     """Return the persistent memory directory for a project."""
     path = Path(cwd).resolve()
-    digest = sha1(str(path).encode("utf-8")).hexdigest()[:12]
-    memory_dir = get_data_dir() / "memory" / f"{path.name}-{digest}"
+    memory_root = get_memory_store_dir()
+    if memory_store_uses_shared_root():
+        memory_root.mkdir(parents=True, exist_ok=True)
+        _merge_legacy_project_memory_dir(path, memory_root)
+        return memory_root
+
+    leaf = _project_memory_leaf(path)
+    memory_dir = memory_root / leaf
+    legacy_dir = get_data_dir() / "memory" / leaf
+
+    if not memory_dir.exists() and legacy_dir.exists() and legacy_dir != memory_dir:
+        legacy_dir.rename(memory_dir)
+
     memory_dir.mkdir(parents=True, exist_ok=True)
     return memory_dir
+
+
+def get_project_memory_entries_dir(cwd: str | Path) -> Path:
+    """Return the directory that stores child memory entry files."""
+    entries_dir = get_project_memory_dir(cwd) / "entries"
+    entries_dir.mkdir(parents=True, exist_ok=True)
+    return entries_dir
 
 
 def get_memory_entrypoint(cwd: str | Path) -> Path:
     """Return the project memory entrypoint file."""
     return get_project_memory_dir(cwd) / "MEMORY.md"
+
+
+def get_memory_metadata_index(cwd: str | Path) -> Path:
+    """Return the hidden metadata index used by the memory store."""
+    return get_project_memory_dir(cwd) / ".memory.index.json"

--- a/src/openharness/memory/provider.py
+++ b/src/openharness/memory/provider.py
@@ -1,0 +1,230 @@
+"""Memory store provider abstraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Protocol
+
+from openharness.memory.types import MemoryHeader
+
+
+class MemoryStoreProvider(Protocol):
+    """Abstract durable memory backend."""
+
+    def scan_memory_files(self, cwd: str | Path, *, max_files: int | None = 50) -> list[MemoryHeader]:
+        """Return memory headers for the project."""
+
+    def list_memory_files(self, cwd: str | Path) -> list[Path]:
+        """Return memory document paths for the project."""
+
+    def upsert_memory_entry(
+        self,
+        cwd: str | Path,
+        *,
+        key: str,
+        title: str,
+        content: str,
+        description: str = "",
+        memory_type: str = "",
+    ) -> tuple[Path, str]:
+        """Create or update one durable memory entry."""
+
+    def add_memory_entry(self, cwd: str | Path, title: str, content: str) -> Path:
+        """Append one manual memory entry."""
+
+    def remove_memory_entry(self, cwd: str | Path, name: str) -> bool:
+        """Delete one durable memory entry."""
+
+
+MemoryProviderFactory = Callable[[str | Path, Any | None], MemoryStoreProvider]
+
+
+class FileMemoryStoreProvider:
+    """Default durable memory backend backed by the local filesystem."""
+
+    def scan_memory_files(self, cwd: str | Path, *, max_files: int | None = 50) -> list[MemoryHeader]:
+        from openharness.memory.scan import scan_memory_files_in_file_store
+
+        return scan_memory_files_in_file_store(cwd, max_files=max_files)
+
+    def list_memory_files(self, cwd: str | Path) -> list[Path]:
+        return [header.path for header in self.scan_memory_files(cwd, max_files=None)]
+
+    def upsert_memory_entry(
+        self,
+        cwd: str | Path,
+        *,
+        key: str,
+        title: str,
+        content: str,
+        description: str = "",
+        memory_type: str = "",
+    ) -> tuple[Path, str]:
+        from openharness.memory.manager import upsert_memory_entry_in_file_store
+
+        return upsert_memory_entry_in_file_store(
+            cwd,
+            key=key,
+            title=title,
+            content=content,
+            description=description,
+            memory_type=memory_type,
+        )
+
+    def add_memory_entry(self, cwd: str | Path, title: str, content: str) -> Path:
+        from openharness.memory.manager import add_memory_entry_in_file_store
+
+        return add_memory_entry_in_file_store(cwd, title, content)
+
+    def remove_memory_entry(self, cwd: str | Path, name: str) -> bool:
+        from openharness.memory.manager import remove_memory_entry_in_file_store
+
+        return remove_memory_entry_in_file_store(cwd, name)
+
+
+_DEFAULT_PROVIDER: MemoryStoreProvider | None = None
+_PROVIDER_OVERRIDES: dict[Path, MemoryStoreProvider] = {}
+_PROVIDER_FACTORIES: dict[str, MemoryProviderFactory] = {}
+_PROVIDER_LOCK = RLock()
+
+
+def _normalize_root(root: str | Path) -> Path:
+    return Path(root).expanduser().resolve()
+
+
+def _normalize_provider_name(name: str) -> str:
+    return name.strip().lower()
+
+
+def _file_memory_provider_factory(cwd: str | Path, settings: Any | None = None) -> MemoryStoreProvider:
+    del cwd, settings
+    return FileMemoryStoreProvider()
+
+
+def register_memory_provider_factory(name: str, factory: MemoryProviderFactory) -> str:
+    """Register a named provider factory for runtime selection."""
+    normalized = _normalize_provider_name(name)
+    with _PROVIDER_LOCK:
+        _PROVIDER_FACTORIES[normalized] = factory
+    return normalized
+
+
+def unregister_memory_provider_factory(name: str) -> None:
+    """Remove a named provider factory."""
+    normalized = _normalize_provider_name(name)
+    with _PROVIDER_LOCK:
+        if normalized == "file":
+            _PROVIDER_FACTORIES[normalized] = _file_memory_provider_factory
+            return
+        _PROVIDER_FACTORIES.pop(normalized, None)
+
+
+def list_memory_provider_names() -> tuple[str, ...]:
+    """Return the available named memory backends."""
+    with _PROVIDER_LOCK:
+        if "file" not in _PROVIDER_FACTORIES:
+            _PROVIDER_FACTORIES["file"] = _file_memory_provider_factory
+        return tuple(sorted(_PROVIDER_FACTORIES))
+
+
+def create_memory_provider(
+    provider_name: str,
+    cwd: str | Path,
+    *,
+    settings: Any | None = None,
+) -> MemoryStoreProvider:
+    """Instantiate a named provider backend."""
+    normalized = _normalize_provider_name(provider_name or "file")
+    with _PROVIDER_LOCK:
+        if "file" not in _PROVIDER_FACTORIES:
+            _PROVIDER_FACTORIES["file"] = _file_memory_provider_factory
+        factory = _PROVIDER_FACTORIES.get(normalized)
+    if factory is None:
+        available = ", ".join(list_memory_provider_names())
+        raise ValueError(f"Unknown memory provider: {provider_name}. Available providers: {available}")
+    return factory(cwd, settings)
+
+
+def configure_memory_provider(
+    cwd: str | Path,
+    provider_name: str,
+    *,
+    settings: Any | None = None,
+) -> MemoryStoreProvider:
+    """Create and register the active provider for one project root."""
+    provider = create_memory_provider(provider_name, cwd, settings=settings)
+    register_memory_provider(cwd, provider)
+    return provider
+
+
+def get_default_memory_provider() -> MemoryStoreProvider:
+    """Return the default durable memory backend."""
+    global _DEFAULT_PROVIDER
+    with _PROVIDER_LOCK:
+        if "file" not in _PROVIDER_FACTORIES:
+            _PROVIDER_FACTORIES["file"] = _file_memory_provider_factory
+        if _DEFAULT_PROVIDER is None:
+            _DEFAULT_PROVIDER = FileMemoryStoreProvider()
+        return _DEFAULT_PROVIDER
+
+
+def set_default_memory_provider(provider: MemoryStoreProvider | None) -> None:
+    """Override the default durable memory backend."""
+    global _DEFAULT_PROVIDER
+    with _PROVIDER_LOCK:
+        _DEFAULT_PROVIDER = provider
+
+
+def register_memory_provider(root: str | Path, provider: MemoryStoreProvider) -> Path:
+    """Register a provider override for one project root."""
+    normalized = _normalize_root(root)
+    with _PROVIDER_LOCK:
+        _PROVIDER_OVERRIDES[normalized] = provider
+    return normalized
+
+
+def unregister_memory_provider(root: str | Path) -> None:
+    """Remove a provider override for one project root."""
+    normalized = _normalize_root(root)
+    with _PROVIDER_LOCK:
+        _PROVIDER_OVERRIDES.pop(normalized, None)
+
+
+def reset_memory_provider_registry() -> None:
+    """Reset all provider overrides and restore the default file backend."""
+    global _DEFAULT_PROVIDER
+    with _PROVIDER_LOCK:
+        _PROVIDER_OVERRIDES.clear()
+        _DEFAULT_PROVIDER = None
+
+
+def get_memory_provider(cwd: str | Path) -> MemoryStoreProvider:
+    """Resolve the active durable memory backend for one workspace path."""
+    normalized = _normalize_root(cwd)
+    with _PROVIDER_LOCK:
+        for root in sorted(_PROVIDER_OVERRIDES, key=lambda item: len(item.parts), reverse=True):
+            try:
+                normalized.relative_to(root)
+            except ValueError:
+                continue
+            return _PROVIDER_OVERRIDES[root]
+    return get_default_memory_provider()
+
+
+__all__ = [
+    "configure_memory_provider",
+    "create_memory_provider",
+    "FileMemoryStoreProvider",
+    "list_memory_provider_names",
+    "MemoryProviderFactory",
+    "MemoryStoreProvider",
+    "get_default_memory_provider",
+    "get_memory_provider",
+    "register_memory_provider_factory",
+    "register_memory_provider",
+    "reset_memory_provider_registry",
+    "set_default_memory_provider",
+    "unregister_memory_provider_factory",
+    "unregister_memory_provider",
+]

--- a/src/openharness/memory/scan.py
+++ b/src/openharness/memory/scan.py
@@ -2,27 +2,151 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import re
 
-from openharness.memory.paths import get_project_memory_dir
+from openharness.memory.provider import get_memory_provider
+from openharness.memory import paths as memory_paths
 from openharness.memory.types import MemoryHeader
+from openharness.utils.fs import atomic_write_text
 
 
-def scan_memory_files(cwd: str | Path, *, max_files: int = 50) -> list[MemoryHeader]:
-    """Return memory headers sorted by newest first."""
-    memory_dir = get_project_memory_dir(cwd)
+_MEMORY_INDEX_VERSION = 1
+_MEMORY_INDEX_LINE_RE = re.compile(r"^\s*-\s*\[(?P<title>[^\]]+)\]\((?P<target>[^)]+)\)\s*$")
+
+
+def _load_index_records(cwd: str | Path) -> dict[str, dict[str, object]]:
+    index_path = memory_paths.get_memory_metadata_index(cwd)
+    if not index_path.exists():
+        return {}
+
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+
+    if not isinstance(payload, dict) or payload.get("version") != _MEMORY_INDEX_VERSION:
+        return {}
+    records = payload.get("entries")
+    if not isinstance(records, list):
+        return {}
+
+    indexed: dict[str, dict[str, object]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        relative_path = record.get("relative_path")
+        if not isinstance(relative_path, str) or not relative_path:
+            continue
+        indexed[relative_path] = record
+    return indexed
+
+
+def _scan_memory_files_from_disk(cwd: str | Path) -> list[MemoryHeader]:
+    """Build memory headers from MEMORY.md and cached metadata without opening child files."""
+    memory_dir = memory_paths.get_project_memory_dir(cwd)
+    entrypoint = memory_paths.get_memory_entrypoint(cwd)
+    if not entrypoint.exists():
+        return []
+
+    try:
+        entrypoint_lines = entrypoint.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    indexed_records = _load_index_records(cwd)
+    resolved_memory_dir = memory_dir.resolve()
     headers: list[MemoryHeader] = []
-    for path in memory_dir.glob("*.md"):
-        if path.name == "MEMORY.md":
+    seen_paths: set[Path] = set()
+    for line in entrypoint_lines:
+        match = _MEMORY_INDEX_LINE_RE.match(line)
+        if match is None:
+            continue
+        relative_path = match.group("target").strip()
+        title = match.group("title").strip()
+        if not relative_path:
+            continue
+        path = (memory_dir / relative_path).resolve()
+        try:
+            path.relative_to(resolved_memory_dir)
+        except ValueError:
+            continue
+        if path in seen_paths or path.name == "MEMORY.md":
             continue
         try:
-            text = path.read_text(encoding="utf-8")
+            stat = path.stat()
         except OSError:
             continue
-        header = _parse_memory_file(path, text)
-        headers.append(header)
+        record = indexed_records.get(relative_path, {})
+        headers.append(
+            MemoryHeader(
+                path=path,
+                title=title or str(record.get("title") or path.stem),
+                description=str(record.get("description") or ""),
+                modified_at=stat.st_mtime,
+                memory_type=str(record.get("memory_type") or ""),
+                memory_key=str(record.get("memory_key") or ""),
+                body_preview=str(record.get("body_preview") or ""),
+            )
+        )
+        seen_paths.add(path)
     headers.sort(key=lambda item: item.modified_at, reverse=True)
+    return headers
+
+
+def _header_to_index_record(memory_dir: Path, header: MemoryHeader) -> dict[str, object]:
+    stat = header.path.stat()
+    return {
+        "relative_path": header.path.relative_to(memory_dir).as_posix(),
+        "title": header.title,
+        "description": header.description,
+        "memory_type": header.memory_type,
+        "memory_key": header.memory_key,
+        "body_preview": header.body_preview,
+        "modified_at": header.modified_at,
+        "modified_at_ns": stat.st_mtime_ns,
+    }
+
+
+def write_memory_index(cwd: str | Path, headers: list[MemoryHeader]) -> None:
+    """Persist a machine-readable metadata index for memory headers."""
+    memory_dir = memory_paths.get_project_memory_dir(cwd)
+    index_path = memory_paths.get_memory_metadata_index(cwd)
+    payload = {
+        "version": _MEMORY_INDEX_VERSION,
+        "entries": [_header_to_index_record(memory_dir, header) for header in headers],
+    }
+    atomic_write_text(index_path, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def rebuild_memory_index(cwd: str | Path) -> list[MemoryHeader]:
+    """Rebuild and persist the metadata index from MEMORY.md plus cached metadata."""
+    headers = _scan_memory_files_from_disk(cwd)
+    write_memory_index(cwd, headers)
+    return headers
+
+
+def _load_indexed_headers(cwd: str | Path) -> list[MemoryHeader] | None:
+    headers = _scan_memory_files_from_disk(cwd)
+    if not headers:
+        return None
+    return headers
+
+
+def scan_memory_files_in_file_store(cwd: str | Path, *, max_files: int | None = 50) -> list[MemoryHeader]:
+    """Return memory headers sorted by newest first."""
+    headers = _load_indexed_headers(cwd)
+    if headers is None:
+        headers = rebuild_memory_index(cwd)
+    if max_files is None:
+        return headers
     return headers[:max_files]
+
+
+def scan_memory_files(cwd: str | Path, *, max_files: int | None = 50) -> list[MemoryHeader]:
+    """Return memory headers from the active memory provider."""
+    return get_memory_provider(cwd).scan_memory_files(cwd, max_files=max_files)
 
 
 def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
@@ -31,6 +155,7 @@ def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
     title = path.stem
     description = ""
     memory_type = ""
+    memory_key = ""
     body_start = 0
 
     # Parse YAML frontmatter (--- ... ---)
@@ -49,6 +174,8 @@ def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
                         description = value
                     elif key == "type":
                         memory_type = value
+                    elif key == "key":
+                        memory_key = value
                 body_start = i + 1
                 break
 
@@ -79,5 +206,6 @@ def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
         description=description,
         modified_at=path.stat().st_mtime,
         memory_type=memory_type,
+        memory_key=memory_key,
         body_preview=body_preview,
     )

--- a/src/openharness/memory/types.py
+++ b/src/openharness/memory/types.py
@@ -15,4 +15,5 @@ class MemoryHeader:
     description: str
     modified_at: float
     memory_type: str = ""
+    memory_key: str = ""
     body_preview: str = ""

--- a/src/openharness/personalization/extractor.py
+++ b/src/openharness/personalization/extractor.py
@@ -7,7 +7,48 @@ import re
 
 log = logging.getLogger(__name__)
 
-# Patterns that indicate environment-specific facts worth capturing
+_RULE_KEY_TYPES = {
+    "pitfall",
+    "guardrail",
+    "forbidden_command",
+    "protected_path",
+    "style_rule",
+    "naming_rule",
+    "validation_rule",
+    "retry_rule",
+}
+
+
+def _compile_rule_pattern(*labels: str, optional_colon: bool = False) -> re.Pattern:
+    escaped = "|".join(re.escape(label) for label in labels)
+    separator = r"\s*:?\s*" if optional_colon else r"\s*:\s*"
+    return re.compile(rf"(?im)^(?:[-*•]\s*)?(?:{escaped}){separator}(.+)$")
+
+
+def _normalize_extraction_input(text: str) -> str:
+    return (
+        text.replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("：", ":")
+        .replace("（", "(")
+        .replace("）", ")")
+        .replace("　", " ")
+    )
+
+
+def _clean_fact_value(value: str) -> str:
+    cleaned = " ".join(value.split()).strip()
+    cleaned = cleaned.strip("`'\"“”‘’[]()（）")
+    cleaned = cleaned.rstrip("。；：，,.!！?？:;")
+    return cleaned.strip()
+
+
+def _rule_fact_key(fact_type: str, value: str) -> str:
+    if fact_type not in _RULE_KEY_TYPES:
+        return value
+    return " ".join(value.split()).strip().casefold()
+
+# Patterns that indicate durable facts, guardrails, and workflow rules worth capturing.
 _FACT_PATTERNS: list[tuple[str, str, re.Pattern]] = [
     ("ssh_host", "SSH connection", re.compile(
         r"ssh\s+(?:-[io]\s+\S+\s+)*(\S+@[\d.]+|\S+@\S+)", re.IGNORECASE
@@ -40,6 +81,39 @@ _FACT_PATTERNS: list[tuple[str, str, re.Pattern]] = [
     ("cron_schedule", "Cron schedule", re.compile(
         r"((?:\d+|\*)\s+(?:\d+|\*)\s+(?:\d+|\*)\s+(?:\d+|\*)\s+(?:\d+|\*))\s+\S+"
     )),
+    ("pitfall", "Pitfall", _compile_rule_pattern(
+        "pitfall", "gotcha", "common mistake", "easy mistake", "repair pattern", "fix pattern", "workaround",
+        "高频易错点", "常见坑", "易错点", "避坑", "避坑经验", "修复套路", "修复模式"
+    )),
+    ("guardrail", "Guardrail", _compile_rule_pattern(
+        "guardrail", "safety rule", "security rule", "red line", "hard rule", "fixed constraint",
+        "安全红线", "红线规则", "硬规则", "固定约束", "长期约束", "保护规则"
+    )),
+    ("forbidden_command", "Forbidden command", _compile_rule_pattern(
+        "forbidden command", "never run", "do not run", "don't run",
+        "禁止命令", "不要运行", "不要执行", "禁止执行", "不可运行", "不可执行",
+        optional_colon=True,
+    )),
+    ("protected_path", "Protected path", _compile_rule_pattern(
+        "protected file", "protected path", "do not delete", "don't delete", "never delete", "do not edit", "don't edit", "never edit",
+        "保护文件", "保护路径", "不要删除", "禁止删除", "不可删除", "不要修改", "禁止修改", "不可修改",
+        optional_colon=True,
+    )),
+    ("style_rule", "Style rule", _compile_rule_pattern(
+        "output style", "response style", "reply style", "style rule",
+        "输出风格", "回复风格", "回答风格", "风格规则"
+    )),
+    ("naming_rule", "Naming rule", _compile_rule_pattern(
+        "naming rule", "naming convention", "命名规则", "命名约定"
+    )),
+    ("validation_rule", "Validation rule", _compile_rule_pattern(
+        "validation rule", "validation step", "always validate with", "verify with",
+        "验证规则", "验证步骤", "校验规则", "校验步骤",
+        optional_colon=True,
+    )),
+    ("retry_rule", "Retry rule", _compile_rule_pattern(
+        "retry rule", "retry strategy", "retry policy", "重试规则", "重试策略", "重试机制"
+    )),
 ]
 
 
@@ -47,11 +121,12 @@ def extract_facts_from_text(text: str) -> list[dict]:
     """Extract environment-specific facts from conversation text using patterns."""
     facts = []
     seen_keys = set()
+    normalized_text = _normalize_extraction_input(text)
 
     for fact_type, label, pattern in _FACT_PATTERNS:
-        for match in pattern.finditer(text):
+        for match in pattern.finditer(normalized_text):
             value = match.group(1) if match.lastindex else match.group(0)
-            value = value.strip().rstrip(".,;:)")
+            value = _clean_fact_value(value)
             if not value or len(value) < 3:
                 continue
 
@@ -59,7 +134,7 @@ def extract_facts_from_text(text: str) -> list[dict]:
             if fact_type == "ip_address" and value.startswith(("0.", "255.", "127.0.0.1")):
                 continue
 
-            key = f"{fact_type}:{value}"
+            key = f"{fact_type}:{_rule_fact_key(fact_type, value)}"
             if key in seen_keys:
                 continue
             seen_keys.add(key)
@@ -125,6 +200,14 @@ def facts_to_rules_markdown(facts: list[dict]) -> str:
         "git_remote": "Git Repositories",
         "ray_cluster": "Ray Cluster Config",
         "cron_schedule": "Scheduled Jobs",
+        "pitfall": "Pitfalls And Fix Patterns",
+        "guardrail": "Guardrails",
+        "forbidden_command": "Forbidden Commands",
+        "protected_path": "Protected Paths",
+        "style_rule": "Style Rules",
+        "naming_rule": "Naming Rules",
+        "validation_rule": "Validation Rules",
+        "retry_rule": "Retry Rules",
     }
 
     for fact_type, items in grouped.items():

--- a/src/openharness/personalization/session_hook.py
+++ b/src/openharness/personalization/session_hook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from openharness.engine.messages import ConversationMessage
+from openharness.memory.auto_write import sync_fact_memories
 from openharness.personalization.extractor import (
     extract_facts_from_text,
     facts_to_rules_markdown,
@@ -19,7 +20,7 @@ from openharness.personalization.rules import (
 log = logging.getLogger(__name__)
 
 
-def update_rules_from_session(messages: list[ConversationMessage]) -> int:
+def update_rules_from_session(messages: list[ConversationMessage], cwd: str | None = None, *, sync_memory: bool = True) -> int:
     """Extract local facts from session messages and update rules.
 
     Called at session end. Returns the number of new facts extracted.
@@ -56,10 +57,18 @@ def update_rules_from_session(messages: list[ConversationMessage]) -> int:
     if rules_md:
         save_local_rules(rules_md)
 
+    memory_updates = 0
+    if cwd and sync_memory:
+        try:
+            memory_updates = sync_fact_memories(cwd, new_facts)
+        except Exception:
+            log.exception("Failed to sync extracted session facts into durable memory for %s", cwd)
+
     new_count = len(merged["facts"]) - len(existing.get("facts", []))
     log.info(
-        "Personalization: %d new facts extracted (%d total)",
+        "Personalization: %d new facts extracted (%d total, %d memory updates)",
         max(new_count, 0),
         len(merged["facts"]),
+        memory_updates,
     )
     return max(new_count, 0)

--- a/src/openharness/prompts/context.py
+++ b/src/openharness/prompts/context.py
@@ -12,7 +12,8 @@ from openharness.config.paths import (
 )
 from openharness.config.settings import Settings
 from openharness.coordinator.coordinator_mode import get_coordinator_system_prompt, is_coordinator_mode
-from openharness.memory import find_relevant_memories, load_memory_prompt
+from openharness.memory.auto_write import load_memory_policy_skill_content
+from openharness.memory import load_memory_prompt
 from openharness.personalization.rules import load_local_rules
 from openharness.prompts.claudemd import load_claude_md_prompt
 from openharness.prompts.system_prompt import build_system_prompt
@@ -142,25 +143,14 @@ def build_runtime_system_prompt(
         if memory_section:
             sections.append(memory_section)
 
-        if latest_user_prompt:
-            relevant = find_relevant_memories(
-                latest_user_prompt,
+        if settings.memory.auto_write_enabled:
+            memory_policy = load_memory_policy_skill_content(
                 cwd,
-                max_results=settings.memory.max_files,
+                extra_skill_dirs=extra_skill_dirs,
+                extra_plugin_roots=extra_plugin_roots,
+                settings=settings,
             )
-            if relevant:
-                lines = ["# Relevant Memories"]
-                for header in relevant:
-                    content = header.path.read_text(encoding="utf-8", errors="replace").strip()
-                    lines.extend(
-                        [
-                            "",
-                            f"## {header.path.name}",
-                            "```md",
-                            content[:8000],
-                            "```",
-                        ]
-                    )
-                sections.append("\n".join(lines))
+            if memory_policy:
+                sections.append(memory_policy)
 
     return "\n\n".join(section for section in sections if section.strip())

--- a/src/openharness/skills/bundled/content/durable-memory-policy.md
+++ b/src/openharness/skills/bundled/content/durable-memory-policy.md
@@ -1,0 +1,43 @@
+---
+name: durable-memory-policy
+description: Shared durable-memory write policy for the main model and reviewer.
+---
+
+# Durable Memory Writes
+
+Use the memory_write tool for durable context that should survive future sessions.
+
+## Good Candidates
+
+- Stable user preferences or workflow preferences
+- Repeated requests for the same tool, backend, format, or workflow across the session when they imply a durable default
+- Recurring project constraints, decisions, or conventions
+- High-frequency mistakes, gotchas, and fix patterns the agent should avoid repeating
+- Safety guardrails, permission boundaries, protected files, and forbidden commands
+- Output style, naming, validation, and retry rules that should shape future behavior
+- Durable environment facts like hosts, paths, env names, or service endpoints
+- Long-lived task context that future turns are likely to need
+
+## Do Not Store
+
+- Secrets, tokens, passwords, or credentials
+- Transient logs, stack traces, or one-off debug output
+- Short-lived plans that will be obsolete after this session
+- Facts already obvious from repository source unless the conversation adds durable context
+
+## Stable Key Patterns
+
+- preference:<topic>
+- project:<topic>
+- environment:<topic>
+- task:<topic>
+- pitfall:<topic>
+- guardrail:<topic>
+- forbidden_command:<topic>
+- protected_path:<topic>
+- style_rule:<topic>
+- naming_rule:<topic>
+- validation_rule:<topic>
+- retry_rule:<topic>
+
+Reuse stable keys when updating existing memory so entries stay deduplicated.

--- a/src/openharness/skills/bundled/content/durable-memory-reviewer.md
+++ b/src/openharness/skills/bundled/content/durable-memory-reviewer.md
@@ -1,0 +1,19 @@
+---
+name: durable-memory-reviewer
+description: Review-only instructions layered on top of the shared durable-memory policy.
+---
+
+# Durable Memory Reviewer
+
+Review the just-completed conversation turn and decide whether OpenHarness should write durable memory.
+
+## Goal
+
+Your only job is to decide whether the completed turn should update persistent memory.
+
+Apply the loaded durable-memory-policy skill as the write policy. Do not restate it or invent a second policy.
+
+## Completion Rules
+
+- If no memory update is needed, reply with exactly NO_MEMORY_UPDATE.
+- After finishing all required writes, reply with exactly MEMORY_REVIEW_COMPLETE.

--- a/src/openharness/skills/loader.py
+++ b/src/openharness/skills/loader.py
@@ -27,6 +27,15 @@ _USER_COMPAT_SKILL_DIRS = (
 _DEFAULT_PROJECT_SKILL_DIRS = (".openharness/skills", ".agents/skills", ".claude/skills")
 
 
+def strip_skill_frontmatter(content: str) -> str:
+    """Return skill markdown without YAML frontmatter."""
+    if content.startswith("---\n"):
+        end_index = content.find("\n---\n", 4)
+        if end_index != -1:
+            return content[end_index + 5 :].lstrip()
+    return content.strip()
+
+
 def get_user_skills_dir() -> Path:
     """Return the OpenHarness user skills directory."""
     path = get_config_dir() / "skills"

--- a/src/openharness/tools/__init__.py
+++ b/src/openharness/tools/__init__.py
@@ -23,6 +23,7 @@ from openharness.tools.image_generation_tool import ImageGenerationTool
 from openharness.tools.image_to_text_tool import ImageToTextTool
 from openharness.tools.list_mcp_resources_tool import ListMcpResourcesTool
 from openharness.tools.lsp_tool import LspTool
+from openharness.tools.memory_write_tool import MemoryWriteTool
 from openharness.tools.mcp_auth_tool import McpAuthTool
 from openharness.tools.mcp_tool import McpToolAdapter
 from openharness.tools.notebook_edit_tool import NotebookEditTool
@@ -56,6 +57,7 @@ def create_default_tool_registry(mcp_manager=None) -> ToolRegistry:
         FileEditTool(),
         NotebookEditTool(),
         LspTool(),
+        MemoryWriteTool(),
         McpAuthTool(),
         GlobTool(),
         GrepTool(),

--- a/src/openharness/tools/memory_write_tool.py
+++ b/src/openharness/tools/memory_write_tool.py
@@ -1,0 +1,79 @@
+"""Tool for writing durable OpenHarness memory entries."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from openharness.memory.manager import remove_memory_entry, upsert_memory_entry
+from openharness.tools.base import BaseTool, ToolExecutionContext, ToolResult
+
+
+class MemoryWriteToolInput(BaseModel):
+    """Arguments for durable memory writes."""
+
+    action: Literal["upsert", "delete"] = Field(
+        default="upsert",
+        description="Whether to create/update a durable memory entry or delete one by key.",
+    )
+    key: str = Field(description="Stable key used to deduplicate durable memory entries.")
+    title: str = Field(default="", description="Short human-readable title for the memory entry.")
+    content: str = Field(default="", description="Markdown body for the durable memory entry.")
+    description: str = Field(default="", description="One-line summary used for indexing and retrieval.")
+    memory_type: str = Field(default="", description="Durable memory category such as preference, project, or environment.")
+
+    @model_validator(mode="after")
+    def _validate_required_fields(self) -> "MemoryWriteToolInput":
+        if self.action == "upsert":
+            if not self.title.strip():
+                raise ValueError("title is required when action=upsert")
+            if not self.content.strip():
+                raise ValueError("content is required when action=upsert")
+        return self
+
+
+class MemoryWriteTool(BaseTool):
+    """Create, update, or delete durable memory in the OpenHarness memory store."""
+
+    name = "memory_write"
+    description = (
+        "Create, update, or delete durable memory entries stored in OpenHarness's internal project memory directory. "
+        "Use it only for information that should persist across future sessions."
+    )
+    input_model = MemoryWriteToolInput
+
+    def is_read_only(self, arguments: MemoryWriteToolInput) -> bool:
+        del arguments
+        return True
+
+    async def execute(self, arguments: MemoryWriteToolInput, context: ToolExecutionContext) -> ToolResult:
+        if arguments.action == "delete":
+            removed = remove_memory_entry(context.cwd, arguments.key)
+            if removed:
+                return ToolResult(
+                    output=f"Deleted memory entry {arguments.key}",
+                    metadata={"key": arguments.key, "action": "delete", "deleted": True},
+                )
+            return ToolResult(
+                output=f"Memory entry not found for {arguments.key}",
+                metadata={"key": arguments.key, "action": "delete", "deleted": False},
+            )
+
+        path, status = upsert_memory_entry(
+            context.cwd,
+            key=arguments.key,
+            title=arguments.title,
+            content=arguments.content,
+            description=arguments.description,
+            memory_type=arguments.memory_type,
+        )
+        return ToolResult(
+            output=f"{status.capitalize()} durable memory {path.name}",
+            metadata={
+                "key": arguments.key,
+                "action": arguments.action,
+                "status": status,
+                "memory_path": str(path),
+            },
+        )

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,7 +22,7 @@ from openharness.commands import (
     create_default_command_registry,
     lookup_skill_slash_command,
 )
-from openharness.config import get_config_file_path, load_settings
+from openharness.config import get_config_file_path, load_settings_for_project
 from openharness.engine import QueryEngine
 from openharness.engine.messages import (
     ConversationMessage,
@@ -42,12 +43,28 @@ from openharness.state import AppState, AppStateStore
 from openharness.services.session_backend import DEFAULT_SESSION_BACKEND, SessionBackend
 from openharness.tools import ToolRegistry, create_default_tool_registry
 from openharness.keybindings import load_keybindings
+from openharness.memory import configure_memory_provider
 
 PermissionPrompt = Callable[[str, str], Awaitable[bool]]
 AskUserPrompt = Callable[[str], Awaitable[str]]
 SystemPrinter = Callable[[str], Awaitable[None]]
 StreamRenderer = Callable[[StreamEvent], Awaitable[None]]
 ClearHandler = Callable[[], Awaitable[None]]
+
+log = logging.getLogger(__name__)
+
+
+def load_settings(cwd: str | Path | None = None):
+    """Backward-compatible settings loader for runtime callers and tests."""
+    return load_settings_for_project(cwd or Path.cwd())
+
+
+def _load_runtime_settings(cwd: str | Path | None = None):
+    """Load settings while tolerating older test monkeypatches with no args."""
+    try:
+        return load_settings(cwd)
+    except TypeError:
+        return load_settings()
 
 
 def _resolve_image_generation_config(settings) -> dict[str, str]:
@@ -142,13 +159,13 @@ class RuntimeBundle:
     def current_settings(self):
         """Return the effective settings for this session.
 
-        We persist most settings to disk (``~/.openharness/settings.json``), but
-        CLI options like ``--model``/``--api-format`` should remain in effect for
-        the lifetime of the running process. Without this overlay, issuing any
-        slash command (e.g. ``/fast``) would refresh UI state from disk and
-        "snap back" the model/provider to whatever is stored in the config file.
+        We persist most settings to disk, including project overrides in
+        ``.openharness/settings.json``. CLI options like ``--model`` and
+        ``--api-format`` should still remain in effect for the lifetime of the
+        running process. Without this overlay, issuing any slash command would
+        refresh UI state from disk and snap back to the persisted settings.
         """
-        return load_settings().merge_cli_overrides(**self.settings_overrides)
+        return _load_runtime_settings(self.cwd).merge_cli_overrides(**self.settings_overrides)
 
     def current_plugins(self):
         """Return currently visible plugins for the working tree."""
@@ -268,6 +285,7 @@ async def build_runtime(
     autodream_context: dict[str, object] | None = None,
 ) -> RuntimeBundle:
     """Build the shared runtime for an OpenHarness session."""
+    cwd = str(Path(cwd).expanduser().resolve()) if cwd else str(Path.cwd())
     settings_overrides: dict[str, Any] = {
         "model": model,
         "max_turns": max_turns,
@@ -278,11 +296,11 @@ async def build_runtime(
         "active_profile": active_profile,
         "permission_mode": permission_mode,
     }
-    settings = load_settings().merge_cli_overrides(**settings_overrides)
-    cwd = str(Path(cwd).expanduser().resolve()) if cwd else str(Path.cwd())
+    settings = _load_runtime_settings(cwd).merge_cli_overrides(**settings_overrides)
     normalized_skill_dirs = tuple(str(Path(path).expanduser().resolve()) for path in (extra_skill_dirs or ()))
     normalized_plugin_roots = tuple(str(Path(path).expanduser().resolve()) for path in (extra_plugin_roots or ()))
     plugins = load_plugins(settings, cwd, extra_roots=normalized_plugin_roots)
+    configure_memory_provider(cwd, settings.memory.provider, settings=settings)
     if api_client:
         resolved_api_client = api_client
     else:
@@ -346,6 +364,12 @@ async def build_runtime(
 
     restored_metadata = {
         "permission_mode": settings.permission.mode.value,
+        "memory_review_state": {
+            "turns_since_review": 0,
+            "turns_since_write": 0,
+            "reviews": 0,
+            "writes": 0,
+        },
         "read_file_state": [],
         "invoked_skills": [],
         "async_agent_state": [],
@@ -378,6 +402,11 @@ async def build_runtime(
             settings.auto_compact_threshold_tokens
             or settings.memory.auto_compact_threshold_tokens
         ),
+        memory_auto_write_enabled=settings.memory.auto_write_enabled,
+        memory_review_after_response=settings.memory.review_after_response,
+        memory_review_interval_turns=settings.memory.review_interval_turns,
+        memory_review_max_messages=settings.memory.review_max_messages,
+        memory_repeat_prompt_threshold=settings.memory.repeat_prompt_threshold,
         max_turns=engine_max_turns,
         permission_prompt=permission_prompt,
         ask_user_prompt=ask_user_prompt,
@@ -454,9 +483,14 @@ async def close_runtime(bundle: RuntimeBundle) -> None:
     # Extract local environment rules from session before closing
     try:
         from openharness.personalization.session_hook import update_rules_from_session
-        update_rules_from_session(bundle.engine.messages)
+        settings = bundle.current_settings()
+        update_rules_from_session(
+            bundle.engine.messages,
+            bundle.cwd,
+            sync_memory=settings.memory.session_fact_sync_enabled and settings.memory.auto_write_enabled,
+        )
     except Exception:
-        pass  # personalization is best-effort, never block session end
+        log.exception("Session-end personalization sync failed for %s", bundle.cwd)
 
     await bundle.mcp_manager.close()
     await bundle.hook_executor.execute(

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -10,10 +10,11 @@ import pytest
 import openharness.commands.registry as registry_module
 from openharness.commands.registry import CommandContext, create_default_command_registry, lookup_skill_slash_command
 from openharness.autopilot import RepoVerificationStep
-from openharness.config.paths import get_feedback_log_path, get_project_issue_file, get_project_pr_comments_file
-from openharness.config.settings import load_settings, save_settings, Settings
+from openharness.config.paths import get_feedback_log_path, get_project_issue_file, get_project_pr_comments_file, get_project_settings_file
+from openharness.config.settings import load_settings, load_settings_for_project, save_settings, Settings
 from openharness.engine.messages import ConversationMessage, TextBlock
 from openharness.engine.query_engine import QueryEngine
+from openharness.memory import FileMemoryStoreProvider, get_project_memory_dir, register_memory_provider_factory, unregister_memory_provider_factory
 from openharness.mcp.types import McpHttpServerConfig, McpStdioServerConfig
 from openharness.permissions import PermissionChecker
 from openharness.plugins.types import PluginCommandDefinition
@@ -258,6 +259,43 @@ async def test_memory_show_reads_normal_entries_with_md_fallback(tmp_path: Path,
     result = await show_command.handler(show_args, CommandContext(engine=_make_engine(tmp_path), cwd=str(tmp_path)))
 
     assert "hello world" in result.message
+
+
+@pytest.mark.asyncio
+async def test_memory_backend_command_persists_project_override_and_requests_refresh(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    register_memory_provider_factory("demo", lambda cwd, settings=None: FileMemoryStoreProvider())
+    try:
+        registry = create_default_command_registry()
+        context = _make_context(repo)
+
+        command, args = registry.lookup("/memory backend set demo")
+        assert command is not None
+        result = await command.handler(args, context)
+
+        assert result.refresh_runtime is True
+        assert result.message == "Project memory backend set to demo"
+        assert load_settings_for_project(repo).memory.provider == "demo"
+        assert get_project_settings_file(repo).exists()
+
+        show_command, show_args = registry.lookup("/memory backend show")
+        assert show_command is not None
+        show_result = await show_command.handler(show_args, context)
+        assert "Memory backend: demo" in show_result.message
+        assert "Source: project" in show_result.message
+
+        reset_command, reset_args = registry.lookup("/memory backend default")
+        assert reset_command is not None
+        reset_result = await reset_command.handler(reset_args, context)
+        assert reset_result.refresh_runtime is True
+        assert "Reset project memory backend override." in reset_result.message
+        assert load_settings_for_project(repo).memory.provider == "file"
+        assert get_project_settings_file(repo).exists() is False
+    finally:
+        unregister_memory_provider_factory("demo")
 
 
 @pytest.mark.asyncio
@@ -836,6 +874,9 @@ async def test_memory_command_manages_entries(tmp_path: Path, monkeypatch):
     list_command, list_args = registry.lookup("/memory list")
     list_result = await list_command.handler(list_args, context)
     assert "pytest_tips.md" in list_result.message
+
+    entrypoint = get_project_memory_dir(tmp_path) / "MEMORY.md"
+    assert "(entries/pytest_tips.md)" in entrypoint.read_text(encoding="utf-8")
 
     show_command, show_args = registry.lookup("/memory show pytest_tips")
     show_result = await show_command.handler(show_args, context)

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -8,13 +8,17 @@ from pathlib import Path
 import pytest
 
 from openharness.auth.storage import store_credential
+from openharness.config.paths import get_project_settings_file
 from openharness.config.settings import (
     ProviderProfile,
     Settings,
     display_model_setting,
+    load_project_settings_overrides,
     load_settings,
+    load_settings_for_project,
     normalize_anthropic_model_name,
     save_settings,
+    set_project_memory_provider,
     strip_ansi_escape_sequences,
     _apply_env_overrides,
 )
@@ -230,6 +234,39 @@ class TestLoadSaveSettings:
 
         assert materialized.context_window_tokens == 100000
         assert materialized.auto_compact_threshold_tokens == 90000
+
+    def test_load_settings_for_project_applies_memory_backend_override_per_workspace(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        set_project_memory_provider(repo_a, "demo")
+
+        repo_a_settings = load_settings_for_project(repo_a)
+        repo_b_settings = load_settings_for_project(repo_b)
+        overrides = load_project_settings_overrides(repo_a)
+
+        assert repo_a_settings.memory.provider == "demo"
+        assert repo_b_settings.memory.provider == "file"
+        assert overrides == {"memory": {"provider": "demo"}}
+        assert get_project_settings_file(repo_a).exists()
+
+    def test_set_project_memory_provider_none_clears_override_file(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        set_project_memory_provider(repo, "demo")
+        project_settings_path = get_project_settings_file(repo)
+        assert project_settings_path.exists()
+
+        set_project_memory_provider(repo, None)
+
+        assert load_settings_for_project(repo).memory.provider == "file"
+        assert load_project_settings_overrides(repo) == {}
+        assert project_settings_path.exists() is False
 
     def test_merge_cli_active_profile_does_not_inherit_flat_provider_fields(self):
         settings = Settings(

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -371,6 +371,38 @@ async def test_query_engine_coordinator_mode_uses_coordinator_prompt_and_runs_ag
     assert "coordinator mode is active" in events[-1].message.text
 
 
+def test_build_runtime_system_prompt_keeps_memory_as_index_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    from openharness.memory import get_memory_entrypoint, get_project_memory_dir
+
+    entrypoint = get_memory_entrypoint(project_dir)
+    entrypoint.write_text("# Memory Index\n- [高风险区域保护规则](memory.md)\n", encoding="utf-8")
+    child_memory = get_project_memory_dir(project_dir) / "memory.md"
+    child_memory.write_text(
+        "---\n"
+        "name: 高风险区域保护规则\n"
+        "description: 避免直接修改高风险区域\n"
+        "---\n"
+        "绝不能直接改生产配置。这段内容不应在系统 prompt 中预展开。\n",
+        encoding="utf-8",
+    )
+
+    system_prompt = build_runtime_system_prompt(
+        Settings(),
+        cwd=project_dir,
+        latest_user_prompt="请看看高风险区域保护规则",
+    )
+
+    assert "# Memory" in system_prompt
+    assert "[高风险区域保护规则](memory.md)" in system_prompt
+    assert "Treat MEMORY.md as the default index" in system_prompt
+    assert "# Relevant Memories" not in system_prompt
+    assert "绝不能直接改生产配置。这段内容不应在系统 prompt 中预展开。" not in system_prompt
+
+
 @pytest.mark.asyncio
 async def test_query_engine_allows_unbounded_turns_when_max_turns_is_none(tmp_path: Path):
     sample = tmp_path / "hello.txt"
@@ -581,6 +613,255 @@ async def test_query_engine_tracks_recent_read_files_and_skills(tmp_path: Path):
     assert isinstance(verified, list)
     assert any("Inspected file" in entry for entry in verified)
     assert any("Loaded skill demo-skill" in entry for entry in verified)
+
+
+@pytest.mark.asyncio
+async def test_query_engine_runs_silent_turn_memory_review(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    engine = QueryEngine(
+        api_client=FakeApiClient(
+            [
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="Use ssh dev@10.0.0.8 and keep the dev312 conda env for this project.")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=3, output_tokens=4),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_memory_1",
+                                name="memory_write",
+                                input={
+                                    "action": "upsert",
+                                    "key": "environment:ssh_dev_10_0_0_8",
+                                    "title": "SSH host: dev@10.0.0.8",
+                                    "description": "Stable SSH target for this project",
+                                    "memory_type": "environment",
+                                    "content": "Use `ssh dev@10.0.0.8` for the project host and keep the `dev312` conda environment active.",
+                                },
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=2, output_tokens=2),
+                ),
+                _FakeResponse(
+                    message=ConversationMessage(role="assistant", content=[TextBlock(text="MEMORY_REVIEW_COMPLETE")]),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                ),
+            ]
+        ),
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        memory_review_interval_turns=1,
+    )
+
+    events = [event async for event in engine.submit_message("Remember the environment details.")]
+
+    assert isinstance(events[-1], AssistantTurnComplete)
+    memory_dir = tmp_path / "data" / "memory"
+    created_files = list(memory_dir.rglob("*.md"))
+    assert any(path.name != "MEMORY.md" for path in created_files)
+    state = engine.tool_metadata.get("memory_review_state")
+    assert isinstance(state, dict)
+    assert state["reviews"] == 1
+    assert state["writes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_query_engine_repeats_prompt_threshold_into_memory_review(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+
+    class CapturingApiClient:
+        def __init__(self) -> None:
+            self.requests = []
+            self._calls = 0
+
+        async def stream_message(self, request):
+            self.requests.append(request)
+            self._calls += 1
+            if self._calls == 1:
+                yield ApiMessageCompleteEvent(
+                    message=ConversationMessage(role="assistant", content=[TextBlock(text="Use pm-rag for this topic.")]),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                    stop_reason=None,
+                )
+                return
+            if self._calls == 2:
+                yield ApiMessageCompleteEvent(
+                    message=ConversationMessage(role="assistant", content=[TextBlock(text="Still using pm-rag.")]),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                    stop_reason=None,
+                )
+                return
+            if self._calls == 3:
+                yield ApiMessageCompleteEvent(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[
+                            ToolUseBlock(
+                                id="toolu_memory_repeat_1",
+                                name="memory_write",
+                                input={
+                                    "action": "upsert",
+                                    "key": "preference:pm_rag_for_test_pm_change_management",
+                                    "title": "Use pm-rag for requirement-change management questions",
+                                    "description": "Repeated user request to use pm-rag for test project management questions",
+                                    "memory_type": "preference",
+                                    "content": "When the user asks about requirement-change management as a test project manager, prefer pm-rag.",
+                                },
+                            )
+                        ],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                    stop_reason=None,
+                )
+                return
+            yield ApiMessageCompleteEvent(
+                message=ConversationMessage(role="assistant", content=[TextBlock(text="MEMORY_REVIEW_COMPLETE")]),
+                usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                stop_reason=None,
+            )
+
+    api_client = CapturingApiClient()
+    engine = QueryEngine(
+        api_client=api_client,
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        memory_review_interval_turns=99,
+        memory_repeat_prompt_threshold=2,
+    )
+
+    first_events = [
+        event
+        async for event in engine.submit_message(
+            "When project requirements change often, answer with pm-rag."
+        )
+    ]
+    assert isinstance(first_events[-1], AssistantTurnComplete)
+    assert len(api_client.requests) == 1
+
+    second_events = [
+        event
+        async for event in engine.submit_message(
+            "When project requirements change often, answer with pm-rag."
+        )
+    ]
+
+    assert isinstance(second_events[-1], AssistantTurnComplete)
+    assert len(api_client.requests) == 4
+    review_prompt_texts = [
+        message.text
+        for request in api_client.requests
+        for message in request.messages
+        if getattr(message, "text", "")
+    ]
+    review_prompt = next(
+        text for text in review_prompt_texts if "# Repeated User Prompt Candidates" in text
+    )
+    assert "Asked 2 times this session" in review_prompt
+    assert "pm-rag" in review_prompt
+
+    memory_dir = tmp_path / "data" / "memory"
+    created_files = list(memory_dir.rglob("*.md"))
+    assert any(path.name != "MEMORY.md" for path in created_files)
+
+    review_state = engine.tool_metadata.get("memory_review_state")
+    assert isinstance(review_state, dict)
+    assert review_state["reviews"] == 1
+    assert review_state["writes"] == 1
+
+    repeat_state = engine.tool_metadata.get("memory_repeat_prompt_state")
+    assert isinstance(repeat_state, dict)
+    prompts = repeat_state.get("prompts")
+    assert isinstance(prompts, dict)
+    assert any(
+        isinstance(record, dict)
+        and record.get("count") == 2
+        and record.get("reviewed_stage") == 1
+        for record in prompts.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_engine_loads_memory_reviewer_skill_from_extra_skill_dirs(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    policy_dir = skills_root / "durable-memory-policy"
+    policy_dir.mkdir(parents=True)
+    (policy_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: durable-memory-policy\n"
+        "description: Custom policy\n"
+        "---\n\n"
+        "# Custom durable memory policy\n\n"
+        "Prefer deployment and environment facts first.\n",
+        encoding="utf-8",
+    )
+    skill_dir = skills_root / "durable-memory-reviewer"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: durable-memory-reviewer\n"
+        "description: Custom reviewer\n"
+        "---\n\n"
+        "# Custom durable reviewer\n\n"
+        "Use the override instructions from this skill.\n",
+        encoding="utf-8",
+    )
+
+    class CapturingApiClient:
+        def __init__(self) -> None:
+            self.requests = []
+            self._calls = 0
+
+        async def stream_message(self, request):
+            self.requests.append(request)
+            self._calls += 1
+            if self._calls == 1:
+                yield ApiMessageCompleteEvent(
+                    message=ConversationMessage(
+                        role="assistant",
+                        content=[TextBlock(text="No durable memory this turn.")],
+                    ),
+                    usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                    stop_reason=None,
+                )
+                return
+            yield ApiMessageCompleteEvent(
+                message=ConversationMessage(role="assistant", content=[TextBlock(text="NO_MEMORY_UPDATE")]),
+                usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+                stop_reason=None,
+            )
+
+    api_client = CapturingApiClient()
+    engine = QueryEngine(
+        api_client=api_client,
+        tool_registry=create_default_tool_registry(),
+        permission_checker=PermissionChecker(PermissionSettings()),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+        memory_review_interval_turns=1,
+        tool_metadata={"extra_skill_dirs": (str(skills_root),)},
+    )
+
+    events = [event async for event in engine.submit_message("Do the thing.")]
+
+    assert isinstance(events[-1], AssistantTurnComplete)
+    assert len(api_client.requests) == 2
+    review_request = api_client.requests[1]
+    assert "# Custom durable memory policy" in review_request.messages[0].text
+    assert "# Custom durable reviewer" in review_request.messages[1].text
+    assert "# Completed Conversation Turn" in review_request.messages[2].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory/test_auto_write.py
+++ b/tests/test_memory/test_auto_write.py
@@ -1,0 +1,95 @@
+"""Tests for automatic durable-memory review helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openharness.engine.messages import ConversationMessage, TextBlock
+from openharness.memory.auto_write import (
+    MEMORY_POLICY_SKILL_NAME,
+    MEMORY_REVIEW_SKILL_NAME,
+    build_turn_memory_review_messages,
+    build_turn_memory_review_prompt,
+)
+from openharness.memory.manager import upsert_memory_entry
+
+
+def test_build_turn_memory_review_prompt_uses_compact_memory_snapshot(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    for index in range(15):
+        upsert_memory_entry(
+            project_dir,
+            key=f"guardrail:rule_{index}",
+            title=f"规则 {index}",
+            description=f"用于测试的 durable memory {index}",
+            memory_type="guardrail",
+            content=f"Guardrail: rule {index}",
+        )
+
+    prompt = build_turn_memory_review_prompt(
+        [ConversationMessage(role="user", content=[TextBlock(text="Guardrail: never delete migrations/")])],
+        project_dir,
+        max_messages=1,
+    )
+
+    assert "# Current Durable Memories" in prompt
+    assert "- Total entries: 15" in prompt
+    assert "Persistent memory directory" not in prompt
+    assert "Treat MEMORY.md as the default index" not in prompt
+    assert "... 3 more entries in MEMORY.md" in prompt
+
+
+def test_build_turn_memory_review_messages_prepends_bundled_skill(tmp_path: Path):
+    review_messages = build_turn_memory_review_messages(
+        [ConversationMessage(role="user", content=[TextBlock(text="Guardrail: never force-push main")])],
+        tmp_path,
+        max_messages=1,
+    )
+
+    assert len(review_messages) == 3
+    assert "# Durable Memory Writes" in review_messages[0].text
+    assert "Use the memory_write tool for durable context" in review_messages[0].text
+    assert "# Durable Memory Reviewer" in review_messages[1].text
+    assert "If no memory update is needed, reply with exactly NO_MEMORY_UPDATE." in review_messages[1].text
+    assert "# Completed Conversation Turn" in review_messages[2].text
+
+
+def test_build_turn_memory_review_messages_accepts_skill_override(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    policy_dir = skills_root / MEMORY_POLICY_SKILL_NAME
+    policy_dir.mkdir(parents=True)
+    (policy_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {MEMORY_POLICY_SKILL_NAME}\n"
+        "description: Custom policy\n"
+        "---\n\n"
+        "# Custom durable memory policy\n\n"
+        "Prefer long-lived team conventions first.\n",
+        encoding="utf-8",
+    )
+    reviewer_dir = skills_root / MEMORY_REVIEW_SKILL_NAME
+    reviewer_dir.mkdir(parents=True)
+    (reviewer_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {MEMORY_REVIEW_SKILL_NAME}\n"
+        "description: Custom reviewer\n"
+        "---\n\n"
+        "# Custom durable reviewer\n\n"
+        "Always check the override instructions first.\n",
+        encoding="utf-8",
+    )
+
+    review_messages = build_turn_memory_review_messages(
+        [ConversationMessage(role="user", content=[TextBlock(text="Remember the SSH host")])],
+        tmp_path,
+        max_messages=1,
+        extra_skill_dirs=[skills_root],
+    )
+
+    assert len(review_messages) == 3
+    assert review_messages[0].text == "# Custom durable memory policy\n\nPrefer long-lived team conventions first."
+    assert "# Custom durable reviewer" in review_messages[1].text
+    assert "override instructions" in review_messages[1].text

--- a/tests/test_memory/test_memdir.py
+++ b/tests/test_memory/test_memdir.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from openharness.config.paths import use_memory_store_dir
 from openharness.memory import (
+    add_memory_entry,
     find_relevant_memories,
     get_memory_entrypoint,
+    get_project_memory_entries_dir,
     get_project_memory_dir,
+    list_memory_files,
     load_memory_prompt,
+    upsert_memory_entry,
 )
+from openharness.memory.paths import get_memory_metadata_index
 from openharness.memory.scan import _parse_memory_file, scan_memory_files
 
 
@@ -19,10 +25,51 @@ def test_memory_paths_are_stable(tmp_path: Path, monkeypatch):
     project_dir.mkdir()
 
     memory_dir = get_project_memory_dir(project_dir)
+    entries_dir = get_project_memory_entries_dir(project_dir)
     entrypoint = get_memory_entrypoint(project_dir)
 
     assert memory_dir.exists()
+    assert entries_dir.parent == memory_dir
     assert entrypoint.parent == memory_dir
+
+
+def test_memory_paths_can_be_redirected_into_ohmo_workspace(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    workspace_memory = tmp_path / ".ohmo-home" / "memory"
+
+    with use_memory_store_dir(workspace_memory, shared_root=True):
+        memory_dir = get_project_memory_dir(project_dir)
+        entries_dir = get_project_memory_entries_dir(project_dir)
+
+    assert memory_dir == workspace_memory
+    assert entries_dir.parent == memory_dir
+
+
+def test_memory_paths_migrate_legacy_project_dir_into_redirected_root(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    legacy_dir = get_project_memory_dir(project_dir)
+    legacy_entry = legacy_dir / "MEMORY.md"
+    legacy_child = legacy_dir / "legacy.md"
+    legacy_child.write_text("Use ssh legacy@example.com for the older environment.\n", encoding="utf-8")
+    legacy_entry.write_text("# Memory Index\n- [Legacy](legacy.md)\n", encoding="utf-8")
+
+    workspace_memory = tmp_path / ".ohmo-home" / "memory"
+    with use_memory_store_dir(workspace_memory, shared_root=True):
+        memory_dir = get_project_memory_dir(project_dir)
+        entrypoint = get_memory_entrypoint(project_dir)
+        files = list_memory_files(project_dir)
+
+    assert memory_dir == workspace_memory
+    assert files and files[0].parent == workspace_memory / "entries"
+    entrypoint_text = entrypoint.read_text(encoding="utf-8")
+    assert "Legacy" in entrypoint_text
+    assert "entries/legacy" in entrypoint_text
+    assert not legacy_dir.exists()
 
 
 def test_load_memory_prompt_includes_entrypoint(tmp_path: Path, monkeypatch):
@@ -37,20 +84,36 @@ def test_load_memory_prompt_includes_entrypoint(tmp_path: Path, monkeypatch):
     assert prompt is not None
     assert "Persistent memory directory" in prompt
     assert "Testing" in prompt
+    assert "Child memory entries directory" in prompt
+    assert "Treat MEMORY.md as the default index" in prompt
+    assert "read that child file on demand" in prompt
 
 
 def test_find_relevant_memories(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
-    memory_dir = get_project_memory_dir(project_dir)
-    (memory_dir / "pytest_tips.md").write_text("Pytest markers and fixtures\n", encoding="utf-8")
-    (memory_dir / "docker_notes.md").write_text("Docker compose caveats\n", encoding="utf-8")
+    upsert_memory_entry(
+        project_dir,
+        key="project:pytest_tips",
+        title="Pytest Tips",
+        description="Testing tips",
+        memory_type="project",
+        content="Pytest markers and fixtures\nUse fixture scopes carefully.",
+    )
+    upsert_memory_entry(
+        project_dir,
+        key="project:docker_notes",
+        title="Docker Notes",
+        description="Container notes",
+        memory_type="project",
+        content="Docker compose caveats\nWatch bind mounts on Linux.",
+    )
 
     matches = find_relevant_memories("fix pytest fixtures", project_dir)
 
     assert matches
-    assert matches[0].path.name == "pytest_tips.md"
+    assert matches[0].path.name == "project_pytest_tips.md"
 
 
 # --- Frontmatter parsing tests ---
@@ -60,6 +123,7 @@ def test_parse_frontmatter_extracts_fields(tmp_path: Path):
     path = tmp_path / "project_auth.md"
     path.write_text(
         "---\n"
+        "key: project:auth\n"
         "name: auth-rewrite\n"
         "description: Auth middleware driven by compliance\n"
         "type: project\n"
@@ -74,6 +138,7 @@ def test_parse_frontmatter_extracts_fields(tmp_path: Path):
     assert header.title == "auth-rewrite"
     assert header.description == "Auth middleware driven by compliance"
     assert header.memory_type == "project"
+    assert header.memory_key == "project:auth"
     assert "Session token storage" in header.body_preview
 
 
@@ -129,10 +194,13 @@ def test_scan_memory_files_with_frontmatter(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
-    memory_dir = get_project_memory_dir(project_dir)
-    (memory_dir / "topic.md").write_text(
-        "---\nname: my-topic\ndescription: Important topic\ntype: reference\n---\nContent.\n",
-        encoding="utf-8",
+    upsert_memory_entry(
+        project_dir,
+        key="reference:topic",
+        title="my-topic",
+        description="Important topic",
+        memory_type="reference",
+        content="Content.",
     )
 
     headers = scan_memory_files(project_dir)
@@ -143,6 +211,168 @@ def test_scan_memory_files_with_frontmatter(tmp_path: Path, monkeypatch):
     assert headers[0].memory_type == "reference"
 
 
+def test_upsert_memory_entry_merges_semantic_duplicates(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    memory_dir = get_project_memory_dir(project_dir)
+    entrypoint = get_memory_entrypoint(project_dir)
+
+    first = memory_dir / "memory.md"
+    first.write_text(
+        "---\n"
+        "key: guardrail:migration_and_release_protection\n"
+        "name: 保护迁移文件和发布配置\n"
+        "description: 迁移文件和发布配置受保护，不能删除或擅自更改。\n"
+        "type: guardrail\n"
+        "---\n"
+        "本仓库的迁移文件和发布配置是受保护的，不得删除、移动或未经明确确认进行更改。\n",
+        encoding="utf-8",
+    )
+    second = memory_dir / "memory_guardrail_no_delete_.md"
+    second.write_text(
+        "---\n"
+        "key: guardrail:no_delete_migration_release_config\n"
+        "name: 保护迁移文件和发布配置\n"
+        "description: 迁移文件和发布配置未经确认不可删除。\n"
+        "type: guardrail\n"
+        "---\n"
+        "仓库中的迁移文件和发布配置未经明确确认，不得删除。\n",
+        encoding="utf-8",
+    )
+    entrypoint.write_text(
+        "# Memory Index\n"
+        "- [保护迁移文件和发布配置](memory.md)\n"
+        "- [保护迁移文件和发布配置](memory_guardrail_no_delete_.md)\n",
+        encoding="utf-8",
+    )
+
+    path, status = upsert_memory_entry(
+        project_dir,
+        key="guardrail:migration_and_release_protection",
+        title="保护迁移文件和发布配置",
+        description="迁移文件和发布配置未经确认不可删除。",
+        memory_type="guardrail",
+        content="仓库中的迁移文件和发布配置未经明确确认，不得删除、移动或改动。",
+    )
+
+    assert status == "updated"
+    assert path.exists()
+    files = list_memory_files(project_dir)
+    assert len(files) == 1
+    assert files[0] == path
+    assert "不得删除、移动或改动" in path.read_text(encoding="utf-8")
+    index_text = entrypoint.read_text(encoding="utf-8")
+    assert index_text.count("[保护迁移文件和发布配置]") == 1
+
+
+def test_upsert_memory_entry_uses_english_key_slug_for_filename(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    entrypoint = get_memory_entrypoint(project_dir)
+
+    path, status = upsert_memory_entry(
+        project_dir,
+        key="preference:reply_language_should_be_chinese_by_default_even_when_key_is_long",
+        title="默认回复语言为中文",
+        description="默认使用中文回复。",
+        memory_type="preference",
+        content="默认回复语言为中文，除非用户明确要求其他语言。",
+    )
+
+    assert status == "created"
+    assert path.parent == get_project_memory_entries_dir(project_dir)
+    assert path.name.startswith("preference_reply_language_should_be_chinese_by_default")
+    assert path.name.endswith(".md")
+    assert entrypoint.read_text(encoding="utf-8").strip().endswith(f"[默认回复语言为中文](entries/{path.name})")
+
+
+def test_scan_memory_files_uses_metadata_index_without_reopening_entries(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    path, _ = upsert_memory_entry(
+        project_dir,
+        key="guardrail:never_delete_migrations",
+        title="保护迁移文件",
+        description="迁移文件不能删除。",
+        memory_type="guardrail",
+        content="Guardrail: never delete migrations/",
+    )
+
+    metadata_index = get_memory_metadata_index(project_dir)
+    assert metadata_index.exists()
+
+    original_read_text = Path.read_text
+
+    def _guarded_read_text(self: Path, *args, **kwargs):
+        if self == path:
+            raise AssertionError("scan_memory_files should use the metadata index for current entries")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _guarded_read_text)
+
+    headers = scan_memory_files(project_dir, max_files=None)
+
+    assert len(headers) == 1
+    assert headers[0].memory_key == "guardrail:never_delete_migrations"
+
+
+def test_scan_memory_files_rebuilds_from_memory_md_without_opening_entries(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    path, _ = upsert_memory_entry(
+        project_dir,
+        key="guardrail:never_delete_migrations",
+        title="保护迁移文件",
+        description="旧描述",
+        memory_type="guardrail",
+        content="Guardrail: never delete migrations/",
+    )
+
+    metadata_index = get_memory_metadata_index(project_dir)
+    metadata_index.unlink()
+
+    original_read_text = Path.read_text
+
+    def _guarded_read_text(self: Path, *args, **kwargs):
+        if self == path:
+            raise AssertionError("scan_memory_files should rebuild from MEMORY.md without reopening child entries")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _guarded_read_text)
+
+    headers = scan_memory_files(project_dir, max_files=None)
+
+    assert len(headers) == 1
+    assert headers[0].title == "保护迁移文件"
+    assert headers[0].path == path
+    assert headers[0].description == ""
+    assert headers[0].body_preview == ""
+
+
+def test_add_memory_entry_uses_entries_dir_and_english_collision_suffix(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    first = add_memory_entry(project_dir, "Pytest Tips", "use fixtures")
+    second = add_memory_entry(project_dir, "Pytest Tips", "still use fixtures, but for another note")
+
+    assert first.parent == get_project_memory_entries_dir(project_dir)
+    assert first.name == "pytest_tips.md"
+    assert second.parent == get_project_memory_entries_dir(project_dir)
+    assert second.name.startswith("pytest_tips_")
+    assert second.name.endswith(".md")
+    suffix = second.stem.removeprefix("pytest_tips_")
+    assert len(suffix) == 8
+    assert all(char in "0123456789abcdef" for char in suffix)
+
+
 # --- Search relevance tests ---
 
 
@@ -150,17 +380,24 @@ def test_search_prefers_metadata_over_body(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
-    memory_dir = get_project_memory_dir(project_dir)
 
     # File A: "redis" appears in frontmatter description
-    (memory_dir / "a_redis.md").write_text(
-        "---\nname: cache-layer\ndescription: Redis caching strategy\n---\nGeneral notes.\n",
-        encoding="utf-8",
+    upsert_memory_entry(
+        project_dir,
+        key="project:cache_layer",
+        title="cache-layer",
+        description="Redis caching strategy",
+        memory_type="project",
+        content="General notes.",
     )
     # File B: "redis" appears only in body
-    (memory_dir / "b_infra.md").write_text(
-        "---\nname: infra-notes\ndescription: Infrastructure overview\n---\nWe use redis for sessions.\n",
-        encoding="utf-8",
+    upsert_memory_entry(
+        project_dir,
+        key="project:infra_notes",
+        title="infra-notes",
+        description="Infrastructure overview",
+        memory_type="project",
+        content="General notes.\nWe use redis for sessions.",
     )
 
     matches = find_relevant_memories("redis caching", project_dir)
@@ -173,10 +410,13 @@ def test_search_finds_body_content(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
-    memory_dir = get_project_memory_dir(project_dir)
-    (memory_dir / "deploy.md").write_text(
-        "---\nname: deploy\ndescription: Deployment notes\n---\nKubernetes rollout strategy details.\n",
-        encoding="utf-8",
+    upsert_memory_entry(
+        project_dir,
+        key="project:deploy",
+        title="deploy",
+        description="Deployment notes",
+        memory_type="project",
+        content="General deployment context.\nKubernetes rollout strategy details.",
     )
 
     matches = find_relevant_memories("kubernetes rollout", project_dir)
@@ -189,10 +429,13 @@ def test_search_handles_cjk_queries(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
-    memory_dir = get_project_memory_dir(project_dir)
-    (memory_dir / "chinese_note.md").write_text(
-        "---\nname: meeting\ndescription: 项目会议纪要\n---\n讨论了部署计划。\n",
-        encoding="utf-8",
+    upsert_memory_entry(
+        project_dir,
+        key="project:meeting",
+        title="meeting",
+        description="项目会议纪要",
+        memory_type="project",
+        content="讨论了部署计划。",
     )
 
     matches = find_relevant_memories("会议", project_dir)

--- a/tests/test_memory/test_provider.py
+++ b/tests/test_memory/test_provider.py
@@ -1,0 +1,148 @@
+"""Tests for memory provider delegation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.memory import register_memory_provider, reset_memory_provider_registry, unregister_memory_provider
+from openharness.memory.manager import add_memory_entry, list_memory_files, remove_memory_entry, upsert_memory_entry
+from openharness.memory.scan import scan_memory_files
+from openharness.memory.types import MemoryHeader
+from openharness.tools.base import ToolExecutionContext
+from openharness.tools.memory_write_tool import MemoryWriteTool, MemoryWriteToolInput
+
+
+class RecordingMemoryProvider:
+    def __init__(self, repo: Path) -> None:
+        self.repo = repo.resolve()
+        self.calls: list[tuple] = []
+        self.memory_path = self.repo / "provider-memory.md"
+        self.headers = [
+            MemoryHeader(
+                path=self.memory_path,
+                title="Provider note",
+                description="Recorded by provider",
+                modified_at=123.0,
+                memory_type="project",
+                memory_key="project:provider",
+                body_preview="Provider preview",
+            )
+        ]
+
+    def scan_memory_files(self, cwd: str | Path, *, max_files: int | None = 50) -> list[MemoryHeader]:
+        self.calls.append(("scan", Path(cwd).resolve(), max_files))
+        if max_files is None:
+            return list(self.headers)
+        return list(self.headers[:max_files])
+
+    def list_memory_files(self, cwd: str | Path) -> list[Path]:
+        self.calls.append(("list", Path(cwd).resolve()))
+        return [self.memory_path]
+
+    def upsert_memory_entry(
+        self,
+        cwd: str | Path,
+        *,
+        key: str,
+        title: str,
+        content: str,
+        description: str = "",
+        memory_type: str = "",
+    ) -> tuple[Path, str]:
+        self.calls.append(
+            ("upsert", Path(cwd).resolve(), key, title, content, description, memory_type)
+        )
+        return self.memory_path, "updated"
+
+    def add_memory_entry(self, cwd: str | Path, title: str, content: str) -> Path:
+        self.calls.append(("add", Path(cwd).resolve(), title, content))
+        return self.repo / "manual-provider-memory.md"
+
+    def remove_memory_entry(self, cwd: str | Path, name: str) -> bool:
+        self.calls.append(("remove", Path(cwd).resolve(), name))
+        return True
+
+
+def test_memory_provider_registry_delegates_manager_and_scan_calls(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    provider = RecordingMemoryProvider(repo)
+    register_memory_provider(repo, provider)
+
+    try:
+        headers = scan_memory_files(repo, max_files=1)
+        listed = list_memory_files(repo)
+        path, status = upsert_memory_entry(
+            repo,
+            key="project:provider",
+            title="Provider note",
+            content="Provider-backed content.",
+            description="Recorded by provider",
+            memory_type="project",
+        )
+        added = add_memory_entry(repo, "Manual note", "Manual content")
+        removed = remove_memory_entry(repo, "project:provider")
+    finally:
+        unregister_memory_provider(repo)
+        reset_memory_provider_registry()
+
+    assert [header.title for header in headers] == ["Provider note"]
+    assert listed == [repo / "provider-memory.md"]
+    assert path == repo / "provider-memory.md"
+    assert status == "updated"
+    assert added == repo / "manual-provider-memory.md"
+    assert removed is True
+    assert provider.calls == [
+        ("scan", repo.resolve(), 1),
+        ("list", repo.resolve()),
+        (
+            "upsert",
+            repo.resolve(),
+            "project:provider",
+            "Provider note",
+            "Provider-backed content.",
+            "Recorded by provider",
+            "project",
+        ),
+        ("add", repo.resolve(), "Manual note", "Manual content"),
+        ("remove", repo.resolve(), "project:provider"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_memory_write_tool_uses_registered_memory_provider(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    provider = RecordingMemoryProvider(repo)
+    register_memory_provider(repo, provider)
+
+    try:
+        result = await MemoryWriteTool().execute(
+            MemoryWriteToolInput(
+                key="project:provider",
+                title="Provider note",
+                description="Recorded by provider",
+                memory_type="project",
+                content="Provider-backed content.",
+            ),
+            ToolExecutionContext(cwd=repo),
+        )
+    finally:
+        unregister_memory_provider(repo)
+        reset_memory_provider_registry()
+
+    assert result.is_error is False
+    assert result.output == "Updated durable memory provider-memory.md"
+    assert provider.calls == [
+        (
+            "upsert",
+            repo.resolve(),
+            "project:provider",
+            "Provider note",
+            "Provider-backed content.",
+            "Recorded by provider",
+            "project",
+        )
+    ]

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -48,7 +48,7 @@ from ohmo.memory import add_memory_entry as add_ohmo_memory_entry
 from ohmo.memory import list_memory_files as list_ohmo_memory_files
 from ohmo.gateway.router import session_key_for_message
 from ohmo.session_storage import save_session_snapshot
-from ohmo.workspace import get_gateway_restart_notice_path, get_skills_dir, initialize_workspace
+from ohmo.workspace import get_gateway_restart_notice_path, get_memory_dir, get_skills_dir, initialize_workspace
 
 
 def test_gateway_router_uses_thread_and_sender_for_group_when_present():
@@ -305,6 +305,9 @@ async def test_runtime_pool_restores_messages_for_group_sender_scoped_session_ke
 
     async def fake_build_runtime(**kwargs):
         captured["restore_messages"] = kwargs.get("restore_messages")
+        from openharness.memory import get_project_memory_dir
+
+        captured["memory_dir"] = get_project_memory_dir(tmp_path)
         return SimpleNamespace(
             engine=SimpleNamespace(set_system_prompt=lambda prompt: None, messages=[]),
             session_id="newsession",
@@ -320,6 +323,7 @@ async def test_runtime_pool_restores_messages_for_group_sender_scoped_session_ke
     bundle = await pool.get_bundle("feishu:chat-1:alice")
 
     assert captured["restore_messages"] is not None
+    assert captured["memory_dir"] == get_memory_dir(workspace)
     assert bundle.session_id == "sess123"
 
 

--- a/tests/test_ohmo/test_loading.py
+++ b/tests/test_ohmo/test_loading.py
@@ -3,11 +3,12 @@ import json
 from pathlib import Path
 
 from openharness.config.settings import load_settings
+from openharness.memory import get_project_memory_dir
 from openharness.plugins import load_plugins
 from openharness.skills import load_skill_registry
 
 from ohmo.runtime import run_ohmo_backend
-from ohmo.workspace import get_plugins_dir, get_skills_dir, initialize_workspace
+from ohmo.workspace import get_memory_dir, get_plugins_dir, get_skills_dir, initialize_workspace
 
 
 def _write_plugin(root: Path, name: str, skill_name: str) -> None:
@@ -134,6 +135,7 @@ def test_run_ohmo_backend_passes_private_skill_and_plugin_roots(tmp_path, monkey
 
     async def fake_run_backend_host(**kwargs):
         captured.update(kwargs)
+        captured["memory_dir"] = get_project_memory_dir(kwargs["cwd"])
         return 0
 
     monkeypatch.setattr("ohmo.runtime.run_backend_host", fake_run_backend_host)
@@ -144,6 +146,7 @@ def test_run_ohmo_backend_passes_private_skill_and_plugin_roots(tmp_path, monkey
     assert result == 0
     assert captured["extra_skill_dirs"] == (str(get_skills_dir(workspace)),)
     assert captured["extra_plugin_roots"] == (str(get_plugins_dir(workspace)),)
+    assert captured["memory_dir"] == get_memory_dir(workspace)
 
 
 def test_plugin_loader_supports_directory_skill_layout(tmp_path, monkeypatch):

--- a/tests/test_personalization/test_extractor.py
+++ b/tests/test_personalization/test_extractor.py
@@ -56,6 +56,64 @@ class TestExtractFacts:
         ssh_facts = [f for f in facts if f["type"] == "ssh_host"]
         assert len(ssh_facts) == 1
 
+    def test_extracts_pitfall_fix_pattern(self):
+        text = "Pitfall: if the sandbox is stale, restart it before rerunning tests"
+        facts = extract_facts_from_text(text)
+        pitfall_facts = [f for f in facts if f["type"] == "pitfall"]
+        assert len(pitfall_facts) == 1
+        assert "restart it before rerunning tests" in pitfall_facts[0]["value"]
+
+    def test_extracts_guardrail_forbidden_command_and_protected_path(self):
+        text = (
+            "Guardrail: never mutate production data directly\n"
+            "Forbidden command: rm -rf /tmp/project-cache\n"
+            "Protected path: migrations/"
+        )
+        facts = extract_facts_from_text(text)
+        guardrails = [f for f in facts if f["type"] == "guardrail"]
+        forbidden = [f for f in facts if f["type"] == "forbidden_command"]
+        protected = [f for f in facts if f["type"] == "protected_path"]
+        assert len(guardrails) == 1
+        assert "mutate production data directly" in guardrails[0]["value"]
+        assert len(forbidden) == 1
+        assert forbidden[0]["value"] == "rm -rf /tmp/project-cache"
+        assert len(protected) == 1
+        assert protected[0]["value"] == "migrations/"
+
+    def test_extracts_style_validation_and_retry_rules(self):
+        text = (
+            "Output style: concise bullets only\n"
+            "Naming convention: use snake_case for generated files\n"
+            "Validation rule: always run pytest tests/test_engine/test_query_engine.py first\n"
+            "Retry strategy: retry flaky network requests once after reconnect"
+        )
+        facts = extract_facts_from_text(text)
+        assert any(f["type"] == "style_rule" and "concise bullets only" in f["value"] for f in facts)
+        assert any(f["type"] == "naming_rule" and "snake_case" in f["value"] for f in facts)
+        assert any(f["type"] == "validation_rule" and "pytest tests/test_engine/test_query_engine.py first" in f["value"] for f in facts)
+        assert any(f["type"] == "retry_rule" and "retry flaky network requests once" in f["value"] for f in facts)
+
+    def test_extracts_chinese_rule_labels(self):
+        text = (
+            "高频易错点：改完接口字段后要同步更新测试和文档\n"
+            "安全红线：不要直接改生产配置\n"
+            "禁止命令：rm -rf migrations/\n"
+            "保护路径：migrations/\n"
+            "输出风格：默认用中文回复\n"
+            "命名规则：工具函数要见名知意\n"
+            "验证规则：修改后先运行 pytest tests/test_engine/test_query_engine.py\n"
+            "重试策略：网络恢复后只重试一次"
+        )
+        facts = extract_facts_from_text(text)
+        assert any(f["type"] == "pitfall" and "同步更新测试和文档" in f["value"] for f in facts)
+        assert any(f["type"] == "guardrail" and "不要直接改生产配置" in f["value"] for f in facts)
+        assert any(f["type"] == "forbidden_command" and f["value"] == "rm -rf migrations/" for f in facts)
+        assert any(f["type"] == "protected_path" and f["value"] == "migrations/" for f in facts)
+        assert any(f["type"] == "style_rule" and "默认用中文回复" in f["value"] for f in facts)
+        assert any(f["type"] == "naming_rule" and "见名知意" in f["value"] for f in facts)
+        assert any(f["type"] == "validation_rule" and "pytest tests/test_engine/test_query_engine.py" in f["value"] for f in facts)
+        assert any(f["type"] == "retry_rule" and "网络恢复后只重试一次" in f["value"] for f in facts)
+
 
 class TestMergeFacts:
     def test_merge_new_facts(self):
@@ -86,9 +144,13 @@ class TestFactsToMarkdown:
         facts = [
             {"key": "ssh_host:a@1.1", "type": "ssh_host", "value": "a@1.1", "confidence": 0.7},
             {"key": "conda_env:dev312", "type": "conda_env", "value": "dev312", "confidence": 0.7},
+            {"key": "guardrail:no-prod", "type": "guardrail", "value": "never write to prod", "confidence": 0.7},
+            {"key": "style_rule:concise", "type": "style_rule", "value": "concise bullets only", "confidence": 0.7},
         ]
         md = facts_to_rules_markdown(facts)
         assert "## SSH Hosts" in md
         assert "## Python Environments" in md
+        assert "## Guardrails" in md
+        assert "## Style Rules" in md
         assert "`a@1.1`" in md
         assert "`dev312`" in md

--- a/tests/test_personalization/test_session_hook.py
+++ b/tests/test_personalization/test_session_hook.py
@@ -1,0 +1,141 @@
+"""Tests for session-end personalization persistence."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from openharness.engine.messages import ConversationMessage, TextBlock
+from openharness.memory import scan_memory_files
+from openharness.personalization import rules as personalization_rules
+from openharness.personalization.session_hook import update_rules_from_session
+
+
+def test_update_rules_from_session_syncs_memory(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rules_dir = tmp_path / "local_rules"
+    monkeypatch.setattr(personalization_rules, "_RULES_DIR", rules_dir)
+    monkeypatch.setattr(personalization_rules, "_RULES_FILE", rules_dir / "rules.md")
+    monkeypatch.setattr(personalization_rules, "_FACTS_FILE", rules_dir / "facts.json")
+
+    count = update_rules_from_session(
+        [
+            ConversationMessage(
+                role="user",
+                content=[TextBlock(text="ssh dev@10.0.0.8 && conda activate dev312")],
+            )
+        ],
+        str(repo),
+    )
+
+    assert count >= 1
+    headers = scan_memory_files(repo)
+    assert headers
+    assert any(header.memory_key.startswith("ssh_host:") or header.memory_key.startswith("conda_env:") for header in headers)
+
+
+def test_update_rules_from_session_syncs_guardrails_and_style_rules(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rules_dir = tmp_path / "local_rules"
+    monkeypatch.setattr(personalization_rules, "_RULES_DIR", rules_dir)
+    monkeypatch.setattr(personalization_rules, "_RULES_FILE", rules_dir / "rules.md")
+    monkeypatch.setattr(personalization_rules, "_FACTS_FILE", rules_dir / "facts.json")
+
+    count = update_rules_from_session(
+        [
+            ConversationMessage(
+                role="user",
+                content=[
+                    TextBlock(
+                        text=(
+                            "Guardrail: never delete migrations/\n"
+                            "Protected path: migrations/\n"
+                            "Output style: concise bullets only\n"
+                            "Retry strategy: retry flaky network requests once"
+                        )
+                    )
+                ],
+            )
+        ],
+        str(repo),
+    )
+
+    assert count >= 1
+    headers = scan_memory_files(repo)
+    assert any(header.memory_key.startswith("guardrail:") for header in headers)
+    assert any(header.memory_key.startswith("protected_path:") for header in headers)
+    assert any(header.memory_key.startswith("style_rule:") or header.memory_key.startswith("retry_rule:") for header in headers)
+    header_by_key = {header.memory_key: header for header in headers}
+    assert header_by_key["guardrail:never delete migrations/"].memory_type == "guardrail"
+    assert header_by_key["protected_path:migrations/"].memory_type == "protected_path"
+    assert header_by_key["style_rule:concise bullets only"].memory_type == "style_rule"
+    assert header_by_key["retry_rule:retry flaky network requests once"].memory_type == "retry_rule"
+
+
+def test_update_rules_from_session_supports_chinese_rule_labels(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rules_dir = tmp_path / "local_rules"
+    monkeypatch.setattr(personalization_rules, "_RULES_DIR", rules_dir)
+    monkeypatch.setattr(personalization_rules, "_RULES_FILE", rules_dir / "rules.md")
+    monkeypatch.setattr(personalization_rules, "_FACTS_FILE", rules_dir / "facts.json")
+
+    count = update_rules_from_session(
+        [
+            ConversationMessage(
+                role="user",
+                content=[
+                    TextBlock(
+                        text=(
+                            "高频易错点：改完接口字段后要同步更新测试和文档\n"
+                            "安全红线：不要直接改生产配置\n"
+                            "输出风格：默认用中文回复\n"
+                            "重试策略：网络恢复后只重试一次"
+                        )
+                    )
+                ],
+            )
+        ],
+        str(repo),
+    )
+
+    assert count >= 1
+    headers = scan_memory_files(repo)
+    assert any(header.memory_type == "pitfall" for header in headers)
+    assert any(header.memory_type == "guardrail" for header in headers)
+    assert any(header.memory_type == "style_rule" for header in headers)
+    assert any(header.memory_type == "retry_rule" for header in headers)
+
+
+def test_update_rules_from_session_logs_memory_sync_failures(tmp_path: Path, monkeypatch, caplog):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rules_dir = tmp_path / "local_rules"
+    monkeypatch.setattr(personalization_rules, "_RULES_DIR", rules_dir)
+    monkeypatch.setattr(personalization_rules, "_RULES_FILE", rules_dir / "rules.md")
+    monkeypatch.setattr(personalization_rules, "_FACTS_FILE", rules_dir / "facts.json")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("sync failed")
+
+    monkeypatch.setattr("openharness.personalization.session_hook.sync_fact_memories", _boom)
+
+    with caplog.at_level(logging.ERROR):
+        count = update_rules_from_session(
+            [
+                ConversationMessage(
+                    role="user",
+                    content=[TextBlock(text="Guardrail: never delete migrations/")],
+                )
+            ],
+            str(repo),
+        )
+
+    assert count >= 1
+    assert "Failed to sync extracted session facts into durable memory" in caplog.text

--- a/tests/test_prompts/test_claudemd.py
+++ b/tests/test_prompts/test_claudemd.py
@@ -58,6 +58,47 @@ def test_build_runtime_system_prompt_combines_sections(tmp_path: Path, monkeypat
     assert "Memory" in prompt
 
 
+def test_build_runtime_system_prompt_includes_shared_durable_memory_policy(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    prompt = build_runtime_system_prompt(Settings(), cwd=repo, latest_user_prompt="hello")
+
+    assert "# Durable Memory Writes" in prompt
+    assert "Use the memory_write tool for durable context that should survive future sessions." in prompt
+    assert "## Stable Key Patterns" in prompt
+    assert "NO_MEMORY_UPDATE" not in prompt
+
+
+def test_build_runtime_system_prompt_accepts_memory_policy_skill_override(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "durable-memory-policy"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: durable-memory-policy\n"
+        "description: Custom policy\n"
+        "---\n\n"
+        "# Custom Durable Memory Writes\n\n"
+        "Prefer long-lived branch policy and deployment constraints.\n",
+        encoding="utf-8",
+    )
+
+    prompt = build_runtime_system_prompt(
+        Settings(),
+        cwd=repo,
+        latest_user_prompt="hello",
+        extra_skill_dirs=[skills_root],
+    )
+
+    assert "# Custom Durable Memory Writes" in prompt
+    assert "Prefer long-lived branch policy and deployment constraints." in prompt
+
+
 def test_build_runtime_system_prompt_includes_project_context_and_fast_mode(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
     repo = tmp_path / "repo"

--- a/tests/test_skills/test_loader.py
+++ b/tests/test_skills/test_loader.py
@@ -17,6 +17,8 @@ def test_load_skill_registry_includes_bundled(tmp_path: Path, monkeypatch):
     registry = load_skill_registry()
 
     names = [skill.name for skill in registry.list_skills()]
+    assert "durable-memory-policy" in names
+    assert "durable-memory-reviewer" in names
     assert "simplify" in names
     assert "review" in names
     assert "skill-creator" in names

--- a/tests/test_tools/test_core_tools.py
+++ b/tests/test_tools/test_core_tools.py
@@ -22,6 +22,7 @@ from openharness.tools.file_write_tool import FileWriteTool, FileWriteToolInput
 from openharness.tools.glob_tool import GlobTool, GlobToolInput
 from openharness.tools.grep_tool import GrepTool, GrepToolInput
 from openharness.tools.lsp_tool import LspTool, LspToolInput
+from openharness.tools.memory_write_tool import MemoryWriteTool, MemoryWriteToolInput
 from openharness.tools.notebook_edit_tool import NotebookEditTool, NotebookEditToolInput
 from openharness.tools.remote_trigger_tool import RemoteTriggerTool, RemoteTriggerToolInput
 from openharness.tools.skill_tool import SkillTool, SkillToolInput
@@ -204,6 +205,47 @@ async def test_todo_write_upsert(tmp_path: Path):
     noop = await tool.execute(TodoWriteToolInput(item="task A", checked=True), ctx)
     assert "No change" in noop.output
     assert (tmp_path / "TODO.md").read_text(encoding="utf-8").count("task A") == 1
+
+
+@pytest.mark.asyncio
+async def test_memory_write_tool_upserts_and_deletes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    ctx = ToolExecutionContext(cwd=repo)
+    tool = MemoryWriteTool()
+
+    created = await tool.execute(
+        MemoryWriteToolInput(
+            key="preference:python",
+            title="Language preference",
+            description="User prefers Python",
+            memory_type="preference",
+            content="Prefer Python over JavaScript for automation tasks.",
+        ),
+        ctx,
+    )
+    updated = await tool.execute(
+        MemoryWriteToolInput(
+            key="preference:python",
+            title="Language preference",
+            description="User prefers Python strongly",
+            memory_type="preference",
+            content="Prefer Python over JavaScript for automation and scripting tasks.",
+        ),
+        ctx,
+    )
+    deleted = await tool.execute(
+        MemoryWriteToolInput(action="delete", key="preference:python"),
+        ctx,
+    )
+
+    assert created.is_error is False
+    assert "Created durable memory" in created.output
+    assert updated.is_error is False
+    assert "Updated durable memory" in updated.output
+    assert deleted.is_error is False
+    assert "Deleted memory entry" in deleted.output
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui/test_runtime_close.py
+++ b/tests/test_ui/test_runtime_close.py
@@ -1,0 +1,58 @@
+"""Tests for runtime shutdown behavior."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from openharness.hooks import HookEvent
+from openharness.ui.runtime import close_runtime
+
+
+class _FakeManager:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeHookExecutor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, dict]] = []
+
+    async def execute(self, event, payload) -> None:
+        self.calls.append((event, payload))
+
+
+@pytest.mark.asyncio
+async def test_close_runtime_logs_personalization_failures(tmp_path, monkeypatch, caplog):
+    async def _noop_stop() -> None:
+        return None
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("session sync failed")
+
+    monkeypatch.setattr("openharness.sandbox.session.stop_docker_sandbox", _noop_stop)
+    monkeypatch.setattr("openharness.personalization.session_hook.update_rules_from_session", _boom)
+
+    manager = _FakeManager()
+    hook_executor = _FakeHookExecutor()
+    bundle = SimpleNamespace(
+        current_settings=lambda: SimpleNamespace(
+            memory=SimpleNamespace(session_fact_sync_enabled=True, auto_write_enabled=True)
+        ),
+        engine=SimpleNamespace(messages=[]),
+        cwd=str(tmp_path),
+        mcp_manager=manager,
+        hook_executor=hook_executor,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        await close_runtime(bundle)
+
+    assert manager.closed is True
+    assert any(event == HookEvent.SESSION_END for event, _ in hook_executor.calls)
+    assert "Session-end personalization sync failed" in caplog.text

--- a/tests/test_ui/test_runtime_memory_provider.py
+++ b/tests/test_ui/test_runtime_memory_provider.py
@@ -1,0 +1,44 @@
+"""Tests for project-scoped runtime memory backend selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.config.settings import set_project_memory_provider
+from openharness.ui.runtime import build_runtime, close_runtime
+
+
+class StaticApiClient:
+    async def stream_message(self, request):
+        del request
+        if False:  # pragma: no cover
+            yield None
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_configures_project_memory_provider(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    set_project_memory_provider(repo, "demo")
+
+    calls: list[tuple[Path, str, str]] = []
+
+    def fake_configure_memory_provider(cwd, provider_name, *, settings=None):
+        resolved = Path(cwd).resolve()
+        configured = settings.memory.provider if settings is not None else ""
+        calls.append((resolved, provider_name, configured))
+        return object()
+
+    monkeypatch.setattr("openharness.ui.runtime.configure_memory_provider", fake_configure_memory_provider)
+
+    bundle = await build_runtime(cwd=repo, api_client=StaticApiClient())
+    try:
+        assert calls == [(repo.resolve(), "demo", "demo")]
+        assert bundle.current_settings().memory.provider == "demo"
+    finally:
+        await close_runtime(bundle)


### PR DESCRIPTION
1. add memory_write tool and automatic post-turn memory review
2. sync extracted durable facts at session end
3. refactor memory storage around MEMORY.md indexing, child entries, and provider-based routing
4. wire ohmo into the shared memory pipeline with workspace-local memory storage

https://github.com/HKUDS/OpenHarness/issues/249 [Feature]: Add automatic durable memory write pipeline with provider-based routing and ohmo integration