### PR TITLE
[security] fix(commands): keep /commit local-only over remote channels

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2345,7 +2345,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("doctor", "Show environment diagnostics", _doctor_handler))
     registry.register(SlashCommand("diff", "Show git diff output", _diff_handler))
     registry.register(SlashCommand("branch", "Show git branch information", _branch_handler))
-    registry.register(SlashCommand("commit", "Show status or create a git commit", _commit_handler))
+    registry.register(
+        SlashCommand(
+            "commit",
+            "Show status or create a git commit",
+            _commit_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("issue", "Show or update project issue context", _issue_handler))
     registry.register(SlashCommand("pr_comments", "Show or update project PR comments context", _pr_comments_handler))
     registry.register(SlashCommand("privacy-settings", "Show local privacy and storage settings", _privacy_settings_handler))

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -174,6 +174,7 @@ async def test_sensitive_control_plane_commands_are_local_only(tmp_path: Path, m
         "/mcp",
         "/provider",
         "/model show",
+        "/commit remote requested commit",
         "/ship",
     ):
         command, _ = registry.lookup(payload)

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import subprocess
 from types import SimpleNamespace
 from datetime import datetime
 import json
@@ -753,6 +754,95 @@ async def test_runtime_pool_blocks_registered_bridge_spawn_without_shelling_out(
     assert {session.session_id for session in get_bridge_manager().list_sessions()} == existing_bridge_sessions
     assert marker.exists() is False
 
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_registered_commit_without_running_git_hooks(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "openharness-test@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "OpenHarness Test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tracked = repo / "tracked.txt"
+    tracked.write_text("before\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    marker = repo / "remote-commit-hook-marker.txt"
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text(f"#!/bin/sh\nprintf REMOTE_COMMIT_HOOK_EXEC > {marker}\n", encoding="utf-8")
+    hook.chmod(0o755)
+    tracked.write_text("before\nremote change\n", encoding="utf-8")
+
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/commit remote requested commit")
+    assert command is not None
+    assert command.name == "commit"
+    assert command.remote_invocable is False
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(repo),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=registry,
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=repo, workspace=workspace, provider_profile="codex")
+    message = InboundMessage(
+        channel="slack",
+        sender_id="U_ATTACKER",
+        chat_id="C_SHARED",
+        content="/commit remote requested commit",
+    )
+    updates = [u async for u in pool.stream_message(message, "slack:C_SHARED:U_ATTACKER")]
+
+    assert updates[-1].kind == "final"
+    assert updates[-1].text == "/commit is only available in the local OpenHarness UI."
+    assert marker.exists() is False
+    last_commit = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert last_commit == "initial"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the remote slash-command boundary for local Git operations.

- Marks `/commit` as local-only by default so remote channel/gateway messages cannot stage workspace changes or create Git commits.
- Preserves an explicit admin opt-in metadata path with `remote_admin_opt_in=True` for deployments that intentionally expose this command through trusted remote administration.
- Adds registry coverage so `/commit remote requested commit` is treated with the same local-only expectations as other sensitive control-plane commands.
- Adds a gateway regression proving a remote `/commit ...` message is denied before the Git handler runs, so no new commit is created and no local Git hook executes.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Remote `/commit` could mutate the operator workspace and invoke Git hooks | An admitted remote channel/gateway sender could cause OpenHarness to run `git add -A` and `git commit -m ...` in the local workspace; normal Git commit processing can also execute existing local hooks such as `pre-commit`. | High |

## Before this PR

- `/commit` inherited the default remote slash-command behavior and was remotely invocable.
- A remote message such as `/commit remote requested commit` could reach `_commit_handler()` through the gateway command path.
- `_commit_handler()` stages all workspace changes with `git add -A` and creates a local commit with an attacker-supplied message.
- Existing local Git hooks could execute as part of normal `git commit` processing.
- The command metadata and gateway tests did not cover `/commit` as a local-only Git mutation boundary.

## After this PR

- `/commit` is registered with `remote_invocable=False`.
- `/commit` is registered with `remote_admin_opt_in=True` so remote exposure remains an explicit trusted-admin choice rather than the default.
- Remote `/commit ...` messages now receive the local-only denial before Git commands run.
- Regression coverage verifies both the command metadata and the gateway behavior.

## Explicit operator choice

- Secure default behavior: `/commit` is available from the local OpenHarness UI only.
- Remote default behavior: a remote `/commit ...` message is rejected with `/commit is only available in the local OpenHarness UI.`
- Trusted/admin-controlled behavior: the command metadata now marks `/commit` as eligible for explicit remote-admin opt-in if a deployment intentionally supports that model.
- This keeps workspace mutation and Git hook execution behind a local/trusted boundary unless an operator deliberately changes that policy.

## Why this matters

- Remote channel input and local workspace mutation are different trust boundaries.
- Creating a Git commit is not only a read-only status operation: it stages files, writes local Git history, and can execute repository hooks already present in the workspace.
- A remote sender who is allowed to talk to the gateway should not automatically gain the ability to mutate the operator's local repository.

## How this differs from related issue/PR

This is a sibling hardening change for the same remote slash-command boundary as prior local-only command fixes, but it covers a distinct Git mutation path.

- Prior related fixes marked other commands such as `/tasks`, `/diff`, and `/autopilot` local-only by default.
- Those changes did not cover `/commit`.
- This PR specifically covers `_commit_handler()` and the `git add -A` / `git commit -m ...` behavior behind `/commit`.

## Attack flow

```text
Admitted remote channel/gateway sender sends `/commit remote requested commit`
    -> OhmoSessionRuntimePool parses the remote slash command
        -> `/commit` is allowed because it inherited remote invocation
            -> `_commit_handler()` runs `git add -A` and `git commit -m ...`
                -> local workspace is mutated and existing Git hooks can execute
```

## Affected code

| Issue | Files |
|-------|-------|
| Remote `/commit` workspace mutation and Git hook execution | `src/openharness/commands/registry.py`, `tests/test_commands/test_registry.py`, `tests/test_ohmo/test_gateway.py` |

## Root cause

Remote `/commit` workspace mutation and Git hook execution:

- `/commit` was registered without an explicit local-only policy, so it inherited the default `remote_invocable=True` behavior.
- The gateway command boundary did not distinguish local Git mutation commands from safe remote commands.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Remote `/commit` workspace mutation and Git hook execution | 7.6 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:H/A:L` |

Rationale:

- The attacker must already be an admitted remote channel/gateway sender, so privileges are modeled as low rather than unauthenticated.
- The main impact is integrity of the local workspace and Git history; confidentiality and availability are bounded but possible through hook behavior and committed local content.
- This does not claim the attacker can upload or modify Git hooks by this primitive alone; the hook execution impact applies when executable hooks already exist in the repository.

## Safe reproduction steps

### 1. Remote `/commit` reaches local Git mutation before this fix

1. Create a temporary Git repository and configure a local test Git identity.
2. Commit an initial tracked file.
3. Install a harmless executable `.git/hooks/pre-commit` that writes a marker such as `REMOTE_COMMIT_HOOK_EXEC`.
4. Modify the tracked file.
5. Send a remote gateway message equivalent to `/commit remote requested commit` through the OpenHarness command path.
6. Observe that, before this fix, the command is remotely invocable, a new local commit is created, and the harmless hook marker is written.

## Expected vulnerable behavior

- `/commit` should not have been remotely invocable by default because it mutates the local repository.
- Before this fix, the command metadata allowed the remote gateway path to reach `_commit_handler()`.
- The safe proof signal was a new local commit and a harmless hook marker written by the test `pre-commit` hook.

## Changes in this PR

- Marks `/commit` with `remote_invocable=False`.
- Marks `/commit` with `remote_admin_opt_in=True`.
- Adds `/commit remote requested commit` to the sensitive command metadata regression coverage.
- Adds a gateway regression that sends a remote `/commit ...` message and asserts:
  - the local-only denial is returned;
  - the Git handler is not reached;
  - no new commit is created;
  - the harmless local `pre-commit` hook marker is not written.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Command metadata | `src/openharness/commands/registry.py` | Registers `/commit` as local-only by default and explicitly admin-opt-in for remote exposure. |
| Registry tests | `tests/test_commands/test_registry.py` | Extends sensitive command metadata coverage to include `/commit remote requested commit`. |
| Gateway regression | `tests/test_ohmo/test_gateway.py` | Verifies remote `/commit ...` is denied before Git side effects or hook execution. |

## Maintainer impact

- The patch is intentionally narrow: it only changes `/commit` remote-invocation metadata and tests for that boundary.
- Local `/commit` behavior is preserved.
- Remote channel users lose default access to a local Git mutation command, which matches the behavior expected for other local-control slash commands.
- Frontend, API, storage, model/provider, and unrelated command behavior are untouched.

## Fix rationale

- The gateway should treat local Git mutation as a local/trusted operation unless a deployment explicitly opts into remote administration.
- `remote_invocable=False` is the narrowest durable control for the existing command model.
- `remote_admin_opt_in=True` documents that this can be exposed only as an explicit trusted-admin policy choice.
- The regression exercises the real gateway command boundary and checks for the concrete side effects that matter: commit creation and Git hook execution.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused regression for `/commit` command metadata and gateway blocking behavior.
- [x] Ruff lint for touched files.
- [x] Focused command/gateway test files.
- [x] GitHub CI passed for Python quality, frontend typecheck, and Python 3.10/3.11 tests.

Executed with:

- `uv run python -m pytest tests/test_commands/test_registry.py::test_sensitive_control_plane_commands_are_local_only tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_commit_without_running_git_hooks -q`
- `uv run ruff check src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py`
- `uv run python -m pytest tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q`

## Disclosure notes

- Claims are bounded to admitted remote channel/gateway senders, not unauthenticated internet reachability.
- This PR does not claim a remote attacker can place or modify Git hooks through `/commit` alone.
- The Git hook execution impact applies when the target repository already contains executable hooks that normal `git commit` would run.
- No production systems were tested.
- No unrelated files were changed.
