### PR TITLE
feat(tui): preview diffs before edit and write approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ## [Unreleased]
 
+### Added
+
+- `edit_file` and `write_file` in the React TUI now preview a unified diff before applying file changes, let users approve once or for the rest of the session, and skip the extra prompt automatically in `full_auto` mode.
+
 ## [0.1.9] - 2026-05-07
 
 ### Added

--- a/frontend/terminal/src/App.tsx
+++ b/frontend/terminal/src/App.tsx
@@ -270,6 +270,41 @@ function AppInner({config}: {config: FrontendConfig}): React.JSX.Element {
 			return;
 		}
 
+		// --- Edit diff modal (also appears while busy) ---
+		if (session.modal?.kind === 'edit_diff') {
+			if (chunk.toLowerCase() === 'y') {
+				session.sendRequest({
+					type: 'permission_response',
+					request_id: session.modal.request_id,
+					allowed: true,
+					permission_reply: 'once',
+				});
+				session.setModal(null);
+				return;
+			}
+			if (chunk.toLowerCase() === 'a') {
+				session.sendRequest({
+					type: 'permission_response',
+					request_id: session.modal.request_id,
+					allowed: true,
+					permission_reply: 'always',
+				});
+				session.setModal(null);
+				return;
+			}
+			if (chunk.toLowerCase() === 'n' || isEscape) {
+				session.sendRequest({
+					type: 'permission_response',
+					request_id: session.modal.request_id,
+					allowed: false,
+					permission_reply: 'reject',
+				});
+				session.setModal(null);
+				return;
+			}
+			return;
+		}
+
 		// --- Question modal (also appears while busy) ---
 		if (session.modal?.kind === 'question') {
 			return; // Let TextInput in ModalHost handle input

--- a/frontend/terminal/src/components/ModalHost.test.tsx
+++ b/frontend/terminal/src/components/ModalHost.test.tsx
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {PassThrough} from 'node:stream';
+import React from 'react';
+import {render} from 'ink';
+
+import {ModalHost} from './ModalHost.js';
+
+const stripAnsi = (value: string): string => value.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
+const nextLoopTurn = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+type InkTestStdout = PassThrough & {
+	isTTY: boolean;
+	columns: number;
+	rows: number;
+	cursorTo: () => boolean;
+	clearLine: () => boolean;
+	moveCursor: () => boolean;
+};
+
+function createTestStdout(): InkTestStdout {
+	return Object.assign(new PassThrough(), {
+		isTTY: true,
+		columns: 120,
+		rows: 40,
+		cursorTo: () => true,
+		clearLine: () => true,
+		moveCursor: () => true,
+	});
+}
+
+async function waitForOutputToStabilize(getOutput: () => string): Promise<string> {
+	let previous = '';
+	let sawOutput = false;
+
+	for (let i = 0; i < 50; i += 1) {
+		await nextLoopTurn();
+		const current = getOutput();
+		sawOutput ||= current.length > 0;
+		if (sawOutput && current === previous) {
+			return current;
+		}
+		previous = current;
+	}
+
+	throw new Error(`Ink output did not stabilize: ${JSON.stringify(previous)}`);
+}
+
+test('renders edit diff preview with stats and always shortcut', async () => {
+	const stdout = createTestStdout();
+	let output = '';
+
+	stdout.on('data', (chunk) => {
+		output += chunk.toString();
+	});
+
+	const instance = render(
+		<ModalHost
+			modal={{
+				kind: 'edit_diff',
+				path: 'src/demo.txt',
+				diff: '@@ -1 +1 @@\n-old line\n+new line',
+				added: 1,
+				removed: 1,
+			}}
+			modalInput=""
+			setModalInput={() => undefined}
+			onSubmit={() => undefined}
+		/>,
+		{stdout: stdout as unknown as NodeJS.WriteStream, debug: true, patchConsole: false},
+	);
+
+	const exitPromise = instance.waitUntilExit();
+	const stableOutput = await waitForOutputToStabilize(() => output);
+	instance.unmount();
+	await exitPromise;
+	instance.cleanup();
+	stdout.destroy();
+
+	const rendered = stripAnsi(stableOutput);
+	assert.match(rendered, /Edit src\/demo\.txt/);
+	assert.match(rendered, /\+1/);
+	assert.match(rendered, /-1/);
+	assert.match(rendered, /\+new line/);
+	assert.match(rendered, /-old line/);
+	assert.match(rendered, /\[a\] Always/);
+});

--- a/frontend/terminal/src/components/ModalHost.tsx
+++ b/frontend/terminal/src/components/ModalHost.tsx
@@ -8,6 +8,7 @@ const WAIT_FRAMES = [
 	'Agent is waiting for your input.. ',
 	'Agent is waiting for your input...',
 ];
+const MAX_DIFF_LINES = 40;
 
 function WaitingAnimation(): React.JSX.Element {
 	const [frame, setFrame] = useState(0);
@@ -85,6 +86,104 @@ function QuestionModal({
 	);
 }
 
+type DiffLineKind = 'add' | 'del' | 'hunk' | 'context';
+
+type ParsedDiffLine = {
+	kind: DiffLineKind;
+	content: string;
+};
+
+function parseDiffLines(diffText: string): ParsedDiffLine[] {
+	return diffText
+		.split('\n')
+		.flatMap((raw): ParsedDiffLine[] => {
+			if (!raw || raw.startsWith('+++') || raw.startsWith('---')) {
+				return [];
+			}
+			if (raw.startsWith('@@')) {
+				return [{kind: 'hunk', content: raw}];
+			}
+			if (raw.startsWith('+')) {
+				return [{kind: 'add', content: raw.slice(1)}];
+			}
+			if (raw.startsWith('-')) {
+				return [{kind: 'del', content: raw.slice(1)}];
+			}
+			return [{kind: 'context', content: raw.startsWith(' ') ? raw.slice(1) : raw}];
+		});
+}
+
+function EditDiffModal({modal}: {modal: Record<string, unknown>}): React.JSX.Element {
+	const path = String(modal.path ?? '');
+	const added = Number(modal.added ?? 0);
+	const removed = Number(modal.removed ?? 0);
+	const lines = parseDiffLines(String(modal.diff ?? ''));
+	const visibleLines = lines.slice(0, MAX_DIFF_LINES);
+	const hiddenCount = lines.length - visibleLines.length;
+
+	return (
+		<Box flexDirection="column" marginTop={1}>
+			<Text>
+				<Text color="yellow" bold>{'\u250C '}</Text>
+				<Text bold>Edit </Text>
+				<Text color="cyan" bold>{path}</Text>
+				<Text>{'  '}</Text>
+				<Text color="green">{`+${added}`}</Text>
+				<Text>{' '}</Text>
+				<Text color="red">{`-${removed}`}</Text>
+			</Text>
+			{visibleLines.map((line, index) => {
+				if (line.kind === 'hunk') {
+					return (
+						<Text key={index}>
+							<Text color="yellow">{'\u2502 '}</Text>
+							<Text color="cyan" dimColor>{line.content}</Text>
+						</Text>
+					);
+				}
+				if (line.kind === 'add') {
+					return (
+						<Text key={index}>
+							<Text color="yellow">{'\u2502 '}</Text>
+							<Text color="green">+</Text>
+							<Text color="green">{line.content}</Text>
+						</Text>
+					);
+				}
+				if (line.kind === 'del') {
+					return (
+						<Text key={index}>
+							<Text color="yellow">{'\u2502 '}</Text>
+							<Text color="red">-</Text>
+							<Text color="red">{line.content}</Text>
+						</Text>
+					);
+				}
+				return (
+					<Text key={index}>
+						<Text color="yellow">{'\u2502 '}</Text>
+						<Text dimColor>{' '}{line.content}</Text>
+					</Text>
+				);
+			})}
+			{hiddenCount > 0 ? (
+				<Text>
+					<Text color="yellow">{'\u2502 '}</Text>
+					<Text dimColor>... {hiddenCount} more lines hidden</Text>
+				</Text>
+			) : null}
+			<Text>
+				<Text color="yellow">{'\u2514 '}</Text>
+				<Text color="green">[y] Once</Text>
+				<Text>{'  '}</Text>
+				<Text color="green">[a] Always</Text>
+				<Text>{'  '}</Text>
+				<Text color="red">[n] Deny</Text>
+			</Text>
+		</Box>
+	);
+}
+
 function ModalHostInner({
 	modal,
 	modalInput,
@@ -119,6 +218,9 @@ function ModalHostInner({
 				</Text>
 			</Box>
 		);
+	}
+	if (modal?.kind === 'edit_diff') {
+		return <EditDiffModal modal={modal} />;
 	}
 	if (modal?.kind === 'question') {
 		return (

--- a/src/openharness/tools/file_edit_tool.py
+++ b/src/openharness/tools/file_edit_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -53,6 +54,16 @@ class FileEditTool(BaseTool):
         else:
             updated = original.replace(arguments.old_str, arguments.new_str, 1)
 
+        approval_prompt = context.metadata.get("edit_approval_prompt") if context.metadata else None
+        if approval_prompt is not None:
+            diff_text, added, removed = _compute_diff(str(path), original, updated)
+            reply = await approval_prompt(str(path), diff_text, added, removed)
+            if reply == "reject":
+                return ToolResult(output=f"Edit rejected by user: {path}", is_error=True)
+            path.write_text(updated, encoding="utf-8")
+            stats = f"  ({_ANSI_GREEN}+{added}{_ANSI_RESET} {_ANSI_RED}-{removed}{_ANSI_RESET})"
+            return ToolResult(output=f"Updated {path}{stats}")
+
         path.write_text(updated, encoding="utf-8")
         return ToolResult(output=f"Updated {path}")
 
@@ -62,3 +73,23 @@ def _resolve_path(base: Path, candidate: str) -> Path:
     if not path.is_absolute():
         path = base / path
     return path.resolve()
+
+
+def _compute_diff(filename: str, original: str, updated: str) -> tuple[str, int, int]:
+    diff_lines = list(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )
+    added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    return "".join(diff_lines), added, removed
+
+
+_ANSI_GREEN = "\033[32m"
+_ANSI_RED = "\033[31m"
+_ANSI_RESET = "\033[0m"

--- a/src/openharness/tools/file_write_tool.py
+++ b/src/openharness/tools/file_write_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -40,6 +41,19 @@ class FileWriteTool(BaseTool):
             if not allowed:
                 return ToolResult(output=f"Sandbox: {reason}", is_error=True)
 
+        approval_prompt = context.metadata.get("edit_approval_prompt") if context.metadata else None
+        if approval_prompt is not None:
+            original = path.read_text(encoding="utf-8") if path.exists() else ""
+            diff_text, added, removed = _compute_diff(str(path), original, arguments.content)
+            reply = await approval_prompt(str(path), diff_text, added, removed)
+            if reply == "reject":
+                return ToolResult(output=f"Write rejected by user: {path}", is_error=True)
+            if arguments.create_directories:
+                path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(arguments.content, encoding="utf-8")
+            stats = f"  ({_ANSI_GREEN}+{added}{_ANSI_RESET} {_ANSI_RED}-{removed}{_ANSI_RESET})"
+            return ToolResult(output=f"Wrote {path}{stats}")
+
         if arguments.create_directories:
             path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(arguments.content, encoding="utf-8")
@@ -51,3 +65,23 @@ def _resolve_path(base: Path, candidate: str) -> Path:
     if not path.is_absolute():
         path = base / path
     return path.resolve()
+
+
+def _compute_diff(filename: str, original: str, updated: str) -> tuple[str, int, int]:
+    diff_lines = list(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )
+    added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+    return "".join(diff_lines), added, removed
+
+
+_ANSI_GREEN = "\033[32m"
+_ANSI_RED = "\033[31m"
+_ANSI_RESET = "\033[0m"

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -77,6 +77,7 @@ class ReactBackendHost:
         self._write_lock = asyncio.Lock()
         self._request_queue: asyncio.Queue[FrontendRequest] = asyncio.Queue()
         self._permission_requests: dict[str, asyncio.Future[bool]] = {}
+        self._edit_approval_requests: dict[str, asyncio.Future[str]] = {}
         self._question_requests: dict[str, asyncio.Future[str]] = {}
         self._permission_lock = asyncio.Lock()
         self._busy = False
@@ -84,6 +85,7 @@ class ReactBackendHost:
         self._active_request_task: asyncio.Task[bool] | None = None
         # Track last tool input per name for rich event emission
         self._last_tool_inputs: dict[str, dict] = {}
+        self._edit_always_approved = False
 
     async def run(self) -> int:
         self._bundle = await build_runtime(
@@ -100,6 +102,7 @@ class ReactBackendHost:
             restore_tool_metadata=self._config.restore_tool_metadata,
             permission_prompt=self._ask_permission,
             ask_user_prompt=self._ask_question,
+            edit_approval_prompt=self._ask_edit_approval,
             enforce_max_turns=self._config.enforce_max_turns,
             permission_mode=self._config.permission_mode,
             session_backend=self._config.session_backend,
@@ -192,6 +195,11 @@ class ReactBackendHost:
                 request = FrontendRequest.model_validate_json(payload)
             except Exception as exc:  # pragma: no cover - defensive protocol handling
                 await self._emit(BackendEvent(type="error", message=f"Invalid request: {exc}"))
+                continue
+            if request.type == "permission_response" and request.request_id in self._edit_approval_requests:
+                future = self._edit_approval_requests[request.request_id]
+                if not future.done():
+                    future.set_result(_edit_approval_reply_from_request(request))
                 continue
             if request.type == "permission_response" and request.request_id in self._permission_requests:
                 future = self._permission_requests[request.request_id]
@@ -755,6 +763,45 @@ class ReactBackendHost:
             finally:
                 self._permission_requests.pop(request_id, None)
 
+    def _current_permission_mode(self) -> str:
+        if self._bundle is None:
+            return str(self._config.permission_mode or "")
+        return str(self._bundle.app_state.get().permission_mode or "")
+
+    async def _ask_edit_approval(self, path: str, diff: str, added: int, removed: int) -> str:
+        if self._edit_always_approved or self._current_permission_mode() == "full_auto":
+            return "always"
+
+        async with self._permission_lock:
+            request_id = uuid4().hex
+            future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+            self._edit_approval_requests[request_id] = future
+            await self._emit(
+                BackendEvent(
+                    type="modal_request",
+                    modal={
+                        "kind": "edit_diff",
+                        "request_id": request_id,
+                        "path": path,
+                        "diff": diff,
+                        "added": added,
+                        "removed": removed,
+                    },
+                )
+            )
+            try:
+                reply = await asyncio.wait_for(future, timeout=300)
+            except asyncio.TimeoutError:
+                log.warning("Edit approval request %s timed out after 300s, denying", request_id)
+                reply = "reject"
+            finally:
+                self._edit_approval_requests.pop(request_id, None)
+                await self._emit(BackendEvent(type="modal_request", modal=None))
+
+            if reply == "always":
+                self._edit_always_approved = True
+            return reply
+
     async def _ask_question(self, question: str) -> str:
         request_id = uuid4().hex
         future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
@@ -837,3 +884,10 @@ async def run_backend_host(
 
 
 __all__ = ["run_backend_host", "ReactBackendHost", "BackendHostConfig"]
+
+
+def _edit_approval_reply_from_request(request: FrontendRequest) -> str:
+    reply = (request.permission_reply or "").strip().lower()
+    if reply in {"once", "always", "reject"}:
+        return reply
+    return "once" if bool(request.allowed) else "reject"

--- a/src/openharness/ui/protocol.py
+++ b/src/openharness/ui/protocol.py
@@ -30,6 +30,7 @@ class FrontendRequest(BaseModel):
     value: str | None = None
     request_id: str | None = None
     allowed: bool | None = None
+    permission_reply: str | None = None
     answer: str | None = None
 
 

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -45,6 +45,7 @@ from openharness.keybindings import load_keybindings
 
 PermissionPrompt = Callable[[str, str], Awaitable[bool]]
 AskUserPrompt = Callable[[str], Awaitable[str]]
+EditApprovalPrompt = Callable[[str, str, int, int], Awaitable[str]]
 SystemPrinter = Callable[[str], Awaitable[None]]
 StreamRenderer = Callable[[StreamEvent], Awaitable[None]]
 ClearHandler = Callable[[], Awaitable[None]]
@@ -256,6 +257,7 @@ async def build_runtime(
     api_client: SupportsStreamingMessages | None = None,
     permission_prompt: PermissionPrompt | None = None,
     ask_user_prompt: AskUserPrompt | None = None,
+    edit_approval_prompt: EditApprovalPrompt | None = None,
     restore_messages: list[dict] | None = None,
     restore_tool_metadata: dict[str, object] | None = None,
     enforce_max_turns: bool = True,
@@ -389,6 +391,7 @@ async def build_runtime(
             "extra_skill_dirs": normalized_skill_dirs,
             "extra_plugin_roots": normalized_plugin_roots,
             "session_id": session_id,
+            "edit_approval_prompt": edit_approval_prompt,
             "vision_model_config": _resolve_vision_config(settings),
             "image_generation_config": _resolve_image_generation_config(settings),
             **restored_metadata,

--- a/tests/test_tools/test_core_tools.py
+++ b/tests/test_tools/test_core_tools.py
@@ -57,6 +57,76 @@ async def test_file_write_read_and_edit(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_file_write_requests_edit_approval_and_reports_diff_stats(tmp_path: Path):
+    approvals: list[tuple[str, str, int, int]] = []
+
+    async def _approve(path: str, diff: str, added: int, removed: int) -> str:
+        approvals.append((path, diff, added, removed))
+        return "once"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path="notes.txt", content="one\ntwo\n"),
+        ToolExecutionContext(cwd=tmp_path, metadata={"edit_approval_prompt": _approve}),
+    )
+
+    assert result.is_error is False
+    assert (tmp_path / "notes.txt").read_text(encoding="utf-8") == "one\ntwo\n"
+    assert len(approvals) == 1
+    path, diff, added, removed = approvals[0]
+    assert path == str(tmp_path / "notes.txt")
+    assert added == 2
+    assert removed == 0
+    assert "@@" in diff
+    assert "+one" in diff
+    assert "+two" in diff
+    assert "\033[32m+2\033[0m" in result.output
+    assert "\033[31m-0\033[0m" in result.output
+
+
+@pytest.mark.asyncio
+async def test_file_write_rejection_does_not_create_parent_directories(tmp_path: Path):
+    async def _reject(path: str, diff: str, added: int, removed: int) -> str:
+        del path, diff, added, removed
+        return "reject"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path="nested/notes.txt", content="draft\n"),
+        ToolExecutionContext(cwd=tmp_path, metadata={"edit_approval_prompt": _reject}),
+    )
+
+    assert result.is_error is True
+    assert "Write rejected by user" in result.output
+    assert not (tmp_path / "nested").exists()
+
+
+@pytest.mark.asyncio
+async def test_file_edit_rejects_when_edit_approval_denied(tmp_path: Path):
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\n", encoding="utf-8")
+    approvals: list[tuple[str, str, int, int]] = []
+
+    async def _reject(path: str, diff: str, added: int, removed: int) -> str:
+        approvals.append((path, diff, added, removed))
+        return "reject"
+
+    result = await FileEditTool().execute(
+        FileEditToolInput(path="notes.txt", old_str="two", new_str="TWO"),
+        ToolExecutionContext(cwd=tmp_path, metadata={"edit_approval_prompt": _reject}),
+    )
+
+    assert result.is_error is True
+    assert "Edit rejected by user" in result.output
+    assert target.read_text(encoding="utf-8") == "one\ntwo\n"
+    assert len(approvals) == 1
+    path, diff, added, removed = approvals[0]
+    assert path == str(target)
+    assert added == 1
+    assert removed == 1
+    assert "-two" in diff
+    assert "+TWO" in diff
+
+
+@pytest.mark.asyncio
 async def test_glob_and_grep(tmp_path: Path):
     context = ToolExecutionContext(cwd=tmp_path)
     (tmp_path / "a.py").write_text("def alpha():\n    return 1\n", encoding="utf-8")

--- a/tests/test_ui/test_react_backend.py
+++ b/tests/test_ui/test_react_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -102,6 +103,38 @@ async def test_read_requests_resolves_permission_response_without_queueing(monke
 
     assert fut.done()
     assert fut.result() is True
+    queued = await host._request_queue.get()
+    assert queued.type == "shutdown"
+    assert host._request_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_read_requests_resolves_edit_approval_response_without_queueing(monkeypatch):
+    host = ReactBackendHost(BackendHostConfig(api_client=StaticApiClient("unused")))
+    fut = asyncio.get_running_loop().create_future()
+    host._edit_approval_requests["req-1"] = fut
+
+    payload = b'{"type":"permission_response","request_id":"req-1","allowed":true,"permission_reply":"always"}\n'
+
+    class _FakeBuffer:
+        def __init__(self):
+            self._reads = 0
+
+        def readline(self):
+            self._reads += 1
+            if self._reads == 1:
+                return payload
+            return b""
+
+    class _FakeStdin:
+        buffer = _FakeBuffer()
+
+    monkeypatch.setattr("openharness.ui.backend_host.sys.stdin", _FakeStdin())
+
+    await host._read_requests()
+
+    assert fut.done()
+    assert fut.result() == "always"
     queued = await host._request_queue.get()
     assert queued.type == "shutdown"
     assert host._request_queue.empty()
@@ -666,3 +699,56 @@ async def test_concurrent_ask_permission_are_serialised():
     # distinct request IDs must have been emitted.
     assert len(emitted_order) == 2
     assert emitted_order[0] != emitted_order[1]
+
+
+@pytest.mark.asyncio
+async def test_ask_edit_approval_remembers_always_choice():
+    host = ReactBackendHost(BackendHostConfig(api_client=StaticApiClient("unused")))
+    events = []
+
+    async def _emit(event):
+        events.append(event)
+
+    host._emit = _emit  # type: ignore[method-assign]
+
+    async def _resolver():
+        while not host._edit_approval_requests:
+            await asyncio.sleep(0)
+        next(iter(host._edit_approval_requests.values())).set_result("always")
+
+    asyncio.create_task(_resolver())
+    reply = await host._ask_edit_approval("notes.txt", "@@ -1 +1 @@\n-old\n+new", 1, 1)
+
+    assert reply == "always"
+    assert host._edit_always_approved is True
+    assert any(
+        event.type == "modal_request"
+        and event.modal
+        and event.modal.get("kind") == "edit_diff"
+        for event in events
+    )
+
+    events.clear()
+    second_reply = await host._ask_edit_approval("notes.txt", "@@ -1 +1 @@\n-old\n+new", 1, 1)
+
+    assert second_reply == "always"
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_ask_edit_approval_skips_when_session_mode_is_full_auto():
+    host = ReactBackendHost(BackendHostConfig(api_client=StaticApiClient("unused")))
+    events = []
+
+    async def _emit(event):
+        events.append(event)
+
+    host._emit = _emit  # type: ignore[method-assign]
+    host._bundle = SimpleNamespace(
+        app_state=SimpleNamespace(get=lambda: SimpleNamespace(permission_mode="full_auto"))
+    )
+
+    reply = await host._ask_edit_approval("notes.txt", "@@ -1 +1 @@\n-old\n+new", 1, 1)
+
+    assert reply == "always"
+    assert events == []


### PR DESCRIPTION
## Summary
- Preview unified diffs for `edit_file` and `write_file` before file changes are applied in the React TUI
- Add an `edit_diff` approval flow with once / always / reject responses, plus `full_auto` bypass behavior
- Cover the new tool, backend, and modal flow with regression tests and document the feature in `CHANGELOG.md`

## Validation
- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q tests/test_tools/test_core_tools.py tests/test_ui/test_react_backend.py`
- [x] `cd frontend/terminal && node --import tsx --test src/components/ModalHost.test.tsx`
- [x] `cd frontend/terminal && npx tsc --noEmit`
- [x] `uv run pytest -q` *(matches the existing repository baseline except for the pre-existing failures in `tests/test_commands/test_registry.py::test_bundled_user_invocable_skill_registers_as_slash_command` and `tests/test_skills/test_loader.py::test_load_skill_registry_includes_bundled`)*

## Notes
- Related issue: Closes #259
- Follow-up work: None
- Breaking changes: None
