### PR TITLE
[security] fix(ohmo): gate gateway-scoped /provider and /model commands

### DIFF
--- a/ohmo/gateway/runtime.py
+++ b/ohmo/gateway/runtime.py
@@ -260,19 +260,6 @@ class OhmoSessionRuntimePool:
         if parsed is not None and not message.media:
             command, args = parsed
             command_name = str(getattr(command, "name", "") or "")
-            gateway_result = self._handle_gateway_scoped_command(command_name, args)
-            if gateway_result is not None:
-                message_text, refresh_runtime = gateway_result
-                result = CommandResult(message=message_text, refresh_runtime=refresh_runtime)
-                async for update in self._stream_command_result(
-                    bundle=bundle,
-                    message=message,
-                    session_key=session_key,
-                    user_prompt=user_prompt,
-                    result=result,
-                ):
-                    yield update
-                return
             remote_allowed = getattr(command, "remote_invocable", True)
             if not remote_allowed and self._remote_admin_allowed(command):
                 remote_allowed = True
@@ -287,6 +274,19 @@ class OhmoSessionRuntimePool:
                 result = CommandResult(
                     message=f"/{command_name} is only available in the local OpenHarness UI."
                 )
+                async for update in self._stream_command_result(
+                    bundle=bundle,
+                    message=message,
+                    session_key=session_key,
+                    user_prompt=user_prompt,
+                    result=result,
+                ):
+                    yield update
+                return
+            gateway_result = self._handle_gateway_scoped_command(command_name, args)
+            if gateway_result is not None:
+                message_text, refresh_runtime = gateway_result
+                result = CommandResult(message=message_text, refresh_runtime=refresh_runtime)
                 async for update in self._stream_command_result(
                     bundle=bundle,
                     message=message,

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -2654,7 +2654,14 @@ def test_runtime_pool_sanitizes_internal_group_prompt_metadata():
 async def test_runtime_pool_provider_command_refresh_uses_gateway_profile(tmp_path, monkeypatch):
     workspace = tmp_path / ".ohmo-home"
     initialize_workspace(workspace)
-    save_gateway_config(GatewayConfig(provider_profile="kimi-anthropic"), workspace)
+    save_gateway_config(
+        GatewayConfig(
+            provider_profile="kimi-anthropic",
+            allow_remote_admin_commands=True,
+            allowed_remote_admin_commands=["provider", "model"],
+        ),
+        workspace,
+    )
     build_calls: list[dict[str, object]] = []
 
     statuses = {
@@ -2730,6 +2737,92 @@ async def test_runtime_pool_provider_command_refresh_uses_gateway_profile(tmp_pa
     assert updates[-1].text.startswith("ohmo gateway provider_profile set to codex")
     assert build_calls[0]["active_profile"] == "kimi-anthropic"
     assert build_calls[1]["active_profile"] == "codex"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command_text,command_name",
+    [("/provider codex", "provider"), ("/model gpt-5.5", "model")],
+)
+async def test_runtime_pool_rejects_gateway_scoped_command_without_admin_opt_in(
+    tmp_path,
+    monkeypatch,
+    command_text,
+    command_name,
+):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    save_gateway_config(GatewayConfig(provider_profile="kimi-anthropic"), workspace)
+    build_calls: list[dict[str, object]] = []
+    handler_invocations: list[tuple[str, str]] = []
+
+    def fake_provider_handler(args, **_kwargs):
+        handler_invocations.append(("provider", args))
+        return ("provider switched", True)
+
+    def fake_model_handler(args, **_kwargs):
+        handler_invocations.append(("model", args))
+        return ("model switched", True)
+
+    class FakeEngine:
+        def __init__(self):
+            self.messages = [ConversationMessage.from_user_text("before")]
+            self.total_usage = UsageSnapshot()
+
+        def set_system_prompt(self, prompt):
+            del prompt
+
+        async def submit_message(self, content):
+            del content
+            if False:
+                yield None
+
+    async def fake_build_runtime(**kwargs):
+        build_calls.append(kwargs)
+        return SimpleNamespace(
+            engine=FakeEngine(),
+            session_id="sess123",
+            current_settings=lambda: SimpleNamespace(model="gpt-5.4"),
+            commands=create_default_command_registry(),
+            hook_summary=lambda: "",
+            mcp_summary=lambda: "",
+            plugin_summary=lambda: "",
+            cwd=str(tmp_path),
+            tool_registry=None,
+            app_state=None,
+            session_backend=None,
+            extra_skill_dirs=(),
+            extra_plugin_roots=(),
+            enforce_max_turns=False,
+        )
+
+    async def fake_start_runtime(bundle):
+        del bundle
+
+    async def fake_close_runtime(bundle):
+        del bundle
+
+    monkeypatch.setattr(
+        "ohmo.gateway.runtime.handle_gateway_provider_command", fake_provider_handler
+    )
+    monkeypatch.setattr(
+        "ohmo.gateway.runtime.handle_gateway_model_command", fake_model_handler
+    )
+    monkeypatch.setattr("ohmo.gateway.runtime.build_runtime", fake_build_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.start_runtime", fake_start_runtime)
+    monkeypatch.setattr("ohmo.gateway.runtime.close_runtime", fake_close_runtime)
+
+    pool = OhmoSessionRuntimePool(cwd=tmp_path, workspace=workspace, provider_profile="kimi-anthropic")
+    message = InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content=command_text)
+    updates = [u async for u in pool.stream_message(message, "feishu:c1")]
+
+    assert handler_invocations == []
+    assert any(
+        f"/{command_name} is only available in the local OpenHarness UI." in update.text
+        for update in updates
+    )
+    assert load_gateway_config(workspace).provider_profile == "kimi-anthropic"
+    assert len(build_calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #280. Restores the `remote_invocable` / `remote_admin_opt_in` gate for the two ohmo gateway-scoped administrative commands (`/provider`, `/model`) that were silently bypassing it.

## The bug

`ohmo/gateway/runtime.py` short-circuited `/provider` and `/model` through `_handle_gateway_scoped_command` **before** the remote-allowed gate at lines 276-298, so neither `remote_invocable=False` nor the `allow_remote_admin_commands` + `allowed_remote_admin_commands` opt-in was consulted for those two commands. Any sender on the channel allowlist could swap the active provider profile or mutate `allowed_models` over Slack/Telegram/Feishu/Discord/Matrix.

Both commands are registered with `remote_invocable=False, remote_admin_opt_in=True` at `src/openharness/commands/registry.py:2453-2470`, matching the pattern recently extended to `/commit`, `/diff`, `/tasks`, `/autopilot`, `/session`, `/issue`, etc.

## The fix

`ohmo/gateway/runtime.py` — move the `_handle_gateway_scoped_command` call after the existing gate. The gate already supports admin opt-in via `GatewayConfig.allow_remote_admin_commands=True` and `allowed_remote_admin_commands=["provider","model"]`, so the operator-opted-in flow keeps working unchanged.

## Test plan

- [x] New parametrized test `test_runtime_pool_rejects_gateway_scoped_command_without_admin_opt_in` covers both `/provider codex` and `/model gpt-5.5` and asserts:
  - `handle_gateway_provider_command` / `handle_gateway_model_command` are NOT invoked.
  - The user-visible reply is the standard "only available in the local OpenHarness UI" rejection.
  - `gateway.yaml`'s `provider_profile` is unchanged.
  - The runtime is not rebuilt (`build_calls` length stays at 1).
- [x] Existing positive test `test_runtime_pool_provider_command_refresh_uses_gateway_profile` updated to set `allow_remote_admin_commands=True, allowed_remote_admin_commands=["provider","model"]`. It still asserts the runtime rebuild + active-profile swap on success.
- [x] `uv run pytest tests/test_ohmo/test_gateway.py -q` → **72 passed**
- [x] `uv run pytest tests/test_ohmo/ -q` → **92 passed**
- [x] `uv run ruff check src tests scripts` → clean

CHANGELOG intentionally not updated per repo maintainer practice for `[security] fix(...)` commits.
