### PR TITLE
fix(openai): omit empty reasoning_content by default

### DIFF
--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 from typing import Any, AsyncIterator
 from urllib.parse import urlsplit, urlunsplit
@@ -145,13 +146,43 @@ def _convert_user_content_to_openai(blocks: list[ContentBlock]) -> str | list[di
     return content
 
 
+_EMPTY_REASONING_ENV = "OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT"
+
+
+def _empty_reasoning_required() -> bool:
+    """True when the operator's provider requires an empty
+    ``reasoning_content`` field on tool-using assistant messages
+    (Kimi-on-Anthropic style). Default off — strict-OpenAI providers
+    reject the field outright.
+    """
+    raw = os.environ.get(_EMPTY_REASONING_ENV, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _convert_assistant_message(msg: ConversationMessage) -> dict[str, Any]:
     """Convert an assistant ConversationMessage to OpenAI format.
 
-    Providers with thinking models (e.g. Kimi k2.5) require a
-    ``reasoning_content`` field on every assistant message that contains
-    tool calls.  We stash the raw reasoning text on ``msg._reasoning``
-    during parsing and replay it here.
+    ``reasoning_content`` is a non-standard field used by thinking models
+    (e.g. Kimi k2.5) to carry the model's internal chain-of-thought across
+    turns. Some thinking-model providers require it on every assistant
+    message with tool calls — even when empty — or they reject the request.
+    Other OpenAI-compatible providers (Cerebras, OpenAI's own
+    endpoint, etc.) reject the field outright with a 400
+    ``wrong_api_format`` error.
+
+    Behaviour:
+
+    - When the streaming parser captured non-empty reasoning on
+      ``msg._reasoning``, we always replay it. Models that emit reasoning
+      tokens are by definition thinking models that round-trip them.
+    - When there is no captured reasoning but the message has tool calls,
+      we emit ``reasoning_content: ""`` only if the operator opts in via
+      ``OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT=1``. The default is
+      omit, which matches strict-OpenAI providers.
+
+    The opt-in default keeps strict-OpenAI providers (Cerebras, NVIDIA NIM,
+    OpenAI direct, etc.) working out-of-the-box; Kimi-on-Anthropic users
+    set the env var in their dotfiles or settings.
     """
     text_parts = [b.text for b in msg.content if isinstance(b, TextBlock)]
     tool_uses = [b for b in msg.content if isinstance(b, ToolUseBlock)]
@@ -165,8 +196,9 @@ def _convert_assistant_message(msg: ConversationMessage) -> dict[str, Any]:
     reasoning = getattr(msg, "_reasoning", None)
     if reasoning:
         openai_msg["reasoning_content"] = reasoning
-    elif tool_uses:
-        # Thinking models require this field even if empty
+    elif tool_uses and _empty_reasoning_required():
+        # Kimi-style providers reject tool_use messages without this field
+        # even when there's nothing to put in it. Opt-in via env var.
         openai_msg["reasoning_content"] = ""
 
     if tool_uses:

--- a/tests/test_api/test_openai_client.py
+++ b/tests/test_api/test_openai_client.py
@@ -11,6 +11,7 @@ import pytest
 from openharness.api.client import ApiMessageRequest
 from openharness.api.openai_client import (
     OpenAICompatibleClient,
+    _convert_assistant_message,
     _convert_messages_to_openai,
     _convert_tools_to_openai,
     _normalize_openai_base_url,
@@ -435,3 +436,64 @@ class TestStripThinkBlocks:
         visible, buf = _strip_think_blocks(buf)
         assert visible == "answer"
         assert buf == ""
+
+
+class TestReasoningContentEmission:
+    """``reasoning_content`` is a non-standard field. It must round-trip
+    when the streaming parser captured non-empty reasoning, but the
+    legacy "emit empty string when there are tool calls" behaviour now
+    requires opt-in via ``OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT=1``.
+
+    Strict-OpenAI providers (Cerebras, NVIDIA NIM, OpenAI direct) reject
+    requests carrying the field with a ``wrong_api_format`` 400, so the
+    default-off behaviour fixes them out-of-the-box; Kimi-on-Anthropic
+    users opt in via env var.
+    """
+
+    def _msg_with_tool_use(self, *, reasoning: str | None = None) -> ConversationMessage:
+        msg = ConversationMessage(
+            role="assistant",
+            content=[
+                TextBlock(text="ok"),
+                ToolUseBlock(id="tool_1", name="read_file", input={"path": "x"}),
+            ],
+        )
+        if reasoning is not None:
+            msg._reasoning = reasoning  # type: ignore[attr-defined]
+        return msg
+
+    def test_omits_reasoning_when_no_captured_text(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", raising=False)
+        out = _convert_assistant_message(self._msg_with_tool_use())
+        assert "reasoning_content" not in out
+
+    def test_replays_captured_reasoning(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", raising=False)
+        out = _convert_assistant_message(self._msg_with_tool_use(reasoning="thinking…"))
+        assert out["reasoning_content"] == "thinking…"
+
+    def test_emits_empty_when_opted_in(self, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", "1")
+        out = _convert_assistant_message(self._msg_with_tool_use())
+        assert out["reasoning_content"] == ""
+
+    def test_opt_in_truthy_values(self, monkeypatch):
+        for v in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", v)
+            out = _convert_assistant_message(self._msg_with_tool_use())
+            assert out.get("reasoning_content") == "", f"value={v!r}"
+
+    def test_opt_in_falsy_values(self, monkeypatch):
+        for v in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", v)
+            out = _convert_assistant_message(self._msg_with_tool_use())
+            assert "reasoning_content" not in out, f"value={v!r} should not opt in"
+
+    def test_no_tool_calls_never_emits_empty(self, monkeypatch):
+        # Pure-text assistant messages have always omitted the field; the
+        # opt-in is scoped to tool-use messages where Kimi specifically
+        # demands the placeholder.
+        monkeypatch.setenv("OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT", "1")
+        msg = ConversationMessage(role="assistant", content=[TextBlock(text="hi")])
+        out = _convert_assistant_message(msg)
+        assert "reasoning_content" not in out


### PR DESCRIPTION
## Summary

`reasoning_content` is a non-standard field that some thinking-model providers (Kimi k2.5 on Anthropic-format) require on every assistant message with tool calls — even when empty. Other OpenAI-compatible providers (Cerebras, NVIDIA NIM, OpenAI direct, etc.) reject the field outright with a 400 `wrong_api_format` validation error.

Until now, `_convert_assistant_message` unconditionally emitted `reasoning_content: ''` for tool-using assistant messages. That hard-breaks every strict-OpenAI provider on the very first tool turn.

## Behaviour change

- Captured non-empty reasoning is still always replayed.
- The empty-string fallback is now **opt-in** via `OPENHARNESS_REQUIRE_EMPTY_REASONING_CONTENT=1`.
- Default behaviour matches strict-OpenAI providers, which is the larger / standards-compliant population. Kimi-on-Anthropic users set the env var in their dotfiles or settings.

## Verification

Verified end-to-end against Cerebras `gpt-oss-120b` (previously 100% failure rate from this field) — zero `wrong_api_format` errors after the patch.

## Tests

6 cases added in `tests/test_api/test_openai_client.py`:
- captured non-empty reasoning is replayed
- opt-in matrix: truthy values (`1`, `true`, `yes`) emit empty fallback; falsy / unset omit it
- no-tool-calls invariant: field never appears on assistant messages without tool calls

## Files

- `src/openharness/api/openai_client.py` (+38/-6)
- `tests/test_api/test_openai_client.py` (+62/-0)

## Test plan

- [ ] CI green on PR
- [ ] Manual: Cerebras `gpt-oss-120b` tool-using conversation completes without `wrong_api_format`
- [ ] Manual: Kimi k2.5 on Anthropic-format still works with env var set