### PR TITLE
[security] fix(commands): keep diff local-only by default

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2343,7 +2343,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("vim", "Show or update Vim mode", _vim_handler))
     registry.register(SlashCommand("voice", "Show or update voice mode", _voice_handler))
     registry.register(SlashCommand("doctor", "Show environment diagnostics", _doctor_handler))
-    registry.register(SlashCommand("diff", "Show git diff output", _diff_handler))
+    registry.register(
+        SlashCommand(
+            "diff",
+            "Show git diff output",
+            _diff_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("branch", "Show git branch information", _branch_handler))
     registry.register(SlashCommand("commit", "Show status or create a git commit", _commit_handler))
     registry.register(SlashCommand("issue", "Show or update project issue context", _issue_handler))

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -161,6 +161,23 @@ async def test_bridge_command_supports_explicit_remote_admin_opt_in(tmp_path: Pa
     assert getattr(command, "remote_admin_opt_in", False) is True
 
 
+@pytest.mark.asyncio
+async def test_diff_command_is_marked_local_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/diff full")
+    assert command is not None
+    assert command.remote_invocable is False
+
+
+@pytest.mark.asyncio
+async def test_diff_command_supports_explicit_remote_admin_opt_in(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/diff full")
+    assert command is not None
+    assert getattr(command, "remote_admin_opt_in", False) is True
+
 
 @pytest.mark.asyncio
 async def test_sensitive_control_plane_commands_are_local_only(tmp_path: Path, monkeypatch):

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import subprocess
 from types import SimpleNamespace
 from datetime import datetime
 import json
@@ -235,6 +236,75 @@ async def test_runtime_pool_restores_messages_for_private_legacy_session_key(tmp
 
     assert captured["restore_messages"] is not None
     assert bundle.session_id == "sess123"
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_registered_diff_full_without_leaking_workspace_changes(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / ".ohmo-home"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    initialize_workspace(workspace)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "OpenHarness Test"], cwd=repo, check=True)
+    changed_file = repo / "app.env"
+    changed_file.write_text("OPENHARNESS_VALUE=old\n", encoding="utf-8")
+    subprocess.run(["git", "add", "app.env"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    changed_file.write_text("OPENHARNESS_VALUE=LEAKMARK_REMOTE_DIFF_VALUE\n", encoding="utf-8")
+
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/diff full")
+    assert command is not None
+    assert command.name == "diff"
+    assert command.remote_invocable is False
+
+    class FakeEngine:
+        messages = []
+        total_usage = UsageSnapshot()
+        tool_metadata = {}
+
+        def set_system_prompt(self, prompt):
+            return None
+
+    async def fake_build_runtime(**kwargs):
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(repo),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=registry,
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=repo, workspace=workspace, provider_profile="codex")
+    message = InboundMessage(
+        channel="slack",
+        sender_id="U_ALLOWED",
+        chat_id="C_SHARED",
+        content="/diff full",
+    )
+
+    updates = [update async for update in pool.stream_message(message, "slack:C_SHARED:U_ALLOWED")]
+
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "/diff is only available in the local OpenHarness UI."
+    assert "LEAKMARK_REMOTE_DIFF_VALUE" not in updates[-1].text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the remote slash-command boundary for the repository diff command. `/diff full` can include the full uncommitted workspace patch, so it should remain a local OpenHarness UI action unless an operator explicitly opts it into the remote-admin command allowlist.

- Marks `/diff` as local-only by default with `remote_invocable=False`.
- Keeps the existing explicit remote-admin opt-in mechanism available with `remote_admin_opt_in=True`.
- Adds registry and gateway regressions proving remote `/diff full` is denied and does not return a marker value from an uncommitted Git diff.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Remote `/diff full` workspace disclosure | An allowed remote channel sender could receive local uncommitted workspace changes through chat | Medium |

## Before this PR

- `/diff` inherited the default remote-invocable slash-command behavior.
- A remote gateway message such as `/diff full` could execute the command against the active workspace.
- The command returns `git diff HEAD`, which may include `.env` edits, local configuration changes, unpublished patches, prompt/context files, or proprietary source changes.
- There was no regression test covering the remote gateway behavior for `/diff full`.

## After this PR

- `/diff` is local-only by default.
- Remote `/diff full` returns the existing local-only denial message.
- Trusted operators can still explicitly opt the command into remote-admin handling through the existing gateway allowlist controls.
- Tests now cover both command metadata and the gateway path with a temporary Git repo containing a marker diff.

## Why this matters

Remote chat channels are a different trust boundary from the local OpenHarness UI. Even when a sender is allowed to chat with the gateway, returning full local repository diffs can expose sensitive or unpublished workspace contents that the sender should not automatically receive.

## How this differs from related issue/PR

This is the same remote slash-command trust-boundary family as prior hardening work, but it covers a distinct residual command:

- #208 kept `/bridge` local-only because it could spawn shell bridge sessions.
- #232 kept config/auth commands local-only and redacted nested configuration secrets.
- #252 keeps `/tasks` local-only because it can spawn background shell tasks.
- This PR covers `/diff full`, which is a read-side workspace disclosure path through `git diff HEAD`.

The fix is intentionally separate because the vulnerable command, handler, and impact are different: this PR prevents returning local workspace patches, not shell execution or configuration mutation.

## Attack flow

```text
Allowed remote channel sender sends: /diff full
    -> ohmo gateway resolves the slash command
        -> /diff is allowed remotely by default on vulnerable builds
            -> _diff_handler() runs git diff HEAD in the workspace
                -> full uncommitted patch is returned to the remote chat
```

## Affected code

| Issue | Files |
|-------|-------|
| Remote `/diff full` workspace disclosure | `src/openharness/commands/registry.py`, `ohmo/gateway/runtime.py` |

## Root cause

Remote `/diff full` workspace disclosure:

- `SlashCommand.remote_invocable` defaults to `True`.
- `/diff` was registered without overriding that default.
- `_diff_handler()` returns full `git diff HEAD` output for `/diff full`, but that local workspace inspection command was reachable from remote gateway messages.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Remote `/diff full` workspace disclosure | 4.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N` |

Rationale: the issue requires access as an allowed remote channel/gateway sender, has low attack complexity, and primarily affects confidentiality of local workspace contents returned in Git diffs. Severity can be higher in deployments with broad remote channel admission or secret-heavy workspaces.

## Safe reproduction steps

1. Start a vulnerable build where `/diff` is registered with the default `remote_invocable=True` behavior.
2. In the active workspace, create a Git repo with one committed file and then modify it without committing:

   ```text
   OPENHARNESS_VALUE=LEAKMARK_REMOTE_DIFF_VALUE
   ```

3. Send a remote gateway message with `/diff full`.
4. Observe that the final response contains the marker value from the uncommitted diff.

## Expected vulnerable behavior

On vulnerable builds, the gateway returns a patch containing the uncommitted marker, for example:

```diff
-OPENHARNESS_VALUE=old
+OPENHARNESS_VALUE=LEAKMARK_REMOTE_DIFF_VALUE
```

After this PR, the remote gateway path returns:

```text
/diff is only available in the local OpenHarness UI.
```

## Changes in this PR

- Registers `/diff` with `remote_invocable=False`.
- Registers `/diff` with `remote_admin_opt_in=True` so trusted operators can explicitly allow it using the existing remote-admin mechanism if they accept that exposure.
- Adds registry tests for the new `/diff` command metadata.
- Adds a gateway regression that builds a temporary Git repo with a marker diff, sends remote `/diff full`, and asserts the marker is not leaked.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Command metadata | `src/openharness/commands/registry.py` | Marks `/diff` local-only by default with explicit remote-admin opt-in support |
| Registry tests | `tests/test_commands/test_registry.py` | Covers `/diff` remote invocation metadata |
| Gateway tests | `tests/test_ohmo/test_gateway.py` | Covers remote `/diff full` denial and verifies a marker diff is not returned |

## Maintainer impact

- The local `/diff` behavior remains unchanged.
- Remote chat users no longer receive workspace patches by default.
- Self-hosted/trusted deployments can still opt into remote `/diff` through the existing administrative command allowlist.
- The patch is narrow and does not change unrelated slash-command handling.

## Fix rationale

`/diff full` reads local workspace state and can return sensitive code or configuration changes. Keeping that command local-only by default matches the existing approach used for other local control-plane commands while preserving an explicit operator-controlled escape hatch for trusted deployments.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused `/diff` registry and gateway regression tests.
- [x] Full touched command/gateway test files.
- [x] Compile check for touched Python files.
- [x] Whitespace diff check.
- [x] Ruff lint check for touched files.

Executed with:

```bash
uv sync --extra dev
PYTHONPATH=src:. uv run pytest -o addopts='' \
  tests/test_commands/test_registry.py::test_diff_command_is_marked_local_only \
  tests/test_commands/test_registry.py::test_diff_command_supports_explicit_remote_admin_opt_in \
  tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_diff_full_without_leaking_workspace_changes -q
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q
PYTHONPATH=src:. uv run python -m compileall -q src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
git diff --check
uv run ruff check src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
```

Local results:

- Focused tests: `3 passed`
- Touched command/gateway files: `114 passed, 7 warnings`
- The warnings are existing `datetime.utcnow()` deprecation warnings in gateway tests.
- Compile, whitespace, and Ruff checks passed.

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: Token accounting was not available from the local validation and PR tooling in this session.

## Disclosure notes

- This PR is bounded to preventing remote `/diff full` workspace disclosure.
- It does not claim unauthenticated access; the modeled attacker is an allowed remote channel/gateway sender.
- Related open PRs #250 and #252 touch the same test/registry areas, but this PR addresses the remaining `/diff` workspace disclosure path specifically.
- No unrelated files were changed.
