### PR TITLE
feat(hooks): add priority ordering for lifecycle hooksdering for lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- Hooks now support a `priority` field (default `0`). Within an event, hooks run highest-priority first, and hooks sharing a priority keep their registration order. This lets users order, for example, a security-check hook ahead of a logging hook regardless of where each is declared in settings or contributed by plugins.
 - `edit_file` and `write_file` in the React TUI now preview a unified diff before applying file changes, let users approve once or for the rest of the session, and skip the extra prompt automatically in `full_auto` mode.
 
 ### Fixed

--- a/src/openharness/hooks/loader.py
+++ b/src/openharness/hooks/loader.py
@@ -18,8 +18,13 @@ class HookRegistry:
         self._hooks[event].append(hook)
 
     def get(self, event: HookEvent) -> list[HookDefinition]:
-        """Return hooks registered for an event."""
-        return list(self._hooks.get(event, []))
+        """Return hooks registered for an event, ordered by priority.
+
+        Hooks with a higher ``priority`` run first. ``sorted`` is stable, so
+        hooks sharing the same priority keep their registration order.
+        """
+        hooks = self._hooks.get(event, [])
+        return sorted(hooks, key=lambda hook: -getattr(hook, "priority", 0))
 
     def summary(self) -> str:
         """Return a human-readable hook summary."""
@@ -33,6 +38,9 @@ class HookRegistry:
                 matcher = getattr(hook, "matcher", None)
                 detail = getattr(hook, "command", None) or getattr(hook, "prompt", None) or getattr(hook, "url", None) or ""
                 suffix = f" matcher={matcher}" if matcher else ""
+                priority = getattr(hook, "priority", 0)
+                if priority:
+                    suffix += f" priority={priority}"
                 lines.append(f"  - {hook.type}{suffix}: {detail}")
         return "\n".join(lines)
 

--- a/src/openharness/hooks/schemas.py
+++ b/src/openharness/hooks/schemas.py
@@ -15,6 +15,8 @@ class CommandHookDefinition(BaseModel):
     timeout_seconds: int = Field(default=30, ge=1, le=600)
     matcher: str | None = None
     block_on_failure: bool = False
+    priority: int = Field(default=0)
+    """Higher priority runs first within an event; ties keep registration order."""
 
 
 class PromptHookDefinition(BaseModel):
@@ -26,6 +28,8 @@ class PromptHookDefinition(BaseModel):
     timeout_seconds: int = Field(default=30, ge=1, le=600)
     matcher: str | None = None
     block_on_failure: bool = True
+    priority: int = Field(default=0)
+    """Higher priority runs first within an event; ties keep registration order."""
 
 
 class HttpHookDefinition(BaseModel):
@@ -37,6 +41,8 @@ class HttpHookDefinition(BaseModel):
     timeout_seconds: int = Field(default=30, ge=1, le=600)
     matcher: str | None = None
     block_on_failure: bool = False
+    priority: int = Field(default=0)
+    """Higher priority runs first within an event; ties keep registration order."""
 
 
 class AgentHookDefinition(BaseModel):
@@ -48,6 +54,8 @@ class AgentHookDefinition(BaseModel):
     timeout_seconds: int = Field(default=60, ge=1, le=1200)
     matcher: str | None = None
     block_on_failure: bool = True
+    priority: int = Field(default=0)
+    """Higher priority runs first within an event; ties keep registration order."""
 
 
 HookDefinition = (

--- a/tests/test_hooks/test_priority.py
+++ b/tests/test_hooks/test_priority.py
@@ -1,0 +1,99 @@
+"""Tests for hook priority ordering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.api.client import ApiMessageCompleteEvent
+from openharness.api.usage import UsageSnapshot
+from openharness.engine.messages import ConversationMessage, TextBlock
+from openharness.hooks import HookEvent, HookExecutionContext, HookExecutor
+from openharness.hooks.loader import HookRegistry
+from openharness.hooks.schemas import CommandHookDefinition, HttpHookDefinition
+
+
+class FakeApiClient:
+    """Minimal fake streaming client."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    async def stream_message(self, request):
+        del request
+        yield ApiMessageCompleteEvent(
+            message=ConversationMessage(role="assistant", content=[TextBlock(text=self._text)]),
+            usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+            stop_reason=None,
+        )
+
+
+def test_priority_defaults_to_zero():
+    assert CommandHookDefinition(command="true").priority == 0
+    assert HttpHookDefinition(url="https://example.invalid").priority == 0
+
+
+def test_registry_orders_by_priority_descending():
+    registry = HookRegistry()
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="low", priority=1))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="high", priority=10))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="mid", priority=5))
+
+    commands = [hook.command for hook in registry.get(HookEvent.PRE_TOOL_USE)]
+
+    assert commands == ["high", "mid", "low"]
+
+
+def test_registry_ties_keep_registration_order():
+    """sorted() is stable, so equal priorities preserve insertion order."""
+    registry = HookRegistry()
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="first", priority=5))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="second", priority=5))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="third", priority=5))
+
+    commands = [hook.command for hook in registry.get(HookEvent.PRE_TOOL_USE)]
+
+    assert commands == ["first", "second", "third"]
+
+
+def test_negative_priority_runs_last():
+    registry = HookRegistry()
+    registry.register(HookEvent.SESSION_START, CommandHookDefinition(command="cleanup", priority=-10))
+    registry.register(HookEvent.SESSION_START, CommandHookDefinition(command="default"))
+
+    commands = [hook.command for hook in registry.get(HookEvent.SESSION_START)]
+
+    assert commands == ["default", "cleanup"]
+
+
+def test_summary_includes_non_default_priority():
+    registry = HookRegistry()
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="guard", priority=10))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="logger"))
+
+    summary = registry.summary()
+
+    assert "priority=10" in summary
+    # A default (zero) priority is not noisily printed.
+    assert "priority=0" not in summary
+
+
+@pytest.mark.asyncio
+async def test_executor_runs_hooks_in_priority_order(tmp_path: Path):
+    """End-to-end: execute() honours the priority-sorted registry order."""
+    registry = HookRegistry()
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="printf 'low'", priority=1))
+    registry.register(HookEvent.PRE_TOOL_USE, CommandHookDefinition(command="printf 'high'", priority=10))
+    executor = HookExecutor(
+        registry,
+        HookExecutionContext(
+            cwd=tmp_path,
+            api_client=FakeApiClient('{"ok": true}'),
+            default_model="claude-test",
+        ),
+    )
+
+    result = await executor.execute(HookEvent.PRE_TOOL_USE, {"tool_name": "bash"})
+
+    assert [hook.output for hook in result.results] == ["high", "low"]


### PR DESCRIPTION
## Problem
Hooks for a given event run in registration order (settings first, then
plugin-contributed), with no way to control ordering. Users can't guarantee,
for example, that a security-check hook runs before a logging hook.

## Change
Add an optional `priority: int = 0` field to all four hook definitions
(command / prompt / http / agent). `HookRegistry.get()` now returns hooks
highest-priority first via a stable sort, so hooks sharing a priority keep
their registration order. `HookRegistry.summary()` surfaces non-default
priorities. Inspired by openclaw's per-registration hook priority.

## Verification
- `uv run ruff check src/openharness/hooks tests/test_hooks` — clean
- Added `tests/test_hooks/test_priority.py` with 6 tests (defaults, descending
  order, stable ties, negative priority, summary output, end-to-end executor
  order); `uv run pytest tests/test_hooks` → 11 passed, plugin/integration
  tests → 9 passed.
- Backward compatible: existing hooks default to priority `0`, and the stable
  sort preserves their current registration order, so no existing behavior
  changes.

## Notes
Added a `CHANGELOG.md` entry under `Unreleased > Added`.