### PR TITLE
[security] fix(ohmo): scope Slack thread sessions by sender

### DIFF
--- a/src/openharness/channels/impl/slack.py
+++ b/src/openharness/channels/impl/slack.py
@@ -179,8 +179,11 @@ class SlackChannel(BaseChannel):
         except Exception as e:
             logger.debug("Slack reactions_add failed: %s", e)
 
-        # Thread-scoped session key for channel/group messages
-        session_key = f"slack:{chat_id}:{thread_ts}" if thread_ts and channel_type != "im" else None
+        # Preserve Slack thread metadata for reply routing, but let the ohmo
+        # gateway router derive the session key.  The router includes sender
+        # identity for shared chats; passing a senderless Slack override here
+        # would make different people in the same thread share one session.
+        chat_type = "p2p" if channel_type == "im" else "group"
 
         try:
             await self._handle_message(
@@ -188,13 +191,14 @@ class SlackChannel(BaseChannel):
                 chat_id=chat_id,
                 content=text,
                 metadata={
+                    "thread_ts": thread_ts,
+                    "chat_type": chat_type,
                     "slack": {
                         "event": event,
                         "thread_ts": thread_ts,
                         "channel_type": channel_type,
                     },
                 },
-                session_key=session_key,
             )
         except Exception:
             logger.exception("Error handling Slack message from %s", sender_id)

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -128,6 +128,172 @@ def test_gateway_router_separates_senders_in_same_group_without_thread():
     assert session_key_for_message(second) == "feishu:oc_shared:bob"
 
 
+@pytest.mark.asyncio
+async def test_slack_thread_messages_use_sender_scoped_router_keys(monkeypatch):
+    import sys
+    import types
+
+    def install_stub(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    install_stub("slackify_markdown", slackify_markdown=lambda text: text)
+    install_stub("slack_sdk")
+    install_stub("slack_sdk.socket_mode")
+    install_stub("slack_sdk.socket_mode.request", SocketModeRequest=object)
+
+    class FakeSocketModeResponse:
+        def __init__(self, envelope_id=None):
+            self.envelope_id = envelope_id
+
+    install_stub("slack_sdk.socket_mode.response", SocketModeResponse=FakeSocketModeResponse)
+    install_stub("slack_sdk.socket_mode.websockets", SocketModeClient=object)
+    install_stub("slack_sdk.web")
+    install_stub("slack_sdk.web.async_client", AsyncWebClient=object)
+
+    from openharness.channels.impl.slack import SlackChannel
+    from openharness.config.schema import SlackConfig
+
+    class CapturingBus:
+        def __init__(self):
+            self.messages = []
+
+        async def publish_inbound(self, msg):
+            self.messages.append(msg)
+
+    class FakeSocketClient:
+        async def send_socket_mode_response(self, response):
+            return None
+
+    async def send_thread_message(channel, *, user):
+        request = SimpleNamespace(
+            type="events_api",
+            envelope_id=f"env-{user}",
+            payload={
+                "event": {
+                    "type": "app_mention",
+                    "user": user,
+                    "channel": "C_SHARED",
+                    "channel_type": "channel",
+                    "text": "<@BOT> /summary 50",
+                    "thread_ts": "1710000000.000100",
+                    "ts": f"1710000000.{user[-1]}",
+                }
+            },
+        )
+        await channel._on_socket_request(FakeSocketClient(), request)
+
+    bus = CapturingBus()
+    config = SlackConfig(
+        allow_from=["U_ALICE", "U_BOB"],
+        bot_token="xoxb-fake",
+        app_token="xapp-fake",
+        mode="socket",
+        group_policy="mention",
+        reply_in_thread=True,
+        react_emoji="eyes",
+        dm=SimpleNamespace(enabled=True, policy="allowlist", allow_from=["U_ALICE", "U_BOB"]),
+    )
+    channel = SlackChannel(config, bus)
+    channel._bot_user_id = "BOT"
+    channel._web_client = None
+
+    await send_thread_message(channel, user="U_ALICE")
+    await send_thread_message(channel, user="U_BOB")
+
+    alice, bob = bus.messages
+    assert alice.session_key_override is None
+    assert bob.session_key_override is None
+    assert alice.metadata["thread_ts"] == "1710000000.000100"
+    assert bob.metadata["thread_ts"] == "1710000000.000100"
+    assert alice.metadata["chat_type"] == "group"
+    assert bob.metadata["chat_type"] == "group"
+    assert session_key_for_message(alice) == "slack:C_SHARED:1710000000.000100:U_ALICE"
+    assert session_key_for_message(bob) == "slack:C_SHARED:1710000000.000100:U_BOB"
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_summary_does_not_restore_other_slack_thread_sender(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    alice_message = InboundMessage(
+        channel="slack",
+        sender_id="U_ALICE",
+        chat_id="C_SHARED",
+        content="hello",
+        timestamp=datetime.utcnow(),
+        metadata={"thread_ts": "1710000000.000100", "chat_type": "group"},
+    )
+    bob_message = InboundMessage(
+        channel="slack",
+        sender_id="U_BOB",
+        chat_id="C_SHARED",
+        content="/summary 50",
+        timestamp=datetime.utcnow(),
+        metadata={"thread_ts": "1710000000.000100", "chat_type": "group"},
+    )
+    alice_key = session_key_for_message(alice_message)
+    bob_key = session_key_for_message(bob_message)
+    assert alice_key != bob_key
+    save_session_snapshot(
+        cwd=tmp_path,
+        workspace=workspace,
+        model="gpt-5.4",
+        system_prompt="test",
+        session_key=alice_key,
+        usage=UsageSnapshot(),
+        messages=[
+            ConversationMessage(
+                role="user",
+                content=[TextBlock(text="Alice private note: ALICE_PRIVATE_SUMMARY_SECRET")],
+            )
+        ],
+    )
+
+    async def fake_build_runtime(**kwargs):
+        restored = [ConversationMessage.model_validate(item) for item in (kwargs.get("restore_messages") or [])]
+
+        class FakeEngine:
+            def __init__(self):
+                self.messages = restored
+                self.total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=create_default_command_registry(),
+            cwd=str(tmp_path),
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+            tool_registry=None,
+            app_state=None,
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+    updates = [u async for u in pool.stream_message(bob_message, bob_key)]
+
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "No conversation content to summarize."
+    assert "ALICE_PRIVATE_SUMMARY_SECRET" not in updates[-1].text
+
+
 def test_gateway_error_formats_claude_refresh_failure():
     exc = ValueError("Claude OAuth refresh failed: HTTP Error 400: Bad Request")
     assert "claude-login" in _format_gateway_error(exc)


### PR DESCRIPTION
## Summary

This PR hardens Slack thread session routing so ohmo keeps shared-channel Slack sessions scoped to the remote sender.

- Removes the senderless Slack `session_key_override` for threaded channel messages.
- Preserves Slack thread metadata for replies while letting the central gateway router derive sender-scoped session keys.
- Adds regression coverage for Slack thread routing and for remote `/summary` not restoring another sender's saved thread session.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Slack thread session key omitted sender identity | Another allowed Slack participant in the same thread could reuse the same ohmo runtime/session key and retrieve another participant's retained conversation text via `/summary` | Medium |

## Before this PR

- Slack channel messages with a `thread_ts` supplied an explicit session override shaped like `slack:{chat_id}:{thread_ts}`.
- That override bypassed `ohmo.gateway.router.session_key_for_message()`, so the router could not add sender identity for shared chats.
- Two different allowed Slack users in the same thread could therefore share one ohmo runtime/session.
- Remote transcript-inspection commands such as `/summary` operated on that shared session state.

## After this PR

- Slack no longer passes a senderless thread session override for channel messages.
- Slack still records `thread_ts` and `chat_type` metadata for routing/reply behavior.
- The central router now derives keys such as `slack:<chat_id>:<thread_ts>:<sender_id>` for Slack shared threads.
- Regression tests verify both the Slack adapter output and the `/summary` restore behavior.

## Why this matters

ohmo shared-chat sessions are intended to be isolated by sender so that one participant cannot inherit another participant's agent state, restored messages, or in-flight context. A Slack-specific session override reintroduced a senderless boundary for threaded Slack channels. In practice, a second allowed participant in the same Slack thread could ask for `/summary` and receive text from another participant's retained session.

## How this differs from #159

PR #159 fixed the central ohmo router by making `session_key_for_message()` include sender identity for shared chats and threads.

This PR fixes a residual Slack adapter path that bypassed that router logic:

- #159 changed `ohmo/gateway/router.py` and router/runtime tests.
- This PR changes `src/openharness/channels/impl/slack.py`, where Slack supplied an explicit senderless `session_key_override` before the router could apply its sender-scoped rule.
- Both fixes are needed: the central router protects normal inbound messages, while this PR prevents Slack threaded messages from opting out of that protection.

## Attack flow

```text
Alice sends sensitive context in a Slack thread
    -> Slack adapter stores the thread session as slack:<channel>:<thread_ts>
        -> Bob sends /summary in the same Slack thread
            -> ohmo restores/summarizes the shared thread session
                -> Bob receives Alice's retained conversation text
```

## Affected code

| Issue | Files |
|-------|-------|
| Slack senderless thread session override | `src/openharness/channels/impl/slack.py`, `ohmo/gateway/router.py`, `ohmo/gateway/runtime.py`, `src/openharness/commands/registry.py` |

## Root cause

Slack thread session leak:

- The Slack adapter constructed an explicit session override from only channel and thread identifiers.
- `session_key_for_message()` intentionally trusts `message.session_key_override` first, so the sender-scoped shared-chat logic never ran for Slack threaded messages.
- `/summary` then returned recent messages from the shared runtime/session rather than from a sender-scoped session.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Slack thread summary/session leak | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:

- The attacker must already be an allowed Slack participant who can message the bot in the same thread.
- The impact is confidentiality-focused: retained prompts, summaries, or tool-output text from another participant's session can be disclosed.
- The fix does not claim unauthenticated internet reachability or command execution.

## Safe reproduction steps

A focused local harness can reproduce the vulnerable behavior without real Slack credentials:

1. Stub Slack SDK imports and instantiate `SlackChannel` with two allowed users.
2. Send two simulated `app_mention` events in the same Slack channel/thread, one as Alice and one as Bob.
3. On vulnerable code, observe that both inbound messages carry the same override: `slack:C_SHARED:1710000000.000100`.
4. Seed Alice's thread session with a marker such as `ALICE_PRIVATE_SUMMARY_SECRET`.
5. Send Bob's `/summary 50` through the ohmo runtime pool with the same thread key.
6. Observe that the final `/summary` output contains Alice's marker.

## Expected vulnerable behavior

On vulnerable code, the proof signal is:

```text
ALICE_SESSION_OVERRIDE slack:C_SHARED:1710000000.000100
BOB_SESSION_OVERRIDE slack:C_SHARED:1710000000.000100
OVERRIDES_EQUAL True
SUMMARY_REMOTE_INVOCABLE True
FINAL_HAS_ALICE_SECRET True
```

After this PR, Slack thread messages do not set a senderless override, and the router derives distinct sender-scoped keys:

```text
slack:C_SHARED:1710000000.000100:U_ALICE
slack:C_SHARED:1710000000.000100:U_BOB
```

Bob's `/summary` no longer restores Alice's saved thread session.

## Changes in this PR

- Removes Slack's senderless thread `session_key_override`.
- Adds top-level `thread_ts` metadata for the gateway router.
- Adds top-level `chat_type` metadata so Slack channel messages are treated as shared chats by the central router.
- Keeps Slack-specific metadata under `metadata["slack"]` for reply/thread behavior.
- Adds regression coverage for Slack adapter routing and runtime `/summary` restore isolation.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Slack channel hardening | `src/openharness/channels/impl/slack.py` | Stop passing senderless thread overrides; preserve thread/chat metadata for central routing |
| Regression tests | `tests/test_ohmo/test_gateway.py` | Cover Slack thread sender-scoped keys and `/summary` not restoring another sender's session |

## Maintainer impact

- The patch is intentionally narrow and only changes Slack inbound session routing metadata.
- Slack replies still retain thread metadata for outbound behavior.
- Existing central router behavior remains the source of truth for shared-chat session isolation.
- No unrelated channel adapters, frontend code, or command registry behavior is changed.

## Fix rationale

The central gateway router already contains the correct shared-chat boundary: include sender identity whenever a chat/thread can contain multiple participants. Slack should not bypass that invariant with a channel-local override. Preserving thread metadata and letting the router derive the final key keeps the boundary in one place and reduces the chance of future adapter-specific drift.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused Slack/router regression subset passed.
- [x] Full `tests/test_ohmo/test_gateway.py` passed.
- [x] Python compile check passed for touched files.
- [x] `git diff --check` passed.
- [x] Ruff lint passed for touched files.
- [ ] Full repository test suite was not run; this patch is limited to Slack routing and ohmo gateway tests.
- [ ] `ruff format --check` was not clean because the touched legacy files already require broader formatter churn unrelated to this patch; the security diff avoids that unrelated formatting change.

Executed with:

```bash
uv sync --extra dev
PYTHONPATH=src:. uv run pytest -o addopts='' \
  tests/test_ohmo/test_gateway.py::test_slack_thread_messages_use_sender_scoped_router_keys \
  tests/test_ohmo/test_gateway.py::test_runtime_pool_summary_does_not_restore_other_slack_thread_sender \
  tests/test_ohmo/test_gateway.py::test_gateway_router_uses_thread_and_sender_for_group_when_present \
  tests/test_ohmo/test_gateway.py::test_gateway_router_separates_senders_in_same_chat_thread -q
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_ohmo/test_gateway.py -q
PYTHONPATH=src:. uv run python -m compileall -q src/openharness/channels/impl/slack.py tests/test_ohmo/test_gateway.py
git diff --check
uv run ruff check src/openharness/channels/impl/slack.py tests/test_ohmo/test_gateway.py
uv run ruff format --check src/openharness/channels/impl/slack.py tests/test_ohmo/test_gateway.py
```

Results:

- Focused subset: `4 passed`
- Full gateway test file: `64 passed, 9 warnings`
- Compile, whitespace, and Ruff lint: passed
- Ruff format check: reported pre-existing/broad formatting changes in the touched legacy files, so no formatter churn was included

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: Work was performed through an agent session where exact per-phase token telemetry was unavailable.

## Disclosure notes

- This PR is intentionally bounded to Slack threaded ohmo sessions and the `/summary` confidentiality impact.
- It is a related residual variant of the shared-chat session-boundary family addressed in #159, not a claim of a wholly unrelated vulnerability class.
- The attacker model is an allowed Slack participant in the same thread, not an unauthenticated internet user.
- No production Slack workspace was tested.
