### PR TITLE
[security] fix(commands): keep tasks local-only by default

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2354,7 +2354,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("upgrade", "Show upgrade instructions", _upgrade_handler))
     registry.register(SlashCommand("agents", "List or inspect agent and teammate tasks", _agents_handler))
     registry.register(SlashCommand("subagents", "Show subagent usage and inspect worker tasks", _agents_handler))
-    registry.register(SlashCommand("tasks", "Manage background tasks", _tasks_handler))
+    registry.register(
+        SlashCommand(
+            "tasks",
+            "Manage background tasks",
+            _tasks_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("autopilot", "Manage repo autopilot intake and context", _autopilot_handler))
     registry.register(
         SlashCommand(

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -161,6 +161,23 @@ async def test_bridge_command_supports_explicit_remote_admin_opt_in(tmp_path: Pa
     assert getattr(command, "remote_admin_opt_in", False) is True
 
 
+@pytest.mark.asyncio
+async def test_tasks_command_is_marked_local_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/tasks run id")
+    assert command is not None
+    assert command.remote_invocable is False
+
+
+@pytest.mark.asyncio
+async def test_tasks_command_supports_explicit_remote_admin_opt_in(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/tasks run id")
+    assert command is not None
+    assert getattr(command, "remote_admin_opt_in", False) is True
+
 
 @pytest.mark.asyncio
 async def test_sensitive_control_plane_commands_are_local_only(tmp_path: Path, monkeypatch):

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -28,6 +28,7 @@ from openharness.engine.stream_events import (
 from openharness.memory import add_memory_entry as add_project_memory_entry
 from openharness.memory import list_memory_files as list_project_memory_files
 from openharness.permissions import PermissionChecker, PermissionMode
+from openharness.tasks.manager import get_task_manager
 from openharness.tools.base import ToolExecutionContext, ToolRegistry
 
 from ohmo.gateway.bridge import OhmoGatewayBridge, _format_gateway_error
@@ -753,6 +754,61 @@ async def test_runtime_pool_blocks_registered_bridge_spawn_without_shelling_out(
     assert {session.session_id for session in get_bridge_manager().list_sessions()} == existing_bridge_sessions
     assert marker.exists() is False
 
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_registered_tasks_run_without_shelling_out(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    marker = tmp_path / "remote-tasks-marker.txt"
+    payload = f"/tasks run printf REMOTE_TASKS_EXEC > {marker}"
+    registry = create_default_command_registry()
+    command, _ = registry.lookup(payload)
+    existing_tasks = {task.id for task in get_task_manager().list_tasks()}
+
+    assert command is not None
+    assert command.name == "tasks"
+    assert command.remote_invocable is False
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(tmp_path),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=registry,
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+    message = InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content=payload)
+    updates = [u async for u in pool.stream_message(message, "feishu:c1")]
+
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "/tasks is only available in the local OpenHarness UI."
+    assert {task.id for task in get_task_manager().list_tasks()} == existing_tasks
+    assert marker.exists() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the ohmo remote slash-command boundary by keeping background task management local-only by default.

- Marks `/tasks` as not remotely invocable unless an operator explicitly opts it into the remote-admin command allowlist.
- Prevents remote channel messages from reaching `/tasks run`, which starts shell-evaluated background commands.
- Adds registry and gateway regression coverage so remote `/tasks run ...` returns the local-only denial and does not create a task or marker file.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Remote `/tasks run` shell execution | An allowed remote channel/gateway sender could execute OS commands as the OpenHarness process user | High |

## Before this PR

- `SlashCommand.remote_invocable` defaults to `True`.
- `/tasks` was registered without `remote_invocable=False`.
- The ohmo gateway allowed remote messages such as `/tasks run <command>` through the slash-command path.
- `_tasks_handler()` passed the command string to `BackgroundTaskManager.create_shell_task(command=...)`, which launches a shell-evaluated subprocess.
- There was no gateway regression proving remote `/tasks run` is blocked before the shell-task path.

## After this PR

- `/tasks` is registered with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Remote `/tasks ...` messages now receive the existing local-only denial unless the operator deliberately enables that command through the remote-admin allowlist.
- Regression tests assert both the command metadata and the remote gateway behavior.
- The gateway regression verifies no background task is created and no command marker file is written.

## Explicit operator choice

This PR uses the existing remote-admin opt-in model already applied to other sensitive commands.

- Default behavior: remote `/tasks ...` is blocked with `/tasks is only available in the local OpenHarness UI.`
- Explicit trusted-admin behavior: operators who have enabled `allow_remote_admin_commands` and allowlisted `tasks` can opt back into remote access intentionally.

Task management is a control-plane feature: `run`, `stop`, `update`, and `output` can start commands, interrupt local work, mutate task metadata, or expose command output. It should not be remotely reachable by default.

## Why this matters

OpenHarness remote channels bridge chat messages into the local agent runtime. When a slash command can spawn a shell task, the boundary is no longer just “remote user can ask the agent a question”; it becomes “remote user can ask the host to execute a command”.

For installations with remote channels enabled, an allowed channel sender could send `/tasks run ...` and run arbitrary commands under the OpenHarness process account.

## How this differs from related issue/PR

This is in the same trust-boundary family as prior command hardening, but it is a distinct remaining command sink:

- #208 kept `/bridge` local-only because `/bridge spawn` could start shell commands.
- #232 kept config/auth commands local-only and redacted nested secrets.
- This PR covers `/tasks`, whose `run` subcommand also reaches shell execution through the background task manager.

Those earlier fixes did not change the `/tasks` registration or add gateway coverage for remote task execution.

## Attack flow

```text
allowed remote channel sender
    -> sends /tasks run <shell command>
        -> ohmo gateway sees /tasks as remotely invocable
            -> _tasks_handler() calls create_shell_task(command=...)
                -> shell command runs as the OpenHarness process user
```

## Affected code

| Issue | Files |
|-------|-------|
| Remote `/tasks run` shell execution | `ohmo/gateway/runtime.py`, `src/openharness/commands/registry.py`, `src/openharness/tasks/manager.py` |

## Root cause

Remote `/tasks run` shell execution:

- Direct cause: `/tasks` inherited the default `remote_invocable=True` metadata even though it includes a shell-spawning subcommand.
- Boundary failure: remote slash-command admission treated task management as a normal remote command instead of a local/admin control-plane operation.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Remote `/tasks run` shell execution | 8.8 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H` |

Rationale:

- The attacker must be able to send messages through an admitted remote channel identity, so this is modeled as `PR:L` rather than unauthenticated.
- The impact is high for confidentiality, integrity, and availability because the command runs with the OpenHarness process user's local privileges.

## Safe reproduction steps

On vulnerable code, a safe local harness can drive the same gateway boundary used by remote chat messages without contacting any real chat provider:

1. Create a temporary repo/workspace and marker path.
2. Build the real default slash-command registry.
3. Send an `InboundMessage(channel="slack", content="/tasks run printf REMOTE_TASKS_EXEC > <marker>")` through `OhmoSessionRuntimePool.stream_message(...)` with a mocked runtime bundle.
4. Observe that `/tasks` is still marked remotely invocable.
5. Wait for the created background task process to complete.
6. Observe the marker file was created with `REMOTE_TASKS_EXEC`.
7. Remove the marker file after capturing the proof signal.

Expected vulnerable signal from current `origin/main` (`1929ad805106dc2f45b79fc6b3cc36e111004259`):

```text
COMMAND tasks
REMOTE_INVOCABLE True
REMOTE_ADMIN_OPT_IN False
FINAL_TEXT Started task b9f43d9e2
NEW_TASK_IDS b9f43d9e2
TASK_STATUS b9f43d9e2 completed
MARKER_EXISTS True
MARKER_CONTENT REMOTE_TASKS_EXEC
CLEANUP_MARKER_EXISTS False
```

## Expected vulnerable behavior

- `/tasks` is considered remotely invocable by the default command registry.
- `/tasks run <command>` starts a shell-backed background task.
- The command can create a local marker file, demonstrating host command execution.

## Changes in this PR

- Registers `/tasks` with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Adds command-registry tests for local-only metadata and explicit remote-admin opt-in metadata.
- Adds a gateway regression using the real default command registry to send a remote `/tasks run ...` payload and assert:
  - the local-only denial is returned,
  - no new background task is created,
  - no marker file is written.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Command metadata | `src/openharness/commands/registry.py` | Marks `/tasks` local-only by default with explicit remote-admin opt-in support |
| Registry tests | `tests/test_commands/test_registry.py` | Adds assertions for `/tasks` remote metadata |
| Gateway regression | `tests/test_ohmo/test_gateway.py` | Adds a remote `/tasks run` denial test that confirms no shell task executes |

## Maintainer impact

- The patch is intentionally narrow and follows the existing local-only pattern already used for `/bridge`, `/config`, `/mcp`, `/permissions`, and other control-plane commands.
- Local CLI/TUI `/tasks` behavior is unchanged.
- Remote operators who intentionally need this behavior can use the existing remote-admin opt-in path rather than receiving it by default.
- No unrelated command, channel, frontend, or task-manager behavior is changed.

## Fix rationale

Task management is privileged because it can start shell commands and expose or mutate task state. The safest durable boundary is to make the whole `/tasks` command local-only by default and require an explicit operator decision before exposing it remotely.

The regression test exercises the gateway boundary instead of only checking metadata, so future refactors that accidentally let remote `/tasks run` reach the handler should fail before a shell command is spawned.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused `/tasks` registry and gateway regressions.
- [x] Existing related local-only gateway command regressions.
- [x] Full command/gateway test files.
- [x] Compile check for touched Python files.
- [x] Whitespace diff check.
- [x] Ruff lint on touched files.

Executed with:

```bash
uv sync --extra dev
PYTHONPATH=src:. uv run pytest -o addopts='' \
  tests/test_commands/test_registry.py::test_tasks_command_is_marked_local_only \
  tests/test_commands/test_registry.py::test_tasks_command_supports_explicit_remote_admin_opt_in \
  tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_tasks_run_without_shelling_out \
  tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_bridge_spawn_without_shelling_out \
  tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_local_only_commands_from_remote_messages -q
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q
PYTHONPATH=src:. uv run python -m compileall -q src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
git diff --check
uv run ruff check src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
```

Local results:

- Focused subset: `5 passed`
- Full touched command/gateway files: `114 passed, 7 warnings`
- Compile, whitespace, and Ruff checks passed
- Warnings were pre-existing `datetime.utcnow()` deprecations in gateway tests


## Disclosure notes

- This PR is bounded to the remote slash-command exposure of `/tasks`.
- The attacker condition is an admitted remote channel/gateway sender; this PR does not claim unauthenticated internet reachability by itself.
- The risk can become more severe in deployments with broad or incorrectly configured remote channel admission.
- No production systems were tested.
- No unrelated files were changed.
