### PR TITLE
[security] fix(commands): keep project context commands local-only

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2476,8 +2476,24 @@ def create_default_command_registry(
             remote_admin_opt_in=True,
         )
     )
-    registry.register(SlashCommand("issue", "Show or update project issue context", _issue_handler))
-    registry.register(SlashCommand("pr_comments", "Show or update project PR comments context", _pr_comments_handler))
+    registry.register(
+        SlashCommand(
+            "issue",
+            "Show or update project issue context",
+            _issue_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
+    registry.register(
+        SlashCommand(
+            "pr_comments",
+            "Show or update project PR comments context",
+            _pr_comments_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("privacy-settings", "Show local privacy and storage settings", _privacy_settings_handler))
     registry.register(SlashCommand("rate-limit-options", "Show ways to reduce provider rate pressure", _rate_limit_options_handler))
     registry.register(SlashCommand("release-notes", "Show recent OpenHarness release notes", _release_notes_handler))

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -204,6 +204,34 @@ async def test_diff_command_supports_explicit_remote_admin_opt_in(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_project_context_commands_are_marked_local_only(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+
+    for payload in (
+        "/issue set Remote supplied issue :: marker",
+        "/pr_comments add src/app.py:1 :: marker",
+    ):
+        command, _ = registry.lookup(payload)
+        assert command is not None
+        assert command.remote_invocable is False, payload
+
+
+@pytest.mark.asyncio
+async def test_project_context_commands_support_explicit_remote_admin_opt_in(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    registry = create_default_command_registry()
+
+    for payload in (
+        "/issue set Remote supplied issue :: marker",
+        "/pr_comments add src/app.py:1 :: marker",
+    ):
+        command, _ = registry.lookup(payload)
+        assert command is not None
+        assert getattr(command, "remote_admin_opt_in", False) is True, payload
+
+
+@pytest.mark.asyncio
 async def test_tasks_command_is_marked_local_only(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
     registry = create_default_command_registry()

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -17,6 +17,7 @@ from openharness.channels.bus.events import InboundMessage
 from openharness.channels.bus.queue import MessageBus
 from openharness.commands import CommandResult
 from openharness.commands.registry import SlashCommand, create_default_command_registry
+from openharness.config.paths import get_project_issue_file, get_project_pr_comments_file
 from openharness.config.settings import PermissionSettings, ProviderProfile, Settings
 from openharness.engine.messages import ConversationMessage, ImageBlock, TextBlock, ToolUseBlock
 from openharness.engine.query_engine import QueryEngine
@@ -1136,6 +1137,70 @@ async def test_runtime_pool_blocks_registered_tasks_run_without_shelling_out(tmp
     assert updates[-1].text == "/tasks is only available in the local OpenHarness UI."
     assert {task.id for task in get_task_manager().list_tasks()} == existing_tasks
     assert marker.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_project_context_commands_without_writing_files(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    initialize_workspace(workspace)
+    registry = create_default_command_registry()
+
+    for payload, expected_name in (
+        ("/issue set Remote supplied issue :: REMOTE_ISSUE_CONTEXT_POISON", "issue"),
+        ("/pr_comments add src/app.py:1 :: REMOTE_PR_COMMENT_POISON", "pr_comments"),
+    ):
+        command, _ = registry.lookup(payload)
+        assert command is not None
+        assert command.name == expected_name
+        assert command.remote_invocable is False
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(repo),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=registry,
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=repo, workspace=workspace, provider_profile="codex")
+
+    for payload, expected_denial in (
+        ("/issue set Remote supplied issue :: REMOTE_ISSUE_CONTEXT_POISON", "/issue is only available in the local OpenHarness UI."),
+        ("/pr_comments add src/app.py:1 :: REMOTE_PR_COMMENT_POISON", "/pr_comments is only available in the local OpenHarness UI."),
+    ):
+        message = InboundMessage(channel="slack", sender_id="U_ATTACKER", chat_id="C_SHARED", content=payload)
+        updates = [u async for u in pool.stream_message(message, "slack:C_SHARED:U_ATTACKER")]
+        assert updates[-1].kind == "final"
+        assert updates[-1].text == expected_denial
+
+    assert get_project_issue_file(repo).exists() is False
+    assert get_project_pr_comments_file(repo).exists() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR hardens the remote slash-command boundary for project context editing commands.

`/issue` and `/pr_comments` can write Markdown into `.openharness/issue.md` and `.openharness/pr_comments.md`. Those files are later injected into runtime system prompts as issue and pull request context. Before this change, both commands inherited the default remote-invocable behavior, so an admitted remote channel sender could persist attacker-controlled project context into future local agent prompts.

This PR:
- marks `/issue` and `/pr_comments` local-only by default;
- keeps explicit remote-admin opt-in metadata available for trusted deployments;
- adds registry and gateway regressions proving remote messages are denied and do not write the project-context files.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Remote project-context prompt poisoning through `/issue` and `/pr_comments` | An admitted remote channel sender could persist attacker-controlled Markdown into project context files that are injected into future runtime system prompts. | Medium |

## Before this PR

- `/issue` and `/pr_comments` were registered without `remote_invocable=False`.
- Remote gateway messages beginning with `/issue ...` or `/pr_comments ...` could reach the command handlers under the default remote-allowed behavior.
- The handlers wrote attacker-supplied content to `.openharness/issue.md` and `.openharness/pr_comments.md`.
- Future runtime prompts loaded those files as `# Issue Context` and `# Pull Request Comments`.
- There was no regression coverage locking these project-context editing commands to the local UI boundary.

## After this PR

- `/issue` is local-only by default.
- `/pr_comments` is local-only by default.
- Both commands retain `remote_admin_opt_in=True` so deployments that intentionally expose them remotely must make that choice explicitly.
- Gateway regression coverage verifies remote `/issue` and `/pr_comments` messages return the local-only denial and leave the project context files unwritten.

## Explicit operator choice

Default behavior:

```text
remote_invocable=False
remote_admin_opt_in=True
```

By default, remote channel senders cannot edit project issue or pull request comment context files.

Trusted/admin-controlled deployments can still opt into remote admin command exposure through the existing remote-admin mechanism. That keeps the default boundary conservative while preserving an explicit operator choice for environments that intentionally trust the remote channel as an administrative surface.

## Why this matters

Project issue and pull request comment files are not ordinary chat history. They are project-local context that OpenHarness later places into the runtime system prompt. If a remote sender can silently persist content there, they can influence later local agent behavior beyond the immediate chat turn.

Keeping these commands local-only by default prevents a remote channel from becoming a persistent project-context write surface unless the operator explicitly enables that admin behavior.

## How this differs from related issue/PR

This is part of the same remote slash-command trust-boundary family as earlier hardening for commands such as `/bridge`, `/config`, `/tasks`, `/diff`, `/autopilot`, and `/commit`, but it fixes a different residual path:

- earlier fixes covered shell execution, local configuration, background tasks, workspace diffs, full-auto agent execution, and Git commit mutation;
- this PR covers project-context persistence commands that write `.openharness/*.md` files later injected into runtime prompts;
- no shell execution is claimed here, and the patch is intentionally scoped to the prompt/context poisoning boundary.

## Attack flow

```text
admitted remote channel sender
    -> ohmo gateway slash-command dispatch
        -> /issue set ... or /pr_comments add ...
            -> local .openharness project-context file write
                -> later build_runtime_system_prompt() injects attacker-controlled context
```

## Affected code

| Issue | Files |
|-------|-------|
| Remote project-context prompt poisoning | `src/openharness/commands/registry.py`, `tests/test_commands/test_registry.py`, `tests/test_ohmo/test_gateway.py` |

## Root cause

Remote project-context prompt poisoning:
- `/issue` and `/pr_comments` inherited `SlashCommand.remote_invocable=True` because their registrations did not override the default.
- The remote gateway enforces the command metadata before dispatching slash commands, so missing local-only metadata left mutating project-context commands reachable from remote channels.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Remote project-context prompt poisoning | 5.4 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N` |

Rationale:
- The attacker must already be admitted by the configured remote channel/gateway policy.
- The impact is persistent context/prompt influence through project-local Markdown files, not direct command execution.
- Confidentiality and integrity impact are bounded to future prompt/context handling and agent behavior influenced by those files.

## Safe reproduction steps

On vulnerable code, use a temporary workspace and fake marker strings only:

1. Create a default command registry.
2. Resolve `/issue set Remote supplied issue :: REMOTE_ISSUE_CONTEXT_POISON`.
3. Observe that the command is remotely invocable.
4. Send the payload through `OhmoSessionRuntimePool.stream_message(...)` as a remote inbound message.
5. Observe `.openharness/issue.md` is written with the marker.
6. Repeat with `/pr_comments add src/app.py:1 :: REMOTE_PR_COMMENT_POISON`.
7. Observe `.openharness/pr_comments.md` is written with the marker.
8. Build the runtime system prompt and observe the markers are included under issue or pull request comment context.

## Expected vulnerable behavior

On vulnerable code:

```text
ISSUE_REMOTE_INVOCABLE True
PR_COMMENTS_REMOTE_INVOCABLE True
ISSUE_FILE_HAS_MARKER True
PROMPT_HAS_MARKER True
PR_FILE_HAS_MARKER True
PROMPT_HAS_PR_MARKER True
```

After this PR, remote messages receive local-only denial responses and the project context files are not written.

## Changes in this PR

- Marks `/issue` with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Marks `/pr_comments` with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Adds registry tests for the local-only default and explicit remote-admin opt-in metadata.
- Adds a gateway regression that sends remote `/issue` and `/pr_comments` messages and verifies no `.openharness/issue.md` or `.openharness/pr_comments.md` file is created.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Command metadata | `src/openharness/commands/registry.py` | Makes project-context editing commands local-only by default with explicit remote-admin opt-in metadata. |
| Registry tests | `tests/test_commands/test_registry.py` | Adds metadata regressions for `/issue` and `/pr_comments`. |
| Gateway tests | `tests/test_ohmo/test_gateway.py` | Adds remote-message regression coverage proving the commands are denied before writing context files. |

## Maintainer impact

- The patch is intentionally small and follows the existing local-only pattern already used for other sensitive slash commands.
- Local UI behavior for `/issue` and `/pr_comments` is unchanged.
- Remote deployments that intentionally treat the channel as an admin surface can still opt in through the existing remote-admin mechanism.
- No unrelated command handlers, prompt assembly code, channel adapters, or storage paths are changed.

## Fix rationale

Project-context editing changes future runtime prompt material, so it should not be remotely reachable by default. Marking these commands local-only at registration time uses the existing gateway enforcement point and avoids duplicating command-specific checks inside the handlers.

The gateway regression exercises the real remote slash-command boundary and verifies the security-relevant effect: remote messages are denied before `.openharness/issue.md` or `.openharness/pr_comments.md` can be written.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused metadata and gateway regressions.
- [x] Full touched command/gateway test files.
- [x] Compile check for touched Python files.
- [x] Whitespace diff check.
- [x] Ruff lint check for touched files.

Executed with:

```bash
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py::test_project_context_commands_are_marked_local_only tests/test_commands/test_registry.py::test_project_context_commands_support_explicit_remote_admin_opt_in tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_project_context_commands_without_writing_files -q
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q
PYTHONPATH=src:. uv run python -m compileall -q src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
git diff --check
uv run ruff check src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
```

Local results:
- focused metadata/gateway subset: `3 passed`
- touched command/gateway files: `128 passed`
- compileall: passed
- `git diff --check`: passed
- Ruff: passed

## Disclosure notes

- This PR is bounded to persistent remote-to-local project-context prompt poisoning.
- It does not claim direct RCE or unauthenticated reachability.
- The attacker condition is an already-admitted remote channel/gateway sender.
- No production systems or real secrets were used for validation.
- No unrelated files were changed.
