### PR TITLE
fix(ohmo): tee gateway run logs to file

### DIFF
--- a/ohmo/cli.py
+++ b/ohmo/cli.py
@@ -25,6 +25,7 @@ from ohmo.runtime import launch_ohmo_react_tui, run_ohmo_backend, run_ohmo_print
 from ohmo.session_storage import OhmoSessionBackend
 from ohmo.workspace import (
     get_gateway_config_path,
+    get_logs_dir,
     get_workspace_root,
     get_soul_path,
     get_state_path,
@@ -407,16 +408,40 @@ def _maybe_restart_gateway(*, cwd: str | Path, workspace: str | Path) -> None:
     print(f"ohmo gateway restarted (pid={pid})")
 
 
-def _configure_gateway_logging(workspace: str | Path | None = None) -> None:
+def _configure_gateway_logging(
+    workspace: str | Path | None = None,
+    *,
+    console: bool = True,
+    log_file: bool = True,
+) -> None:
     """Configure foreground gateway logging."""
     config = load_gateway_config(workspace)
     level_name = str(config.log_level or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
+    handlers = _build_gateway_logging_handlers(workspace, console=console, log_file=log_file)
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+        handlers=handlers,
         force=True,
     )
+
+
+def _build_gateway_logging_handlers(
+    workspace: str | Path | None = None,
+    *,
+    console: bool,
+    log_file: bool,
+) -> list[logging.Handler]:
+    """Build gateway log handlers for foreground and daemon modes."""
+    handlers: list[logging.Handler] = []
+    if console:
+        handlers.append(logging.StreamHandler())
+    if log_file:
+        log_path = get_logs_dir(workspace) / "gateway.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handlers.append(logging.FileHandler(log_path, encoding="utf-8", delay=True))
+    return handlers
 
 
 @app.callback(invoke_without_command=True)
@@ -637,9 +662,11 @@ def user_edit_cmd(
 def gateway_run_cmd(
     cwd: str = typer.Option(str(Path.cwd()), "--cwd", help="Project working directory"),
     workspace: str | None = typer.Option(None, "--workspace", help=_WORKSPACE_HELP),
+    console_log: bool = typer.Option(True, "--console-log/--no-console-log", hidden=True),
+    log_file: bool = typer.Option(True, "--log-file/--no-log-file", hidden=True),
 ) -> None:
     """Run the ohmo gateway in the foreground."""
-    _configure_gateway_logging(workspace)
+    _configure_gateway_logging(workspace, console=console_log, log_file=log_file)
     service = OhmoGatewayService(cwd, workspace)
     raise SystemExit(asyncio.run(service.run_foreground()))
 

--- a/ohmo/gateway/service.py
+++ b/ohmo/gateway/service.py
@@ -290,6 +290,7 @@ def start_gateway_process(cwd: str | Path | None = None, workspace: str | Path |
                 service._cwd,
                 "--workspace",
                 str(get_workspace_root(workspace)),
+                "--no-console-log",
             ],
             **popen_kwargs,
         )

--- a/tests/test_ohmo/test_cli.py
+++ b/tests/test_ohmo/test_cli.py
@@ -1,9 +1,10 @@
 import json
+import logging
 from pathlib import Path
 
 from typer.testing import CliRunner
 
-from ohmo.cli import app
+from ohmo.cli import _build_gateway_logging_handlers, app
 
 
 def test_ohmo_help():
@@ -46,6 +47,42 @@ def test_ohmo_init_noninteractive_defaults_to_deny_all_remote_access(tmp_path: P
     assert result.exit_code == 0
     config = json.loads((workspace / "gateway.json").read_text(encoding="utf-8"))
     assert config["channel_configs"] == {}
+
+
+def test_gateway_logging_handlers_write_gateway_log_file(tmp_path: Path):
+    workspace = tmp_path / ".ohmo-home"
+    runner = CliRunner()
+    result = runner.invoke(app, ["init", "--workspace", str(workspace), "--no-interactive"])
+    assert result.exit_code == 0
+
+    handlers = _build_gateway_logging_handlers(workspace, console=True, log_file=True)
+    try:
+        file_handlers = [handler for handler in handlers if isinstance(handler, logging.FileHandler)]
+        console_handlers = [
+            handler
+            for handler in handlers
+            if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
+        assert len(console_handlers) == 1
+
+        record = logging.LogRecord(
+            name="ohmo.gateway.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="GATEWAY_LOG_OK",
+            args=(),
+            exc_info=None,
+        )
+        file_handlers[0].emit(record)
+        file_handlers[0].flush()
+
+        log_path = workspace / "logs" / "gateway.log"
+        assert "GATEWAY_LOG_OK" in log_path.read_text(encoding="utf-8")
+    finally:
+        for handler in handlers:
+            handler.close()
 
 
 def test_ohmo_init_interactive_writes_gateway_config(tmp_path: Path, monkeypatch):

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import logging
 import subprocess
+import sys
 from types import SimpleNamespace
 from datetime import datetime
 import json
@@ -46,7 +47,7 @@ from ohmo.gateway.runtime import (
     _sanitize_group_command_metadata,
     _sanitize_group_command_prompts,
 )
-from ohmo.gateway.service import OhmoGatewayService, gateway_status, stop_gateway_process
+from ohmo.gateway.service import OhmoGatewayService, gateway_status, start_gateway_process, stop_gateway_process
 from ohmo.group_registry import load_managed_group_record, save_managed_group_record
 from ohmo.memory import add_memory_entry as add_ohmo_memory_entry
 from ohmo.memory import list_memory_files as list_ohmo_memory_files
@@ -421,6 +422,34 @@ def test_gateway_status_prefers_live_config_over_stale_state(tmp_path):
     assert state.running is False
     assert state.provider_profile == "codex"
     assert state.enabled_channels == ["feishu"]
+
+
+def test_start_gateway_process_uses_child_log_file_handler_without_console_duplication(tmp_path, monkeypatch):
+    workspace = tmp_path / ".ohmo-home"
+    initialize_workspace(workspace)
+    captured: dict[str, object] = {}
+
+    class FakeProcess:
+        pid = 1234
+
+    def fake_popen(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr("ohmo.gateway.service.subprocess.Popen", fake_popen)
+
+    assert start_gateway_process(tmp_path, workspace) == 1234
+
+    args = captured["args"]
+    kwargs = captured["kwargs"]
+    assert isinstance(args, list)
+    assert args[:4] == [sys.executable, "-m", "ohmo", "gateway"]
+    assert "run" in args
+    assert "--no-console-log" in args
+    assert isinstance(kwargs, dict)
+    assert kwargs["stdout"] is kwargs["stderr"]
+    assert getattr(kwargs["stdout"], "name", "").endswith("gateway.log")
 
 
 def test_stop_gateway_process_kills_matching_workspace_processes(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- make `ohmo gateway run` write logs to both stderr and `.ohmo/logs/gateway.log` by default
- keep `ohmo gateway start` from duplicating log lines by launching the child with `--no-console-log` while the child still owns its file log handler
- add regression coverage for gateway log handlers and background launch arguments

Closes #282

## Tests
- `python -m pytest tests/test_ohmo/test_cli.py tests/test_ohmo/test_gateway.py -q` -> 83 passed
- `python -m pytest tests/test_ohmo/ -q` -> 94 passed
- `python -m ruff check ohmo/cli.py ohmo/gateway/service.py tests/test_ohmo/test_cli.py tests/test_ohmo/test_gateway.py`
