### PR TITLE
fix(feishu): add domain config to support Lark international (larksuite.com)

### DIFF
--- a/ohmo/cli.py
+++ b/ohmo/cli.py
@@ -269,6 +269,14 @@ def _prompt_channels(existing: GatewayConfig) -> tuple[list[str], dict[str, dict
                 default_value=str(prior.get("group_policy", "mention")),
             )
         elif channel == "feishu":
+            config["domain"] = _select_from_menu(
+                "Feishu domain:",
+                [
+                    ("https://open.feishu.cn", "Feishu (China)"),
+                    ("https://open.larksuite.com", "Lark (International)"),
+                ],
+                default_value=str(prior.get("domain", "https://open.feishu.cn")),
+            )
             config["app_id"] = _text_prompt(
                 "Feishu app id",
                 default=str(prior.get("app_id", "")),

--- a/src/openharness/channels/impl/feishu.py
+++ b/src/openharness/channels/impl/feishu.py
@@ -447,6 +447,7 @@ class FeishuChannel(BaseChannel):
         self._client = lark.Client.builder() \
             .app_id(self.config.app_id) \
             .app_secret(self.config.app_secret) \
+            .domain(self.config.domain) \
             .log_level(lark.LogLevel.INFO) \
             .build()
         return True
@@ -481,6 +482,7 @@ class FeishuChannel(BaseChannel):
             self.config.app_id,
             self.config.app_secret,
             event_handler=event_handler,
+            domain=self.config.domain,
             log_level=lark.LogLevel.INFO
         )
 

--- a/src/openharness/config/schema.py
+++ b/src/openharness/config/schema.py
@@ -59,6 +59,7 @@ class FeishuConfig(BaseChannelConfig):
     group_policy: str = "managed_or_mention"
     bot_open_id: str = ""
     bot_names: list[str] = Field(default_factory=lambda: ["ohmo", "openclaw", "openharness"])
+    domain: str = "https://open.feishu.cn"  # use https://open.larksuite.com for Lark international
 
 
 class DingTalkConfig(BaseChannelConfig):


### PR DESCRIPTION
## Problem

Apps created on `open.larksuite.com` (Lark international) were rejected with `Incorrect domain name` when ohmo tried to connect via WebSocket. Root cause: both the REST client and the WebSocket client hardcoded the default SDK domain `open.feishu.cn`.

## Fix

Add a `domain` field to `FeishuConfig` and pass it through to both call sites:

- `lark.Client.builder().domain(self.config.domain)` (REST)
- `lark.ws.Client(domain=self.config.domain)` (WebSocket)

Default remains `https://open.feishu.cn` — no breaking change for existing users.

## Usage

Users on Lark international add one line to `ohmo.yaml`:

```yaml
feishu:
  domain: "https://open.larksuite.com"
  app_id: "..."
  app_secret: "..."
```

## Test plan

- [ ] Existing Feishu (feishu.cn) apps: no config change required, behaviour unchanged
- [ ] Lark international (larksuite.com) apps: set `domain: https://open.larksuite.com`, verify WebSocket connects without `Incorrect domain name` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)