### PR TITLE
feat(minimax): add MiniMax-M3 and make it the default model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- `MiniMax-M3` as the new default model for the built-in `minimax` provider profile, surfaced as "MiniMax latest" in the model picker. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available for compatibility.
+
 - Hooks now support a `priority` field (default `0`). Within an event, hooks run highest-priority first, and hooks sharing a priority keep their registration order. This lets users order, for example, a security-check hook ahead of a logging hook regardless of where each is declared in settings or contributed by plugins.
 - `edit_file` and `write_file` in the React TUI now preview a unified diff before applying file changes, let users approve once or for the rest of the session, and skip the extra prompt automatically in `full_auto` mode.
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Typical examples:
 | **Claude official** | `https://api.anthropic.com` | `claude-sonnet-4-6`, `claude-opus-4-6` |
 | **Moonshot / Kimi** | `https://api.moonshot.cn/anthropic` | `kimi-k2.5` |
 | **Zhipu / GLM** | custom Anthropic-compatible endpoint | `glm-4.5` |
-| **MiniMax** | custom Anthropic-compatible endpoint | `minimax-m1` |
+| **MiniMax** | custom Anthropic-compatible endpoint | `MiniMax-M3` |
 
 #### OpenAI-Compatible API
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -1564,7 +1564,7 @@ def _specialize_setup_target(manager, target: str) -> str:
         defaults = {
             "kimi-anthropic": ("Kimi (Anthropic-compatible)", "https://api.moonshot.cn/anthropic", "kimi-k2.5"),
             "glm-anthropic": ("GLM (Anthropic-compatible)", "", "glm-4.5"),
-            "minimax-anthropic": ("MiniMax (Anthropic-compatible)", "", "MiniMax-M2.7"),
+            "minimax-anthropic": ("MiniMax (Anthropic-compatible)", "", "MiniMax-M3"),
         }
         label, suggested_base_url, suggested_model = defaults[choice]
         base_url = _text_prompt("Base URL", default=suggested_base_url).strip()

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -244,7 +244,7 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             provider="minimax",
             api_format="openai",
             auth_source="minimax_api_key",
-            default_model="MiniMax-M2.7",
+            default_model="MiniMax-M3",
             base_url="https://api.minimax.io/v1",
         ),
         "nvidia": ProviderProfile(

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -738,6 +738,7 @@ class ReactBackendHost:
         elif provider_name == "minimax":
             families.extend(
                 [
+                    ("MiniMax-M3", "MiniMax latest"),
                     ("MiniMax-M2.7", "MiniMax flagship"),
                     ("MiniMax-M2.7-highspeed", "MiniMax fast"),
                 ]

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -604,7 +604,7 @@ class TestMiniMaxProvider:
         assert profile.provider == "minimax"
         assert profile.api_format == "openai"
         assert profile.auth_source == "minimax_api_key"
-        assert profile.default_model == "MiniMax-M2.7"
+        assert profile.default_model == "MiniMax-M3"
         assert profile.base_url == "https://api.minimax.io/v1"
 
     def test_auth_source_provider_name_minimax(self):
@@ -627,7 +627,7 @@ class TestMiniMaxProvider:
                     provider="minimax",
                     api_format="openai",
                     auth_source="minimax_api_key",
-                    default_model="MiniMax-M2.7",
+                    default_model="MiniMax-M3",
                     base_url="https://api.minimax.io/v1",
                 )
             },
@@ -645,13 +645,13 @@ class TestMiniMaxProvider:
                     provider="minimax",
                     api_format="openai",
                     auth_source="minimax_api_key",
-                    default_model="MiniMax-M2.7",
+                    default_model="MiniMax-M3",
                     base_url="https://api.minimax.io/v1",
                 )
             },
         )
         materialized = settings.materialize_active_profile()
-        assert materialized.model == "MiniMax-M2.7"
+        assert materialized.model == "MiniMax-M3"
         assert materialized.provider == "minimax"
         assert materialized.api_format == "openai"
 

--- a/tests/test_ui/test_react_backend.py
+++ b/tests/test_ui/test_react_backend.py
@@ -537,7 +537,7 @@ async def test_backend_host_uses_effective_model_from_env_override(tmp_path, mon
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
     monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
-    monkeypatch.setenv("OPENHARNESS_MODEL", "minimax-m1")
+    monkeypatch.setenv("OPENHARNESS_MODEL", "MiniMax-M3")
 
     host = ReactBackendHost(BackendHostConfig(api_client=StaticApiClient("unused")))
     host._bundle = await build_runtime(api_client=StaticApiClient("unused"))
@@ -549,11 +549,11 @@ async def test_backend_host_uses_effective_model_from_env_override(tmp_path, mon
     host._emit = _emit  # type: ignore[method-assign]
     await start_runtime(host._bundle)
     try:
-        assert host._bundle.app_state.get().model == "minimax-m1"
+        assert host._bundle.app_state.get().model == "MiniMax-M3"
 
         # Exercise sync_app_state through a slash command refresh path.
         await host._process_line("/fast show")
-        assert host._bundle.app_state.get().model == "minimax-m1"
+        assert host._bundle.app_state.get().model == "MiniMax-M3"
     finally:
         await close_runtime(host._bundle)
 


### PR DESCRIPTION
## Summary

Upgrade the built-in `minimax` provider profile to surface the latest MiniMax model, `MiniMax-M3`, and make it the default for new setups.

## Changes

- `src/openharness/config/settings.py`: `default_provider_profiles()["minimax"].default_model` → `MiniMax-M3`.
- `src/openharness/cli.py`: the `claude-api` → `minimax-anthropic` setup default model is now `MiniMax-M3`.
- `src/openharness/ui/backend_host.py`: model picker now shows `MiniMax-M3` first (labelled "MiniMax latest"), with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` still available below it for users who pinned to them.
- `README.md`: the Anthropic-compatible table now uses `MiniMax-M3` as the example model (the old `minimax-m1` entry no longer matches the catalog).
- `tests/test_config/test_settings.py` and `tests/test_ui/test_react_backend.py`: updated the hard-coded default-model assertions to match.
- `CHANGELOG.md`: short Unreleased entry under `Added`.

The provider name, env key (`MINIMAX_API_KEY`), base URL (`https://api.minimax.io/v1`), API format, and the `minimax-vl` vision regex are unchanged.

## Test plan

- [x] `uv run ruff check src tests scripts` — clean.
- [x] `uv run pytest -q tests/test_config/test_settings.py::TestMiniMaxProvider` — 5 passed.
- [x] `uv run pytest -q tests/test_ui/test_react_backend.py::test_backend_host_uses_effective_model_from_env_override` — 1 passed.