### PR TITLE
[security] fix(ohmo): keep session restore local-only remotely

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2325,7 +2325,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("version", "Show the installed OpenHarness version", _version_handler))
     registry.register(SlashCommand("status", "Show session status", _status_handler))
     registry.register(SlashCommand("context", "Show the active runtime system prompt", _context_handler))
-    registry.register(SlashCommand("summary", "Summarize conversation history", _summary_handler))
+    registry.register(
+        SlashCommand(
+            "summary",
+            "Summarize conversation history",
+            _summary_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("compact", "Compact older conversation history", _compact_handler))
     registry.register(SlashCommand("cost", "Show token usage and estimated cost", _cost_handler))
     registry.register(SlashCommand("usage", "Show usage and token estimates", _usage_handler))
@@ -2333,7 +2341,15 @@ def create_default_command_registry(
     registry.register(SlashCommand("dream", "Consolidate memory", _dream_handler))
     registry.register(SlashCommand("memory", "Inspect and manage project memory", _memory_handler))
     registry.register(SlashCommand("hooks", "Show configured hooks", _hooks_handler))
-    registry.register(SlashCommand("resume", "Restore the latest saved session", _resume_handler))
+    registry.register(
+        SlashCommand(
+            "resume",
+            "Restore the latest saved session",
+            _resume_handler,
+            remote_invocable=False,
+            remote_admin_opt_in=True,
+        )
+    )
     registry.register(SlashCommand("session", "Inspect the current session storage", _session_handler))
     registry.register(SlashCommand("export", "Export the current transcript", _export_handler))
     registry.register(SlashCommand("share", "Create a shareable transcript snapshot", _share_handler))

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -235,6 +235,9 @@ async def test_sensitive_control_plane_commands_are_local_only(tmp_path: Path, m
         "/model show",
         "/commit remote requested commit",
         "/ship",
+        "/resume",
+        "/resume session-from-another-sender",
+        "/summary 10",
     ):
         command, _ = registry.lookup(payload)
         assert command is not None

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -293,8 +293,86 @@ async def test_runtime_pool_summary_does_not_restore_other_slack_thread_sender(t
     updates = [u async for u in pool.stream_message(bob_message, bob_key)]
 
     assert updates[-1].kind == "final"
-    assert updates[-1].text == "No conversation content to summarize."
+    assert updates[-1].text == "/summary is only available in the local OpenHarness UI."
     assert "ALICE_PRIVATE_SUMMARY_SECRET" not in updates[-1].text
+
+
+@pytest.mark.asyncio
+async def test_runtime_pool_blocks_registered_resume_without_listing_or_loading_other_sessions(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/resume alice-session")
+
+    assert command is not None
+    assert command.name == "resume"
+    assert command.remote_invocable is False
+
+    alice_secret = "ALICE_PRIVATE_RESUME_SECRET"
+    alice_key = "slack:C_SHARED:thread1:U_ALICE"
+    bob_key = "slack:C_SHARED:thread1:U_BOB"
+    save_session_snapshot(
+        cwd=tmp_path,
+        workspace=workspace,
+        model="gpt-5.4",
+        system_prompt="test",
+        session_id="alice-session",
+        session_key=alice_key,
+        usage=UsageSnapshot(),
+        messages=[ConversationMessage.from_user_text(f"Alice private note: {alice_secret}")],
+    )
+
+    async def fake_build_runtime(**kwargs):
+        class FakeEngine:
+            messages = []
+            total_usage = UsageSnapshot()
+
+            def set_system_prompt(self, prompt):
+                return None
+
+            def load_messages(self, messages):
+                raise AssertionError("remote /resume must not load saved messages")
+
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            cwd=str(tmp_path),
+            session_id="bob-session",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=registry,
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+        )
+
+    async def fake_start_runtime(bundle):
+        return None
+
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="codex")
+    for payload in ("/resume", "/resume alice-session"):
+        message = InboundMessage(
+            channel="slack",
+            sender_id="U_BOB",
+            chat_id="C_SHARED",
+            content=payload,
+            timestamp=datetime.utcnow(),
+            metadata={"thread_ts": "thread1", "chat_type": "group"},
+        )
+        updates = [u async for u in pool.stream_message(message, bob_key)]
+
+        assert updates[-1].kind == "final"
+        assert updates[-1].text == "/resume is only available in the local OpenHarness UI."
+        assert "alice-session" not in updates[-1].text
+        assert alice_secret not in updates[-1].text
 
 
 def test_gateway_error_formats_claude_refresh_failure():


### PR DESCRIPTION
## Summary

This PR keeps the transcript-restoration slash commands local-only over remote ohmo gateway channels.

The ohmo router already derives sender-scoped session keys for shared chats, for example `slack:<chat>:<thread>:<sender>`. However, `/resume` was still remotely invocable and used the global ohmo session backend to list and load saved sessions by ID. In a shared remote workspace, one admitted sender could list or load another sender's saved snapshot, then use transcript-inspection behavior to disclose restored conversation content.

This patch marks `/resume` and `/summary` as local-only by default while preserving explicit remote-admin opt-in support for operators that intentionally enable these commands.

## Security issues covered

| Issue | Impact | Fix |
| --- | --- | --- |
| Remote `/resume` cross-session disclosure | An admitted remote sender can list/load another sender's saved session snapshot from the same ohmo workspace | `/resume` is local-only by default and requires explicit remote-admin opt-in |
| Remote transcript summarization as a follow-on disclosure primitive | Restored or current transcript content can be returned to remote chat | `/summary` is local-only by default and requires explicit remote-admin opt-in |

## Before this PR

- Shared-chat messages were routed to sender-scoped keys such as `slack:C_SHARED:thread1:U_ALICE` and `slack:C_SHARED:thread1:U_BOB`.
- `/resume` remained remotely invocable because `SlashCommand.remote_invocable` defaults to `True`.
- Remote `/resume` listed globally saved session snapshots from the ohmo workspace.
- Remote `/resume <session_id>` loaded any matching global snapshot ID through `context.session_backend.load_by_id(...)`.
- Remote `/summary N` could return restored conversation text back to the caller's channel.

## After this PR

- `/resume` is registered with `remote_invocable=False` and `remote_admin_opt_in=True`.
- `/summary` is registered with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Remote gateway callers receive the existing local-only denial before the command handler can list, load, or summarize transcript state.
- Local UI behavior remains available, and deployments that deliberately allow remote administrative commands can still opt in through the existing remote-admin mechanism.

## Why this matters

Remote ohmo channels can be shared by multiple admitted users. Session snapshots may contain private prompts, tool output, local paths, project details, or credentials accidentally pasted into conversation history.

The router's sender-scoped keys establish an expectation that Alice and Bob in the same shared chat/thread do not share private session state. A globally scoped remote `/resume` bypasses that isolation by using session IDs rather than the caller's router-derived session key.

## How this differs from #159

#159 fixed the router-level shared-chat/session-key collision by including sender identity in shared-chat session keys.

This PR fixes a different layer:

- #159: routes new shared-chat messages into separate sender-scoped runtime sessions.
- This PR: prevents a remotely invocable command from bypassing those sender-scoped keys by listing/loading global session snapshots.

Both boundaries matter. Even when the router produces distinct keys for Alice and Bob, remote `/resume` could still cross that boundary by calling the global session backend directly.

## Attack flow

1. Alice and Bob are both admitted remote senders in the same ohmo gateway workspace.
2. Alice has a saved ohmo session containing private conversation text.
3. Bob sends `/resume` remotely.
4. The gateway lists saved snapshots from the global ohmo session store, including Alice's session ID and summary.
5. Bob sends `/resume <alice_session_id>` remotely.
6. The gateway loads Alice's snapshot into Bob's active runtime state.
7. Bob sends `/summary 10` remotely.
8. Alice's restored conversation text is returned to Bob's remote channel.

## Affected code

- `src/openharness/commands/registry.py`
  - `/resume` registration
  - `/summary` registration
  - `SlashCommand.remote_invocable` default behavior
- `ohmo/gateway/runtime.py`
  - remote slash-command dispatch and local-only denial path
- `ohmo/session_storage.py`
  - global snapshot listing/loading APIs used by `/resume`
- `ohmo/gateway/router.py`
  - sender-scoped routing boundary that `/resume` could bypass

## Root cause

- The gateway correctly scopes remote runtime sessions by sender.
- `/resume` was still remotely invocable.
- The `/resume` handler uses global snapshot APIs rather than checking the caller's remote session key.
- `/summary` was also remotely invocable, making restored transcript content easy to return to the remote caller.

## CVSS assessment

- **Issue:** Remote `/resume` cross-session disclosure
- **CVSS v3.1:** 8.1 High
- **Vector:** `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N`
- **Rationale:** The attacker must already be an admitted remote gateway sender, but no victim interaction is required after a victim session has been saved. The impact is confidentiality-only but can cross the intended per-sender session boundary in shared remote deployments.

## Safe reproduction steps

A safe local harness can seed two fake ohmo snapshots in one temporary workspace:

1. Save Alice's snapshot with session key `slack:C_SHARED:thread1:U_ALICE` and marker text such as `ALICE_PRIVATE_RESUME_SECRET`.
2. Save Bob's snapshot with session key `slack:C_SHARED:thread1:U_BOB`.
3. Confirm `session_key_for_message(...)` returns distinct keys for Alice and Bob.
4. On vulnerable code, confirm `/resume` and `/summary` are remotely invocable.
5. Invoke Bob's remote `/resume` path and observe Alice's session ID/summary in the listing.
6. Invoke Bob's remote `/resume alice-session`, then `/summary 10`, and observe Alice's marker text in Bob's result.

The regression added in this PR uses fake data only and asserts the fixed remote path returns the local-only denial before listing or loading Alice's snapshot.

## Expected vulnerable behavior

On vulnerable code, a narrow harness produced the following signal with fake markers:

```text
ALICE_ROUTER_KEY slack:C_SHARED:thread1:U_ALICE
BOB_ROUTER_KEY slack:C_SHARED:thread1:U_BOB
ROUTER_KEYS_DISTINCT True
RESUME_REMOTE_INVOCABLE True
SUMMARY_REMOTE_INVOCABLE True
LIST_HAS_ALICE True LIST_HAS_BOB True
RESUME_MESSAGE Restored 2 messages from session alice123 (...)
ENGINE_HAS_ALICE_SECRET_AFTER_RESUME True
SUMMARY_HAS_ALICE_SECRET True
```

## Changes in this PR

- Marks `/resume` local-only by default with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Marks `/summary` local-only by default with `remote_invocable=False` and `remote_admin_opt_in=True`.
- Extends command registry coverage so `/resume`, `/resume <id>`, and `/summary N` are checked as local-only remote commands.
- Adds a gateway regression that seeds Alice's saved session, sends Bob's remote `/resume` requests, and verifies no session ID or secret marker is returned or loaded.
- Updates the existing Slack-thread summary regression to expect remote `/summary` to be denied rather than remotely summarizing transcript state.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Command registry | `src/openharness/commands/registry.py` | `/resume` and `/summary` are local-only by default |
| Command tests | `tests/test_commands/test_registry.py` | Registry assertions for session/transcript commands |
| Gateway tests | `tests/test_ohmo/test_gateway.py` | Remote `/resume` and `/summary` denial regressions with fake snapshot data |

## Maintainer impact

- Local `/resume` and `/summary` remain available from the local OpenHarness UI.
- Remote callers receive the same existing local-only denial style used for other sensitive commands.
- Operators that intentionally expose these commands remotely can still opt in through the existing `remote_admin_opt_in` pathway.
- This PR does not change the on-disk snapshot format or the core session-storage APIs.

## Fix rationale

The conservative boundary is to keep transcript restoration and transcript inspection local-only over remote channels. That matches the existing treatment of other sensitive commands that can disclose local state or mutate local control-plane behavior.

A more granular future design could scope remote `/resume` to snapshots whose stored `session_key` matches the caller's router-derived key. Until that scoped command context exists, denying remote use by default avoids cross-user disclosure through global snapshot IDs.

## Type of change

- [x] Security fix
- [x] Regression tests
- [ ] Documentation update
- [ ] Refactor
- [ ] Dependency update

## Test plan

Ran locally:

```bash
uv sync --extra dev
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py::test_sensitive_control_plane_commands_are_local_only tests/test_ohmo/test_gateway.py::test_runtime_pool_summary_does_not_restore_other_slack_thread_sender tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_resume_without_listing_or_loading_other_sessions -q
PYTHONPATH=src:. uv run pytest -o addopts='' tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py -q
PYTHONPATH=src:. uv run python -m compileall -q src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
git diff --check
uv run ruff check src/openharness/commands/registry.py tests/test_commands/test_registry.py tests/test_ohmo/test_gateway.py
```

Observed results:

- Focused regression subset: `3 passed, 4 warnings`
- Touched command/gateway suites: `126 passed, 11 warnings`
- `compileall`: passed
- `git diff --check`: passed
- `ruff check`: passed

The warnings are pre-existing `datetime.utcnow()` deprecation warnings in gateway tests.

## Disclosure notes

This PR is intentionally bounded to a remote gateway confidentiality issue. It does not claim unauthenticated access or remote code execution. The attacker model is an admitted remote gateway sender in a shared ohmo workspace who can invoke remote slash commands.