### PR TITLE
feat(memory): add structured schema and usage index

### DIFF
--- a/ohmo/memory.py
+++ b/ohmo/memory.py
@@ -6,6 +6,21 @@ from pathlib import Path
 from re import sub
 
 from openharness.commands import MemoryCommandBackend
+from openharness.memory.scan import scan_memory_files
+from openharness.memory.schema import (
+    SCHEMA_VERSION,
+    coerce_int,
+    compute_memory_signature,
+    first_content_line,
+    format_datetime,
+    generate_memory_id,
+    memory_metadata_from_path,
+    render_memory_file,
+    split_memory_file,
+    utc_now,
+)
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
 
 from ohmo.workspace import get_memory_dir, get_memory_index_path
 
@@ -13,7 +28,14 @@ from ohmo.workspace import get_memory_dir, get_memory_index_path
 def list_memory_files(workspace: str | Path | None = None) -> list[Path]:
     """List ``.ohmo`` memory markdown files."""
     memory_dir = get_memory_dir(workspace)
-    return sorted(path for path in memory_dir.glob("*.md") if path.name != "MEMORY.md")
+    return sorted(
+        header.path
+        for header in scan_memory_files(
+            _scan_cwd(workspace, memory_dir),
+            max_files=None,
+            memory_dir=memory_dir,
+        )
+    )
 
 
 def add_memory_entry(workspace: str | Path | None, title: str, content: str) -> Path:
@@ -21,30 +43,113 @@ def add_memory_entry(workspace: str | Path | None, title: str, content: str) -> 
     memory_dir = get_memory_dir(workspace)
     memory_dir.mkdir(parents=True, exist_ok=True)
     slug = sub(r"[^a-zA-Z0-9]+", "_", title.strip().lower()).strip("_") or "memory"
-    path = memory_dir / f"{slug}.md"
-    path.write_text(content.strip() + "\n", encoding="utf-8")
+    with exclusive_file_lock(memory_dir / ".memory.lock"):
+        memory_type = "personal"
+        category = "preference"
+        body = content.strip() + "\n"
+        signature = compute_memory_signature(body, memory_type, category)
+        existing = scan_memory_files(
+            _scan_cwd(workspace, memory_dir),
+            max_files=None,
+            include_disabled=True,
+            include_expired=True,
+            memory_dir=memory_dir,
+        )
+        duplicate = next(
+            (header for header in existing if _effective_signature(header.path, header.signature) == signature),
+            None,
+        )
+        path = duplicate.path if duplicate is not None else _next_memory_path(memory_dir, slug)
+        now = utc_now()
+        now_text = format_datetime(now)
+        if path.exists():
+            metadata, old_body, _, _ = split_memory_file(path.read_text(encoding="utf-8"))
+            metadata = memory_metadata_from_path(
+                path,
+                metadata,
+                old_body,
+                now=now,
+                source=str(metadata.get("source") or "manual"),
+                default_type=memory_type,
+                default_category=category,
+            )
+            created_at = str(metadata.get("created_at") or now_text)
+            memory_id = str(metadata.get("id") or generate_memory_id(now))
+        else:
+            metadata = {}
+            created_at = now_text
+            memory_id = generate_memory_id(now)
+        metadata.update(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "id": memory_id,
+                "name": title.strip(),
+                "description": first_content_line(body) or title.strip(),
+                "type": str(metadata.get("type") or memory_type),
+                "category": str(metadata.get("category") or category),
+                "importance": max(coerce_int(metadata.get("importance"), default=0), 1),
+                "source": "manual",
+                "signature": signature,
+                "created_at": created_at,
+                "updated_at": now_text,
+                "ttl_days": metadata.get("ttl_days"),
+                "disabled": False,
+                "supersedes": metadata.get("supersedes") or [],
+            }
+        )
+        atomic_write_text(path, render_memory_file(metadata, body))
 
-    index_path = get_memory_index_path(workspace)
-    existing = index_path.read_text(encoding="utf-8") if index_path.exists() else "# Memory Index\n"
-    if path.name not in existing:
-        existing = existing.rstrip() + f"\n- [{title}]({path.name})\n"
-        index_path.write_text(existing, encoding="utf-8")
+        index_path = get_memory_index_path(workspace)
+        existing_index = index_path.read_text(encoding="utf-8") if index_path.exists() else "# Memory Index\n"
+        if path.name not in existing_index:
+            existing_index = existing_index.rstrip() + f"\n- [{title}]({path.name})\n"
+            atomic_write_text(index_path, existing_index)
     return path
 
 
 def remove_memory_entry(workspace: str | Path | None, name: str) -> bool:
-    """Delete a memory file and remove its index entry."""
+    """Soft-delete a memory file and remove its index entry."""
     memory_dir = get_memory_dir(workspace)
-    matches = [path for path in memory_dir.glob("*.md") if path.stem == name or path.name == name]
+    matches = [
+        header
+        for header in scan_memory_files(
+            _scan_cwd(workspace, memory_dir),
+            max_files=None,
+            include_disabled=True,
+            include_expired=True,
+            memory_dir=memory_dir,
+        )
+        if name in {header.path.stem, header.path.name, header.title, header.id}
+    ]
     if not matches:
         return False
-    path = matches[0]
-    path.unlink(missing_ok=True)
+    header = matches[0]
+    if header.disabled:
+        return False
+    path = header.path
+    with exclusive_file_lock(memory_dir / ".memory.lock"):
+        content = path.read_text(encoding="utf-8")
+        metadata, body, _, _ = split_memory_file(content)
+        metadata = memory_metadata_from_path(
+            path,
+            metadata,
+            body,
+            source="manual",
+            default_type="personal",
+            default_category="preference",
+        )
+        metadata["disabled"] = True
+        metadata["updated_at"] = format_datetime(utc_now())
+        atomic_write_text(path, render_memory_file(metadata, body))
 
-    index_path = get_memory_index_path(workspace)
-    if index_path.exists():
-        lines = [line for line in index_path.read_text(encoding="utf-8").splitlines() if path.name not in line]
-        index_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        index_path = get_memory_index_path(workspace)
+        if index_path.exists():
+            lines = [
+                line
+                for line in index_path.read_text(encoding="utf-8").splitlines()
+                if path.name not in line
+            ]
+            atomic_write_text(index_path, "\n".join(lines).rstrip() + "\n")
     return True
 
 
@@ -82,3 +187,31 @@ def create_memory_command_backend(workspace: str | Path | None = None) -> Memory
         add_entry=lambda title, content: add_memory_entry(workspace, title, content),
         remove_entry=lambda name: remove_memory_entry(workspace, name),
     )
+
+
+def _scan_cwd(workspace: str | Path | None, memory_dir: Path) -> Path:
+    return Path(workspace) if workspace is not None else memory_dir.parent
+
+
+def _next_memory_path(memory_dir: Path, slug: str) -> Path:
+    path = memory_dir / f"{slug}.md"
+    if not path.exists():
+        return path
+    index = 2
+    while True:
+        candidate = memory_dir / f"{slug}_{index}.md"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def _effective_signature(path: Path, existing_signature: str) -> str:
+    if existing_signature:
+        return existing_signature
+    try:
+        metadata, body, _, _ = split_memory_file(path.read_text(encoding="utf-8"))
+    except OSError:
+        return ""
+    memory_type = str(metadata.get("type") or "personal")
+    category = str(metadata.get("category") or "preference")
+    return compute_memory_signature(body, memory_type, category)

--- a/ohmo/memory.py
+++ b/ohmo/memory.py
@@ -181,6 +181,8 @@ def create_memory_command_backend(workspace: str | Path | None = None) -> Memory
 
     return MemoryCommandBackend(
         label="ohmo personal memory",
+        default_type="personal",
+        default_category="preference",
         get_memory_dir=lambda: get_memory_dir(workspace),
         get_entrypoint=lambda: get_memory_index_path(workspace),
         list_files=lambda: list_memory_files(workspace),

--- a/scripts/migrate_memory.py
+++ b/scripts/migrate_memory.py
@@ -1,0 +1,14 @@
+"""Run the OpenHarness memory schema migration from a source checkout."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from openharness.memory.migrate import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -92,6 +92,8 @@ class MemoryCommandBackend:
     """Storage backend used by the generic ``/memory`` slash command."""
 
     label: str
+    default_type: str
+    default_category: str
     get_memory_dir: Callable[[], Path]
     get_entrypoint: Callable[[], Path]
     list_files: Callable[[], list[Path]]
@@ -674,8 +676,8 @@ def create_default_command_registry(
             summary = migrate_memory(
                 context.cwd,
                 memory_dir=backend.get_memory_dir(),
-                default_type="personal" if "ohmo" in backend.label.lower() else "project",
-                default_category="preference" if "ohmo" in backend.label.lower() else "knowledge",
+                default_type=backend.default_type,
+                default_category=backend.default_category,
                 apply=rest == "--apply",
             )
             mode = "dry run" if summary.dry_run else "applied"
@@ -2508,6 +2510,8 @@ def _memory_backend_for_context(context: CommandContext) -> MemoryCommandBackend
     cwd = context.cwd
     return MemoryCommandBackend(
         label="OpenHarness project memory",
+        default_type="project",
+        default_category="knowledge",
         get_memory_dir=lambda: get_project_memory_dir(cwd),
         get_entrypoint=lambda: get_memory_entrypoint(cwd),
         list_files=lambda: list_memory_files(cwd),

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -36,8 +36,10 @@ from openharness.memory import (
     get_memory_entrypoint,
     get_project_memory_dir,
     list_memory_files,
+    migrate_memory,
     remove_memory_entry,
 )
+from openharness.memory.schema import is_disabled_metadata, is_memory_expired, split_memory_file
 from openharness.output_styles import load_output_styles
 from openharness.permissions import PermissionChecker, PermissionMode
 from openharness.plugins import load_plugins
@@ -660,6 +662,37 @@ def create_default_command_registry(
             if not memory_files:
                 return CommandResult(message="No memory files.")
             return CommandResult(message="\n".join(path.name for path in memory_files))
+        if action == "migrate":
+            if rest not in {"--dry-run", "--apply"}:
+                return CommandResult(
+                    message=(
+                        "Usage: /memory "
+                        "[list|show NAME|add TITLE :: CONTENT|remove NAME|"
+                        "migrate --dry-run|migrate --apply]"
+                    )
+                )
+            summary = migrate_memory(
+                context.cwd,
+                memory_dir=backend.get_memory_dir(),
+                default_type="personal" if "ohmo" in backend.label.lower() else "project",
+                default_category="preference" if "ohmo" in backend.label.lower() else "knowledge",
+                apply=rest == "--apply",
+            )
+            mode = "dry run" if summary.dry_run else "applied"
+            lines = [
+                f"Memory migration {mode}.",
+                f"Scanned: {summary.scanned}",
+                f"Changed: {summary.changed}",
+                f"Unchanged: {summary.unchanged}",
+                f"Failed: {summary.failed}",
+            ]
+            if summary.backup_dir:
+                lines.append(f"Backup: {summary.backup_dir}")
+            if summary.changed_files:
+                lines.append("Changed files: " + ", ".join(summary.changed_files))
+            if summary.failed_files:
+                lines.append("Failed files: " + ", ".join(summary.failed_files))
+            return CommandResult(message="\n".join(lines))
         if action == "show" and rest:
             memory_dir = backend.get_memory_dir()
             path, invalid = _resolve_memory_entry_path(memory_dir, rest)
@@ -669,7 +702,11 @@ def create_default_command_registry(
                 return CommandResult(message=f"Memory entry not found: {rest}")
             if not path.exists():
                 return CommandResult(message=f"Memory entry not found: {rest}")
-            return CommandResult(message=path.read_text(encoding="utf-8"))
+            content = path.read_text(encoding="utf-8")
+            metadata, _, _, _ = split_memory_file(content)
+            if is_disabled_metadata(metadata) or is_memory_expired(metadata):
+                return CommandResult(message=f"Memory entry not found: {rest}")
+            return CommandResult(message=content)
         if action == "add" and rest:
             title, separator, content = rest.partition("::")
             if not separator or not title.strip() or not content.strip():
@@ -680,7 +717,13 @@ def create_default_command_registry(
             if backend.remove_entry(rest.strip()):
                 return CommandResult(message=f"Removed memory entry {rest.strip()}")
             return CommandResult(message=f"Memory entry not found: {rest.strip()}")
-        return CommandResult(message="Usage: /memory [list|show NAME|add TITLE :: CONTENT|remove NAME]")
+        return CommandResult(
+            message=(
+                "Usage: /memory "
+                "[list|show NAME|add TITLE :: CONTENT|remove NAME|"
+                "migrate --dry-run|migrate --apply]"
+            )
+        )
 
     async def _hooks_handler(_: str, context: CommandContext) -> CommandResult:
         return CommandResult(message=context.hooks_summary or "No hooks configured.")

--- a/src/openharness/memory/__init__.py
+++ b/src/openharness/memory/__init__.py
@@ -2,9 +2,11 @@
 
 from openharness.memory.memdir import load_memory_prompt
 from openharness.memory.manager import add_memory_entry, list_memory_files, remove_memory_entry
+from openharness.memory.migrate import migrate_memory
 from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
 from openharness.memory.scan import scan_memory_files
 from openharness.memory.search import find_relevant_memories
+from openharness.memory.usage import mark_memory_used
 
 __all__ = [
     "add_memory_entry",
@@ -13,6 +15,8 @@ __all__ = [
     "get_project_memory_dir",
     "list_memory_files",
     "load_memory_prompt",
+    "mark_memory_used",
+    "migrate_memory",
     "remove_memory_entry",
     "scan_memory_files",
 ]

--- a/src/openharness/memory/manager.py
+++ b/src/openharness/memory/manager.py
@@ -6,6 +6,19 @@ from pathlib import Path
 from re import sub
 
 from openharness.memory.paths import get_memory_entrypoint, get_project_memory_dir
+from openharness.memory.scan import scan_memory_files
+from openharness.memory.schema import (
+    SCHEMA_VERSION,
+    compute_memory_signature,
+    first_content_line,
+    format_datetime,
+    generate_memory_id,
+    memory_metadata_from_path,
+    render_memory_file,
+    split_memory_file,
+    coerce_int,
+    utc_now,
+)
 from openharness.utils.file_lock import exclusive_file_lock
 from openharness.utils.fs import atomic_write_text
 
@@ -16,36 +29,101 @@ def _memory_lock_path(cwd: str | Path) -> Path:
 
 def list_memory_files(cwd: str | Path) -> list[Path]:
     """List memory markdown files for the project."""
-    memory_dir = get_project_memory_dir(cwd)
-    return sorted(path for path in memory_dir.glob("*.md"))
+    return sorted(header.path for header in scan_memory_files(cwd, max_files=None))
 
 
 def add_memory_entry(cwd: str | Path, title: str, content: str) -> Path:
-    """Create a memory file and append it to MEMORY.md."""
+    """Create or refresh a memory file and append it to MEMORY.md."""
     memory_dir = get_project_memory_dir(cwd)
     slug = sub(r"[^a-zA-Z0-9]+", "_", title.strip().lower()).strip("_") or "memory"
-    path = memory_dir / f"{slug}.md"
     with exclusive_file_lock(_memory_lock_path(cwd)):
-        atomic_write_text(path, content.strip() + "\n")
+        memory_type = "project"
+        category = "knowledge"
+        body = content.strip() + "\n"
+        signature = compute_memory_signature(body, memory_type, category)
+        existing = scan_memory_files(
+            cwd,
+            max_files=None,
+            include_disabled=True,
+            include_expired=True,
+        )
+        duplicate = next(
+            (header for header in existing if _effective_signature(header.path, header.signature) == signature),
+            None,
+        )
+        path = duplicate.path if duplicate is not None else _next_memory_path(memory_dir, slug)
+        now = utc_now()
+        now_text = format_datetime(now)
+        if path.exists():
+            metadata, old_body, _, _ = split_memory_file(path.read_text(encoding="utf-8"))
+            metadata = memory_metadata_from_path(
+                path,
+                metadata,
+                old_body,
+                now=now,
+                source=str(metadata.get("source") or "manual"),
+            )
+            created_at = str(metadata.get("created_at") or now_text)
+            memory_id = str(metadata.get("id") or generate_memory_id(now))
+        else:
+            metadata = {}
+            created_at = now_text
+            memory_id = generate_memory_id(now)
+
+        metadata.update(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "id": memory_id,
+                "name": title.strip(),
+                "description": first_content_line(body) or title.strip(),
+                "type": str(metadata.get("type") or memory_type),
+                "category": str(metadata.get("category") or category),
+                "importance": max(coerce_int(metadata.get("importance"), default=0), 1),
+                "source": "manual",
+                "signature": signature,
+                "created_at": created_at,
+                "updated_at": now_text,
+                "ttl_days": metadata.get("ttl_days"),
+                "disabled": False,
+                "supersedes": metadata.get("supersedes") or [],
+            }
+        )
+        atomic_write_text(path, render_memory_file(metadata, body))
 
         entrypoint = get_memory_entrypoint(cwd)
-        existing = entrypoint.read_text(encoding="utf-8") if entrypoint.exists() else "# Memory Index\n"
-        if path.name not in existing:
-            existing = existing.rstrip() + f"\n- [{title}]({path.name})\n"
-            atomic_write_text(entrypoint, existing)
+        index_text = entrypoint.read_text(encoding="utf-8") if entrypoint.exists() else "# Memory Index\n"
+        if path.name not in index_text:
+            index_text = index_text.rstrip() + f"\n- [{title}]({path.name})\n"
+            atomic_write_text(entrypoint, index_text)
     return path
 
 
 def remove_memory_entry(cwd: str | Path, name: str) -> bool:
-    """Delete a memory file and remove its index entry."""
-    memory_dir = get_project_memory_dir(cwd)
-    matches = [path for path in memory_dir.glob("*.md") if path.stem == name or path.name == name]
+    """Soft-delete a memory file and remove its index entry."""
+    matches = [
+        header
+        for header in scan_memory_files(
+            cwd,
+            max_files=None,
+            include_disabled=True,
+            include_expired=True,
+        )
+        if name in {header.path.stem, header.path.name, header.title, header.id}
+    ]
     if not matches:
         return False
-    path = matches[0]
+    header = matches[0]
+    if header.disabled:
+        return False
+    path = header.path
     with exclusive_file_lock(_memory_lock_path(cwd)):
         if path.exists():
-            path.unlink()
+            content = path.read_text(encoding="utf-8")
+            metadata, body, _, _ = split_memory_file(content)
+            metadata = memory_metadata_from_path(path, metadata, body, source="manual")
+            metadata["disabled"] = True
+            metadata["updated_at"] = format_datetime(utc_now())
+            atomic_write_text(path, render_memory_file(metadata, body))
 
         entrypoint = get_memory_entrypoint(cwd)
         if entrypoint.exists():
@@ -56,3 +134,27 @@ def remove_memory_entry(cwd: str | Path, name: str) -> bool:
             ]
             atomic_write_text(entrypoint, "\n".join(lines).rstrip() + "\n")
     return True
+
+
+def _next_memory_path(memory_dir: Path, slug: str) -> Path:
+    path = memory_dir / f"{slug}.md"
+    if not path.exists():
+        return path
+    index = 2
+    while True:
+        candidate = memory_dir / f"{slug}_{index}.md"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def _effective_signature(path: Path, existing_signature: str) -> str:
+    if existing_signature:
+        return existing_signature
+    try:
+        metadata, body, _, _ = split_memory_file(path.read_text(encoding="utf-8"))
+    except OSError:
+        return ""
+    memory_type = str(metadata.get("type") or "project")
+    category = str(metadata.get("category") or "knowledge")
+    return compute_memory_signature(body, memory_type, category)

--- a/src/openharness/memory/memdir.py
+++ b/src/openharness/memory/memdir.py
@@ -14,7 +14,7 @@ def load_memory_prompt(cwd: str | Path, *, max_entrypoint_lines: int = 200) -> s
     lines = [
         "# Memory",
         f"- Persistent memory directory: {memory_dir}",
-        "- Use this directory to store durable user or project context that should survive future sessions.",
+        "- Use this directory to store durable project and repository context that should survive future sessions.",
         "- Prefer concise topic files plus an index entry in MEMORY.md.",
     ]
 

--- a/src/openharness/memory/migrate.py
+++ b/src/openharness/memory/migrate.py
@@ -1,0 +1,137 @@
+"""Migration utilities for schema-v1 memory frontmatter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from openharness.memory.paths import get_project_memory_dir
+from openharness.memory.schema import (
+    memory_metadata_from_path,
+    render_memory_file,
+    split_memory_file,
+    utc_now,
+)
+from openharness.utils.fs import atomic_write_text
+
+
+@dataclass(frozen=True)
+class MigrationSummary:
+    """Summary returned by a memory schema migration run."""
+
+    scanned: int
+    changed: int
+    unchanged: int
+    failed: int
+    dry_run: bool
+    backup_dir: str
+    changed_files: tuple[str, ...]
+    failed_files: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def migrate_memory(
+    cwd: str | Path,
+    *,
+    memory_dir: str | Path | None = None,
+    default_type: str = "project",
+    default_category: str = "knowledge",
+    apply: bool = False,
+) -> MigrationSummary:
+    """Backfill schema-v1 frontmatter for top-level memory markdown files."""
+
+    root = Path(memory_dir).expanduser().resolve() if memory_dir is not None else get_project_memory_dir(cwd)
+    root.mkdir(parents=True, exist_ok=True)
+    files = sorted(path for path in root.glob("*.md") if path.name != "MEMORY.md")
+    changed_payloads: list[tuple[Path, str]] = []
+    failed_files: list[str] = []
+    seen_ids: set[str] = set()
+    now = utc_now()
+
+    for path in files:
+        try:
+            content = path.read_text(encoding="utf-8")
+            metadata, body, _, _ = split_memory_file(content)
+            migrated = memory_metadata_from_path(
+                path,
+                metadata,
+                body,
+                now=now,
+                source="migration",
+                default_type=default_type,
+                default_category=default_category,
+                seen_ids=seen_ids,
+            )
+            rendered = render_memory_file(migrated, body)
+            if rendered != content:
+                changed_payloads.append((path, rendered))
+        except OSError:
+            failed_files.append(path.name)
+
+    backup_dir = ""
+    if apply and changed_payloads:
+        backup_path = _create_migration_backup(root)
+        backup_dir = str(backup_path)
+        for path, rendered in changed_payloads:
+            atomic_write_text(path, rendered)
+
+    changed_files = tuple(path.name for path, _ in changed_payloads)
+    return MigrationSummary(
+        scanned=len(files),
+        changed=len(changed_payloads),
+        unchanged=len(files) - len(changed_payloads) - len(failed_files),
+        failed=len(failed_files),
+        dry_run=not apply,
+        backup_dir=backup_dir,
+        changed_files=changed_files,
+        failed_files=tuple(failed_files),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Command-line entrypoint for one-off memory migrations."""
+
+    parser = argparse.ArgumentParser(description="Backfill OpenHarness memory schema metadata.")
+    parser.add_argument("--cwd", default=".", help="Project cwd whose memory store should be migrated.")
+    parser.add_argument("--memory-dir", default=None, help="Explicit memory directory to migrate.")
+    parser.add_argument("--default-type", default="project", help="Type for legacy files without one.")
+    parser.add_argument("--default-category", default="knowledge", help="Category for legacy files without one.")
+    parser.add_argument("--dry-run", action="store_true", help="Report files that would change.")
+    parser.add_argument("--apply", action="store_true", help="Write migrated files and create a backup.")
+    args = parser.parse_args(argv)
+    if args.dry_run == args.apply:
+        parser.error("pass exactly one of --dry-run or --apply")
+    summary = migrate_memory(
+        args.cwd,
+        memory_dir=args.memory_dir,
+        default_type=args.default_type,
+        default_category=args.default_category,
+        apply=args.apply,
+    )
+    print(json.dumps(summary.as_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _create_migration_backup(memory_dir: Path) -> Path:
+    timestamp = utc_now().strftime("%Y%m%d-%H%M%S")
+    backup_dir = memory_dir / "backups" / f"migration-{timestamp}"
+    suffix = 2
+    while backup_dir.exists():
+        backup_dir = memory_dir / "backups" / f"migration-{timestamp}-{suffix}"
+        suffix += 1
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    for path in sorted(memory_dir.glob("*.md")):
+        shutil.copy2(path, backup_dir / path.name)
+    usage_index = memory_dir / "usage_index.json"
+    if usage_index.exists():
+        shutil.copy2(usage_index, backup_dir / usage_index.name)
+    return backup_dir
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/openharness/memory/scan.py
+++ b/src/openharness/memory/scan.py
@@ -5,12 +5,28 @@ from __future__ import annotations
 from pathlib import Path
 
 from openharness.memory.paths import get_project_memory_dir
+from openharness.memory.schema import (
+    coerce_bool,
+    coerce_int,
+    coerce_optional_int,
+    coerce_str_list,
+    first_content_line,
+    is_memory_expired,
+    split_memory_file,
+)
 from openharness.memory.types import MemoryHeader
 
 
-def scan_memory_files(cwd: str | Path, *, max_files: int = 50) -> list[MemoryHeader]:
+def scan_memory_files(
+    cwd: str | Path,
+    *,
+    max_files: int | None = 50,
+    include_disabled: bool = False,
+    include_expired: bool = False,
+    memory_dir: str | Path | None = None,
+) -> list[MemoryHeader]:
     """Return memory headers sorted by newest first."""
-    memory_dir = get_project_memory_dir(cwd)
+    memory_dir = Path(memory_dir) if memory_dir is not None else get_project_memory_dir(cwd)
     headers: list[MemoryHeader] = []
     for path in memory_dir.glob("*.md"):
         if path.name == "MEMORY.md":
@@ -20,45 +36,40 @@ def scan_memory_files(cwd: str | Path, *, max_files: int = 50) -> list[MemoryHea
         except OSError:
             continue
         header = _parse_memory_file(path, text)
+        if header.disabled and not include_disabled:
+            continue
+        if is_memory_expired(_metadata_from_header(header)) and not include_expired:
+            continue
         headers.append(header)
     headers.sort(key=lambda item: item.modified_at, reverse=True)
+    if max_files is None:
+        return headers
     return headers[:max_files]
 
 
 def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
     """Parse a memory file, extracting YAML frontmatter when present."""
-    lines = content.splitlines()
+    metadata, body, _, _ = split_memory_file(content)
+    lines = body.splitlines()
     title = path.stem
     description = ""
     memory_type = ""
-    body_start = 0
-
-    # Parse YAML frontmatter (--- ... ---)
-    if lines and lines[0].strip() == "---":
-        for i, line in enumerate(lines[1:], 1):
-            if line.strip() == "---":
-                for fm_line in lines[1:i]:
-                    key, _, value = fm_line.partition(":")
-                    key = key.strip()
-                    value = value.strip().strip("'\"")
-                    if not value:
-                        continue
-                    if key == "name":
-                        title = value
-                    elif key == "description":
-                        description = value
-                    elif key == "type":
-                        memory_type = value
-                body_start = i + 1
-                break
+    if metadata.get("name"):
+        title = str(metadata["name"])
+    if metadata.get("description"):
+        description = str(metadata["description"])
+    if metadata.get("type"):
+        memory_type = str(metadata["type"])
 
     # Fallback: first non-empty, non-frontmatter line as description
     desc_line_idx: int | None = None
     if not description:
-        for idx, line in enumerate(lines[body_start:body_start + 10], body_start):
+        fallback = first_content_line("\n".join(lines[:10]))
+        if fallback:
+            description = fallback
+        for idx, line in enumerate(lines[:10]):
             stripped = line.strip()
-            if stripped and stripped != "---" and not stripped.startswith("#"):
-                description = stripped[:200]
+            if stripped[:200] == description:
                 desc_line_idx = idx
                 break
 
@@ -66,7 +77,7 @@ def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
     # line already used as description so search scoring stays consistent.
     body_lines = [
         line.strip()
-        for idx, line in enumerate(lines[body_start:], body_start)
+        for idx, line in enumerate(lines)
         if line.strip()
         and not line.strip().startswith("#")
         and idx != desc_line_idx
@@ -80,4 +91,23 @@ def _parse_memory_file(path: Path, content: str) -> MemoryHeader:
         modified_at=path.stat().st_mtime,
         memory_type=memory_type,
         body_preview=body_preview,
+        id=str(metadata.get("id") or ""),
+        schema_version=coerce_int(metadata.get("schema_version"), default=0),
+        category=str(metadata.get("category") or ""),
+        importance=coerce_int(metadata.get("importance"), default=0),
+        source=str(metadata.get("source") or ""),
+        signature=str(metadata.get("signature") or ""),
+        created_at=str(metadata.get("created_at") or ""),
+        updated_at=str(metadata.get("updated_at") or ""),
+        ttl_days=coerce_optional_int(metadata.get("ttl_days")),
+        disabled=coerce_bool(metadata.get("disabled"), default=False),
+        supersedes=coerce_str_list(metadata.get("supersedes")),
     )
+
+
+def _metadata_from_header(header: MemoryHeader) -> dict[str, object]:
+    return {
+        "created_at": header.created_at,
+        "updated_at": header.updated_at,
+        "ttl_days": header.ttl_days,
+    }

--- a/src/openharness/memory/schema.py
+++ b/src/openharness/memory/schema.py
@@ -1,0 +1,303 @@
+"""Structured memory metadata helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import secrets
+import string
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = 1
+
+FRONTMATTER_FIELDS = (
+    "schema_version",
+    "id",
+    "name",
+    "description",
+    "type",
+    "category",
+    "importance",
+    "source",
+    "signature",
+    "created_at",
+    "updated_at",
+    "ttl_days",
+    "disabled",
+    "supersedes",
+)
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time without sub-second noise."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def format_datetime(value: datetime) -> str:
+    """Format a datetime as an ISO-8601 UTC string."""
+
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_datetime(value: object) -> datetime | None:
+    """Parse an ISO datetime value used in memory frontmatter."""
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def normalize_memory_content(text: str) -> str:
+    """Normalize memory content for deterministic signatures."""
+
+    lowered = text.lower()
+    collapsed = re.sub(r"\s+", " ", lowered)
+    punctuation_table = str.maketrans("", "", string.punctuation)
+    return collapsed.translate(punctuation_table).strip()
+
+
+def compute_memory_signature(content: str, memory_type: str, category: str) -> str:
+    """Compute a deterministic content signature for duplicate detection."""
+
+    normalized = normalize_memory_content(content)
+    payload = f"{normalized}|{memory_type.strip().lower()}|{category.strip().lower()}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def generate_memory_id(now: datetime | None = None) -> str:
+    """Generate a stable-looking memory id for a new memory file."""
+
+    timestamp = format_datetime(now or utc_now()).replace("-", "").replace(":", "")
+    timestamp = timestamp.replace("T", "-").replace("Z", "")
+    return f"mem-{timestamp}-{secrets.token_hex(4)}"
+
+
+def split_memory_file(content: str) -> tuple[dict[str, Any], str, int, bool]:
+    """Split a memory file into frontmatter metadata and body text.
+
+    Returns ``(metadata, body, body_start_line, has_closed_frontmatter)``.
+    Unclosed frontmatter is treated as body content after the opening delimiter.
+    """
+
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return {}, content, 0, False
+
+    for idx, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            raw_frontmatter = "".join(lines[1:idx])
+            metadata = _load_frontmatter(raw_frontmatter)
+            return metadata, "".join(lines[idx + 1 :]), idx + 1, True
+
+    return {}, "".join(lines[1:]), 1, False
+
+
+def render_memory_file(metadata: dict[str, Any], body: str) -> str:
+    """Render metadata and body as a memory markdown file."""
+
+    frontmatter = render_frontmatter(metadata)
+    normalized_body = body.lstrip("\n")
+    if normalized_body and not normalized_body.endswith("\n"):
+        normalized_body += "\n"
+    return f"---\n{frontmatter}---\n\n{normalized_body}"
+
+
+def render_frontmatter(metadata: dict[str, Any]) -> str:
+    """Render memory frontmatter in a stable field order."""
+
+    ordered: list[tuple[str, Any]] = []
+    for field in FRONTMATTER_FIELDS:
+        if field in metadata:
+            ordered.append((field, metadata[field]))
+    for key, value in metadata.items():
+        if key not in FRONTMATTER_FIELDS:
+            ordered.append((key, value))
+    return "".join(f"{key}: {_format_yaml_value(value)}\n" for key, value in ordered)
+
+
+def is_disabled_metadata(metadata: dict[str, Any]) -> bool:
+    """Return whether a memory metadata object marks the file disabled."""
+
+    return _as_bool(metadata.get("disabled"), default=False)
+
+
+def is_memory_expired(metadata: dict[str, Any], *, now: datetime | None = None) -> bool:
+    """Return whether a memory should be hidden because its TTL has elapsed."""
+
+    ttl_days = _as_optional_int(metadata.get("ttl_days"))
+    if ttl_days is None or ttl_days <= 0:
+        return False
+    base_time = parse_datetime(metadata.get("updated_at")) or parse_datetime(metadata.get("created_at"))
+    if base_time is None:
+        return False
+    return (now or utc_now()) >= base_time + timedelta(days=ttl_days)
+
+
+def coerce_int(value: object, *, default: int = 0) -> int:
+    """Coerce a metadata value to int."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def coerce_optional_int(value: object) -> int | None:
+    """Coerce a metadata value to optional int."""
+
+    return _as_optional_int(value)
+
+
+def coerce_bool(value: object, *, default: bool = False) -> bool:
+    """Coerce a metadata value to bool."""
+
+    return _as_bool(value, default=default)
+
+
+def coerce_str_list(value: object) -> tuple[str, ...]:
+    """Coerce a metadata value to a tuple of strings."""
+
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if str(item))
+    return ()
+
+
+def memory_metadata_from_path(
+    path: Path,
+    metadata: dict[str, Any],
+    body: str,
+    *,
+    now: datetime | None = None,
+    source: str = "migration",
+    default_type: str = "project",
+    default_category: str = "knowledge",
+    seen_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """Return complete schema-v1 metadata while preserving existing values."""
+
+    updated = dict(metadata)
+    timestamp = _mtime_timestamp(path)
+    created_at = str(updated.get("created_at") or timestamp)
+    updated_at = str(updated.get("updated_at") or timestamp)
+    memory_type = str(updated.get("type") or default_type)
+    category = str(updated.get("category") or default_category)
+    memory_id = str(updated.get("id") or "")
+    if not memory_id or (seen_ids is not None and memory_id in seen_ids):
+        memory_id = _generate_unique_memory_id(now=now, seen_ids=seen_ids)
+    if seen_ids is not None:
+        seen_ids.add(memory_id)
+
+    updated["schema_version"] = coerce_int(updated.get("schema_version"), default=SCHEMA_VERSION)
+    updated["id"] = memory_id
+    updated["name"] = str(updated.get("name") or path.stem)
+    updated["description"] = str(updated.get("description") or first_content_line(body) or path.stem)
+    updated["type"] = memory_type
+    updated["category"] = category
+    updated["importance"] = coerce_int(updated.get("importance"), default=0)
+    updated["source"] = str(updated.get("source") or source)
+    updated["signature"] = str(
+        updated.get("signature") or compute_memory_signature(body, memory_type, category)
+    )
+    updated["created_at"] = created_at
+    updated["updated_at"] = updated_at
+    updated["ttl_days"] = coerce_optional_int(updated.get("ttl_days"))
+    updated["disabled"] = coerce_bool(updated.get("disabled"), default=False)
+    updated["supersedes"] = list(coerce_str_list(updated.get("supersedes")))
+    return updated
+
+
+def first_content_line(body: str, *, limit: int = 200) -> str:
+    """Return the first useful body line for descriptions."""
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped and stripped != "---" and not stripped.startswith("#"):
+            return stripped[:limit]
+    return ""
+
+
+def _load_frontmatter(raw_frontmatter: str) -> dict[str, Any]:
+    try:
+        loaded = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(key): value for key, value in loaded.items()}
+
+
+def _format_yaml_value(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        return json.dumps(list(value), ensure_ascii=False)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _mtime_timestamp(path: Path) -> str:
+    try:
+        modified = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        modified = utc_now()
+    return format_datetime(modified)
+
+
+def _generate_unique_memory_id(
+    *,
+    now: datetime | None = None,
+    seen_ids: set[str] | None = None,
+) -> str:
+    while True:
+        memory_id = generate_memory_id(now=now)
+        if seen_ids is None or memory_id not in seen_ids:
+            return memory_id
+
+
+def _as_bool(value: object, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _as_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/src/openharness/memory/search.py
+++ b/src/openharness/memory/search.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import re
+from datetime import timedelta
 from pathlib import Path
 
 from openharness.memory.scan import scan_memory_files
+from openharness.memory.schema import parse_datetime, utc_now
 from openharness.memory.types import MemoryHeader
+from openharness.memory.usage import get_memory_usage
 
 
 def find_relevant_memories(
@@ -32,8 +35,15 @@ def find_relevant_memories(
         # Metadata matches are weighted 2x; body matches 1x.
         meta_hits = sum(1 for t in tokens if t in meta)
         body_hits = sum(1 for t in tokens if t in body)
-        score = meta_hits * 2.0 + body_hits
-        if score > 0:
+        usage = get_memory_usage(cwd, header.id, memory_dir=header.path.parent)
+        score = (
+            meta_hits * 2.0
+            + body_hits
+            + header.importance * 0.4
+            + min(int(usage["use_count"]), 5) * 0.1
+            + _recency_boost(header)
+        )
+        if meta_hits or body_hits:
             scored.append((score, header))
 
     scored.sort(key=lambda item: (-item[0], -item[1].modified_at))
@@ -47,3 +57,15 @@ def _tokenize(text: str) -> set[str]:
     # Han ideographs (each character carries independent meaning)
     han_chars = set(re.findall(r"[\u4e00-\u9fff\u3400-\u4dbf]", text))
     return ascii_tokens | han_chars
+
+
+def _recency_boost(header: MemoryHeader) -> float:
+    timestamp = parse_datetime(header.updated_at) or parse_datetime(header.created_at)
+    if timestamp is None:
+        return 0.0
+    age = utc_now() - timestamp
+    if age <= timedelta(days=14):
+        return 0.3
+    if age <= timedelta(days=30):
+        return 0.1
+    return 0.0

--- a/src/openharness/memory/types.py
+++ b/src/openharness/memory/types.py
@@ -16,3 +16,14 @@ class MemoryHeader:
     modified_at: float
     memory_type: str = ""
     body_preview: str = ""
+    id: str = ""
+    schema_version: int = 0
+    category: str = ""
+    importance: int = 0
+    source: str = ""
+    signature: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+    ttl_days: int | None = None
+    disabled: bool = False
+    supersedes: tuple[str, ...] = ()

--- a/src/openharness/memory/usage.py
+++ b/src/openharness/memory/usage.py
@@ -1,0 +1,153 @@
+"""Usage index for recalled memory entries."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+from openharness.memory.paths import get_project_memory_dir
+from openharness.memory.scan import scan_memory_files
+from openharness.memory.schema import format_datetime, parse_datetime, utc_now
+from openharness.memory.types import MemoryHeader
+from openharness.utils.file_lock import exclusive_file_lock
+from openharness.utils.fs import atomic_write_text
+
+USAGE_INDEX_NAME = "usage_index.json"
+STALE_UNUSED_DAYS = 60
+STALE_MAX_IMPORTANCE = 1
+
+
+def get_usage_index_path(cwd: str | Path, *, memory_dir: str | Path | None = None) -> Path:
+    """Return the usage index path for a memory store."""
+
+    root = Path(memory_dir) if memory_dir is not None else get_project_memory_dir(cwd)
+    root.mkdir(parents=True, exist_ok=True)
+    return root / USAGE_INDEX_NAME
+
+
+def load_usage_index(cwd: str | Path, *, memory_dir: str | Path | None = None) -> dict[str, Any]:
+    """Load usage index data, returning an empty index for invalid files."""
+
+    path = get_usage_index_path(cwd, memory_dir=memory_dir)
+    if not path.exists():
+        return _empty_index()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty_index()
+    if not isinstance(data, dict):
+        return _empty_index()
+    memories = data.get("memories")
+    if not isinstance(memories, dict):
+        memories = {}
+    normalized = _empty_index()
+    normalized["memories"] = {
+        str(memory_id): _normalize_usage_record(record)
+        for memory_id, record in memories.items()
+        if isinstance(record, dict)
+    }
+    return normalized
+
+
+def save_usage_index(
+    cwd: str | Path,
+    index: dict[str, Any],
+    *,
+    memory_dir: str | Path | None = None,
+) -> None:
+    """Persist usage index data atomically."""
+
+    path = get_usage_index_path(cwd, memory_dir=memory_dir)
+    payload = json.dumps(index, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    atomic_write_text(path, payload)
+
+
+def get_memory_usage(
+    cwd: str | Path,
+    memory_id: str,
+    *,
+    memory_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return usage data for a memory id."""
+
+    if not memory_id:
+        return _normalize_usage_record({})
+    index = load_usage_index(cwd, memory_dir=memory_dir)
+    record = index["memories"].get(memory_id, {})
+    return _normalize_usage_record(record)
+
+
+def mark_memory_used(
+    cwd: str | Path,
+    memories: list[MemoryHeader],
+    *,
+    memory_dir: str | Path | None = None,
+) -> None:
+    """Record that memory entries were recalled into a runtime prompt."""
+
+    usable = [header for header in memories if header.id]
+    if not usable:
+        return
+    resolved_memory_dir = Path(memory_dir) if memory_dir is not None else usable[0].path.parent
+    lock_path = resolved_memory_dir / ".usage_index.lock"
+    with exclusive_file_lock(lock_path):
+        index = load_usage_index(cwd, memory_dir=resolved_memory_dir)
+        now = format_datetime(utc_now())
+        for header in usable:
+            record = _normalize_usage_record(index["memories"].get(header.id, {}))
+            record["use_count"] = int(record["use_count"]) + 1
+            record["last_used_at"] = now
+            record["path"] = header.path.name
+            index["memories"][header.id] = record
+        save_usage_index(cwd, index, memory_dir=resolved_memory_dir)
+
+
+def find_stale_memory_candidates(
+    cwd: str | Path,
+    *,
+    memory_dir: str | Path | None = None,
+) -> list[MemoryHeader]:
+    """Return low-value unused memories that auto-dream should review for pruning."""
+
+    resolved_memory_dir = Path(memory_dir) if memory_dir is not None else None
+    headers = scan_memory_files(
+        cwd,
+        max_files=None,
+        include_disabled=False,
+        include_expired=False,
+        memory_dir=resolved_memory_dir,
+    )
+    now = utc_now()
+    candidates: list[MemoryHeader] = []
+    for header in headers:
+        if header.importance > STALE_MAX_IMPORTANCE:
+            continue
+        usage = get_memory_usage(cwd, header.id, memory_dir=resolved_memory_dir or header.path.parent)
+        if int(usage["use_count"]) > 0:
+            continue
+        updated_at = parse_datetime(header.updated_at) or parse_datetime(header.created_at)
+        if updated_at is None:
+            continue
+        if now - updated_at >= timedelta(days=STALE_UNUSED_DAYS):
+            candidates.append(header)
+    candidates.sort(key=lambda item: (item.importance, item.updated_at or "", item.path.name))
+    return candidates
+
+
+def _empty_index() -> dict[str, Any]:
+    return {"version": 1, "memories": {}}
+
+
+def _normalize_usage_record(record: dict[str, Any]) -> dict[str, Any]:
+    use_count = record.get("use_count", 0)
+    try:
+        use_count = max(0, int(use_count))
+    except (TypeError, ValueError):
+        use_count = 0
+    return {
+        "last_used_at": str(record.get("last_used_at") or ""),
+        "use_count": use_count,
+        "path": str(record.get("path") or ""),
+    }

--- a/src/openharness/prompts/context.py
+++ b/src/openharness/prompts/context.py
@@ -13,6 +13,7 @@ from openharness.config.paths import (
 from openharness.config.settings import Settings
 from openharness.coordinator.coordinator_mode import get_coordinator_system_prompt, is_coordinator_mode
 from openharness.memory import find_relevant_memories, load_memory_prompt
+from openharness.memory.usage import mark_memory_used
 from openharness.personalization.rules import load_local_rules
 from openharness.prompts.claudemd import load_claude_md_prompt
 from openharness.prompts.system_prompt import build_system_prompt
@@ -149,6 +150,10 @@ def build_runtime_system_prompt(
                 max_results=settings.memory.max_files,
             )
             if relevant:
+                try:
+                    mark_memory_used(cwd, relevant, memory_dir=relevant[0].path.parent)
+                except OSError:
+                    pass
                 lines = ["# Relevant Memories"]
                 for header in relevant:
                     content = header.path.read_text(encoding="utf-8", errors="replace").strip()

--- a/src/openharness/services/autodream/prompt.py
+++ b/src/openharness/services/autodream/prompt.py
@@ -60,6 +60,9 @@ Use these categories:
 - Create at most 2 new markdown files in one dream.
 - If a topic is transient, prefer `recent_work.md` or an existing status file over a new topic file.
 - Do not move personal/business context into project memory; keep sensitive personal context in personal memory only.
+- Every top-level memory file must include schema-v1 frontmatter with:
+  `schema_version`, `id`, `name`, `description`, `type`, `category`, `importance`, `source`,
+  `signature`, `created_at`, `updated_at`, `ttl_days`, `disabled`, and `supersedes`.
 
 ---
 
@@ -96,6 +99,8 @@ Update `{ENTRYPOINT_NAME}` so it stays under {MAX_ENTRYPOINT_LINES} lines and re
 
 - Each entry should be one concise line: `- [Title](file.md): one-line hook`.
 - Remove pointers to memories that are stale, wrong, or superseded.
+- For stale, wrong, or superseded memory files, set `disabled: true`; do not delete files.
+- Treat usage-based stale candidates as review candidates, not automatic deletion instructions.
 - Add pointers to newly important memories.
 - Resolve contradictions if multiple files disagree.
 

--- a/src/openharness/services/autodream/service.py
+++ b/src/openharness/services/autodream/service.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from openharness.config.settings import Settings
 from openharness.memory.paths import get_project_memory_dir
+from openharness.memory.usage import find_stale_memory_candidates
 from openharness.services.autodream.backup import create_memory_backup, diff_memory_dirs
 from openharness.services.autodream.lock import (
     list_sessions_touched_since,
@@ -141,12 +142,20 @@ async def start_dream_now(
     resolved_session_dir.mkdir(parents=True, exist_ok=True)
     before = _memory_files_mtime_snapshot(resolved_memory_dir)
     backup_dir = create_memory_backup(resolved_memory_dir, app_label=app_label) if not preview else None
+    stale_candidates = find_stale_memory_candidates(cwd, memory_dir=resolved_memory_dir)
+    stale_section = "\n".join(
+        f"- {header.id or header.path.name}: {header.path.name} "
+        f"(importance={header.importance}, updated_at={header.updated_at or 'unknown'})"
+        for header in stale_candidates[:20]
+    ) or "- (none)"
     extra = (
         f"Application context: `{app_label}`.\n"
         "Tool constraints for this run: only modify files under the memory directory. "
         "Use shell commands only for read-only inspection.\n\n"
         f"Sessions since last consolidation ({len(session_ids)}):\n"
         + "\n".join(f"- {session_id}" for session_id in session_ids)
+        + "\n\nUsage-based stale candidates:\n"
+        + stale_section
     )
     prompt = build_consolidation_prompt(resolved_memory_dir, resolved_session_dir, extra, preview=preview)
     src_root = Path(__file__).resolve().parents[3]

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 
 import openharness.commands.registry as registry_module
-from openharness.commands.registry import CommandContext, create_default_command_registry, lookup_skill_slash_command
+from openharness.commands.registry import (
+    CommandContext,
+    MemoryCommandBackend,
+    create_default_command_registry,
+    lookup_skill_slash_command,
+)
 from openharness.autopilot import RepoVerificationStep
 from openharness.config.paths import get_feedback_log_path, get_project_issue_file, get_project_pr_comments_file
 from openharness.config.settings import load_settings, save_settings, Settings
@@ -930,6 +935,36 @@ async def test_memory_command_migrates_entries(tmp_path: Path, monkeypatch):
     assert "Memory migration applied." in apply_result.message
     assert "Backup:" in apply_result.message
     assert "schema_version: 1" in legacy.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_memory_migrate_uses_backend_defaults_not_label(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    memory_dir = tmp_path / "custom-memory"
+    memory_dir.mkdir()
+    legacy = memory_dir / "legacy.md"
+    legacy.write_text("personal preference note\n", encoding="utf-8")
+    registry = create_default_command_registry()
+    context = _make_context(tmp_path)
+    context.memory_backend = MemoryCommandBackend(
+        label="renamed user notes",
+        default_type="personal",
+        default_category="preference",
+        get_memory_dir=lambda: memory_dir,
+        get_entrypoint=lambda: memory_dir / "MEMORY.md",
+        list_files=lambda: [],
+        add_entry=lambda title, content: memory_dir / f"{title}.md",
+        remove_entry=lambda name: False,
+    )
+
+    apply_command, apply_args = registry.lookup("/memory migrate --apply")
+    result = await apply_command.handler(apply_args, context)
+
+    migrated = legacy.read_text(encoding="utf-8")
+    assert "Memory migration applied." in result.message
+    assert 'type: "personal"' in migrated
+    assert 'category: "preference"' in migrated
 
 
 @pytest.mark.asyncio

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -14,6 +14,7 @@ from openharness.config.paths import get_feedback_log_path, get_project_issue_fi
 from openharness.config.settings import load_settings, save_settings, Settings
 from openharness.engine.messages import ConversationMessage, TextBlock
 from openharness.engine.query_engine import QueryEngine
+from openharness.memory.paths import get_project_memory_dir
 from openharness.mcp.types import McpHttpServerConfig, McpStdioServerConfig
 from openharness.permissions import PermissionChecker
 from openharness.plugins.types import PluginCommandDefinition
@@ -898,6 +899,37 @@ async def test_memory_command_manages_entries(tmp_path: Path, monkeypatch):
     remove_command, remove_args = registry.lookup("/memory remove pytest_tips")
     remove_result = await remove_command.handler(remove_args, context)
     assert "Removed memory entry" in remove_result.message
+
+    list_after_remove = await list_command.handler(list_args, context)
+    assert "pytest_tips.md" not in list_after_remove.message
+
+    show_after_remove = await show_command.handler(show_args, context)
+    assert show_after_remove.message == "Memory entry not found: pytest_tips"
+
+
+@pytest.mark.asyncio
+async def test_memory_command_migrates_entries(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    memory_dir = get_project_memory_dir(tmp_path)
+    legacy = memory_dir / "legacy.md"
+    legacy.write_text("legacy command note\n", encoding="utf-8")
+    registry = create_default_command_registry()
+    context = _make_context(tmp_path)
+
+    dry_command, dry_args = registry.lookup("/memory migrate --dry-run")
+    dry_result = await dry_command.handler(dry_args, context)
+
+    assert "Memory migration dry run." in dry_result.message
+    assert "Changed: 1" in dry_result.message
+    assert "schema_version" not in legacy.read_text(encoding="utf-8")
+
+    apply_command, apply_args = registry.lookup("/memory migrate --apply")
+    apply_result = await apply_command.handler(apply_args, context)
+
+    assert "Memory migration applied." in apply_result.message
+    assert "Backup:" in apply_result.message
+    assert "schema_version: 1" in legacy.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory/test_memdir.py
+++ b/tests/test_memory/test_memdir.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from openharness.memory import (
+    add_memory_entry,
     find_relevant_memories,
     get_memory_entrypoint,
     get_project_memory_dir,
     load_memory_prompt,
+    migrate_memory,
+    remove_memory_entry,
 )
 from openharness.memory.scan import _parse_memory_file, scan_memory_files
+from openharness.memory.usage import find_stale_memory_candidates, load_usage_index, mark_memory_used
 
 
 def test_memory_paths_are_stable(tmp_path: Path, monkeypatch):
@@ -51,6 +55,103 @@ def test_find_relevant_memories(tmp_path: Path, monkeypatch):
 
     assert matches
     assert matches[0].path.name == "pytest_tips.md"
+
+
+def test_add_memory_entry_writes_schema_and_dedupes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    first = add_memory_entry(project_dir, "Pytest Tips", "Use fixtures for setup.")
+    second = add_memory_entry(project_dir, "Pytest Tips Copy", "Use fixtures for setup.")
+
+    assert second == first
+    headers = scan_memory_files(project_dir)
+    assert len(headers) == 1
+    assert headers[0].id.startswith("mem-")
+    assert headers[0].schema_version == 1
+    assert headers[0].source == "manual"
+    assert headers[0].importance == 1
+    assert headers[0].signature
+
+
+def test_remove_memory_entry_soft_deletes_and_hides_entry(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+
+    path = add_memory_entry(project_dir, "Remove Me", "temporary note")
+
+    assert remove_memory_entry(project_dir, "remove_me") is True
+    assert path.exists()
+    assert scan_memory_files(project_dir) == []
+    headers = scan_memory_files(project_dir, include_disabled=True)
+    assert len(headers) == 1
+    assert headers[0].disabled is True
+
+
+def test_migrate_memory_backfills_schema(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    memory_dir = get_project_memory_dir(project_dir)
+    legacy = memory_dir / "legacy.md"
+    legacy.write_text("Legacy deployment note.\n", encoding="utf-8")
+
+    dry_run = migrate_memory(project_dir, apply=False)
+
+    assert dry_run.dry_run is True
+    assert dry_run.changed == 1
+    assert "schema_version" not in legacy.read_text(encoding="utf-8")
+
+    applied = migrate_memory(project_dir, apply=True)
+
+    assert applied.dry_run is False
+    assert applied.changed == 1
+    assert applied.backup_dir
+    migrated = legacy.read_text(encoding="utf-8")
+    assert "schema_version: 1" in migrated
+    assert "source: \"migration\"" in migrated
+    assert "Legacy deployment note." in migrated
+
+    rerun = migrate_memory(project_dir, apply=False)
+    assert rerun.changed == 0
+
+
+def test_usage_index_marks_recalled_memories_and_stale_candidates(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    memory_dir = get_project_memory_dir(project_dir)
+    (memory_dir / "old.md").write_text(
+        "---\n"
+        "schema_version: 1\n"
+        "id: \"mem-old\"\n"
+        "name: \"old\"\n"
+        "description: \"old note\"\n"
+        "type: \"project\"\n"
+        "category: \"knowledge\"\n"
+        "importance: 1\n"
+        "source: \"test\"\n"
+        "signature: \"sig-old\"\n"
+        "created_at: \"2020-01-01T00:00:00Z\"\n"
+        "updated_at: \"2020-01-01T00:00:00Z\"\n"
+        "ttl_days: null\n"
+        "disabled: false\n"
+        "supersedes: []\n"
+        "---\n\n"
+        "Old content.\n",
+        encoding="utf-8",
+    )
+    header = scan_memory_files(project_dir)[0]
+
+    assert [item.id for item in find_stale_memory_candidates(project_dir)] == ["mem-old"]
+
+    mark_memory_used(project_dir, [header])
+    index = load_usage_index(project_dir)
+
+    assert index["memories"]["mem-old"]["use_count"] == 1
+    assert find_stale_memory_candidates(project_dir) == []
 
 
 # --- Frontmatter parsing tests ---

--- a/tests/test_ohmo/test_prompts.py
+++ b/tests/test_ohmo/test_prompts.py
@@ -5,6 +5,8 @@ from openharness.memory import add_memory_entry as add_project_memory_entry
 from openharness.prompts import build_runtime_system_prompt
 
 from ohmo.memory import add_memory_entry as add_ohmo_memory_entry
+from ohmo.memory import list_memory_files as list_ohmo_memory_files
+from ohmo.memory import remove_memory_entry as remove_ohmo_memory_entry
 from ohmo.prompts import build_ohmo_system_prompt
 from ohmo.workspace import (
     get_bootstrap_path,
@@ -53,3 +55,19 @@ def test_ohmo_runtime_prompt_can_exclude_project_memory(tmp_path: Path, monkeypa
 
     assert "ohmo-only personal fact" in runtime_prompt
     assert "project memory should not leak" not in runtime_prompt
+
+
+def test_ohmo_memory_uses_schema_and_soft_delete(tmp_path: Path):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+
+    path = add_ohmo_memory_entry(workspace, "timezone", "The user prefers UTC timestamps.")
+
+    text = path.read_text(encoding="utf-8")
+    assert "schema_version: 1" in text
+    assert "type: \"personal\"" in text
+
+    assert remove_ohmo_memory_entry(workspace, "timezone") is True
+    assert path.exists()
+    assert list_ohmo_memory_files(workspace) == []
+    assert "disabled: true" in path.read_text(encoding="utf-8")

--- a/tests/test_services/test_autodream.py
+++ b/tests/test_services/test_autodream.py
@@ -128,6 +128,26 @@ async def test_start_dream_now_uses_overrides(tmp_path: Path, monkeypatch) -> No
     memory_dir.mkdir(parents=True)
     session_dir.mkdir(parents=True)
     (session_dir / "session-one.json").write_text(json.dumps({"session_id": "one"}), encoding="utf-8")
+    (memory_dir / "old.md").write_text(
+        "---\n"
+        "schema_version: 1\n"
+        "id: \"mem-old\"\n"
+        "name: \"old\"\n"
+        "description: \"old note\"\n"
+        "type: \"project\"\n"
+        "category: \"knowledge\"\n"
+        "importance: 0\n"
+        "source: \"test\"\n"
+        "signature: \"sig-old\"\n"
+        "created_at: \"2020-01-01T00:00:00Z\"\n"
+        "updated_at: \"2020-01-01T00:00:00Z\"\n"
+        "ttl_days: null\n"
+        "disabled: false\n"
+        "supersedes: []\n"
+        "---\n\n"
+        "Old content.\n",
+        encoding="utf-8",
+    )
 
     captured = {}
 
@@ -170,3 +190,5 @@ async def test_start_dream_now_uses_overrides(tmp_path: Path, monkeypatch) -> No
     assert captured["argv"][:3][-1] == "ohmo"
     assert "--workspace" in captured["argv"]
     assert "--dangerously-skip-permissions" not in captured["argv"]
+    assert "Usage-based stale candidates:" in task.prompt
+    assert "old.md" in task.prompt


### PR DESCRIPTION
## Summary

This PR upgrades OpenHarness memory from loose Markdown notes into a structured, reviewable memory store while preserving compatibility with existing memory files.

It adds schema-v1 frontmatter, deterministic signatures, stable memory ids, soft-delete metadata, a usage index for recalled memories, and an explicit migration path for existing stores. Project memory and ohmo personal memory now share the same behavior.

## Why

The current memory system works for small manual stores, but it lacks stable identity, usage feedback, and safe pruning. As memory grows, filenames are not enough for dedupe, ranking, supersession, cleanup, or auto-dream review.

For an open-source project, users also cannot be forced through one synchronized migration. This keeps old Markdown readable while adding `/memory migrate --dry-run` and `/memory migrate --apply`.

## Value

- Stable ids and signatures enable reliable dedupe, ranking, cleanup, and future supersession.
- `usage_index.json` records which memories are actually recalled, improving search ranking and stale-memory review.
- Soft delete uses `disabled: true`, making cleanup reviewable instead of destructive.
- Auto-dream now receives usage-based stale candidates but treats them as review candidates, not delete instructions.
- Project memory and ohmo personal memory now behave consistently.

## Main Changes

- Add schema-v1 frontmatter fields for memory files.
- Add explicit migration via `/memory migrate --dry-run`, `/memory migrate --apply`, and `scripts/migrate_memory.py`.
- Add usage tracking when relevant memories are injected into the runtime prompt.
- Rank memory search by relevance plus importance, usage count, and recency.
- Keep existing memory injection length unchanged.
- Change `/memory remove` to soft-delete.
- Align ohmo personal memory with the same schema and soft-delete behavior.

## Validation

- `ruff check ...` passed
- focused tests: `34 passed`
- migration dry-run script passed
- `git diff --check` passed

A broader related suite produced `168 passed, 1 failed`; the failure is unrelated to memory and comes from a Windows gateway-process test that mocks `os.kill` while the implementation uses `taskkill`.