### PR TITLE
fix(ohmo): normalize chat channel output

### DIFF
--- a/ohmo/cli.py
+++ b/ohmo/cli.py
@@ -338,6 +338,15 @@ def _run_gateway_config_wizard(workspace: str | Path) -> GatewayConfig:
         "Send tool hints to channels?",
         default=existing.send_tool_hints,
     )
+    remote_output_mode = _select_from_menu(
+        "Remote channel output mode:",
+        [
+            ("user", "User-facing output (hide raw tool details)"),
+            ("debug", "Debug output (show raw tool details)"),
+            ("silent", "Silent progress (final/media only)"),
+        ],
+        default_value=existing.remote_output_mode,
+    )
     allow_remote_admin_commands = _confirm_prompt(
         "Allow explicitly listed administrative slash commands from remote channels?",
         default=existing.allow_remote_admin_commands,
@@ -361,6 +370,7 @@ def _run_gateway_config_wizard(workspace: str | Path) -> GatewayConfig:
             "channel_configs": channel_configs,
             "send_progress": send_progress,
             "send_tool_hints": send_tool_hints,
+            "remote_output_mode": remote_output_mode,
             "allow_remote_admin_commands": allow_remote_admin_commands,
             "allowed_remote_admin_commands": allowed_remote_admin_commands,
         }

--- a/ohmo/gateway/bridge.py
+++ b/ohmo/gateway/bridge.py
@@ -12,6 +12,7 @@ from openharness.channels.bus.events import OutboundMessage
 from openharness.channels.bus.queue import MessageBus
 
 from ohmo.group_registry import load_managed_group_record
+from ohmo.gateway.output_normalizer import GatewayOutputState, normalize_gateway_update
 from ohmo.gateway.router import session_key_for_message
 from ohmo.gateway.runtime import OhmoSessionRuntimePool
 
@@ -259,31 +260,43 @@ class OhmoGatewayBridge:
             reply = ""
             final_media: list[str] = []
             final_metadata: dict[str, object] = {}
+            output_state = GatewayOutputState()
+            output_mode = str(getattr(self._runtime_pool, "remote_output_mode", "user"))
             async for update in self._runtime_pool.stream_message(message, session_key):
-                if update.kind == "final":
-                    reply = update.text
-                    final_media = list(getattr(update, "media", None) or (update.metadata or {}).get("_media") or [])
-                    final_metadata = dict(update.metadata or {})
-                    continue
-                if not update.text:
-                    continue
-                logger.info(
-                    "ohmo outbound update channel=%s chat_id=%s session_key=%s kind=%s content=%r",
-                    message.channel,
-                    message.chat_id,
-                    session_key,
-                    update.kind,
-                    _content_snippet(update.text),
-                )
-                await self._bus.publish_outbound(
-                    OutboundMessage(
-                        channel=message.channel,
-                        chat_id=message.chat_id,
-                        content=update.text,
-                        media=list(getattr(update, "media", None) or (update.metadata or {}).get("_media") or []),
-                        metadata={**inbound_meta, **(update.metadata or {})},
+                for outgoing in normalize_gateway_update(
+                    update,
+                    channel=message.channel,
+                    content=message.content,
+                    mode=output_mode,
+                    state=output_state,
+                ):
+                    outgoing_media = list(
+                        getattr(outgoing, "media", None) or (outgoing.metadata or {}).get("_media") or []
                     )
-                )
+                    if outgoing.kind == "final":
+                        reply = outgoing.text
+                        final_media = outgoing_media
+                        final_metadata = dict(outgoing.metadata or {})
+                        continue
+                    if not outgoing.text and not outgoing_media:
+                        continue
+                    logger.info(
+                        "ohmo outbound update channel=%s chat_id=%s session_key=%s kind=%s content=%r",
+                        message.channel,
+                        message.chat_id,
+                        session_key,
+                        outgoing.kind,
+                        _content_snippet(outgoing.text),
+                    )
+                    await self._bus.publish_outbound(
+                        OutboundMessage(
+                            channel=message.channel,
+                            chat_id=message.chat_id,
+                            content=outgoing.text,
+                            media=outgoing_media,
+                            metadata={**inbound_meta, **(outgoing.metadata or {})},
+                        )
+                    )
         except asyncio.CancelledError:
             logger.info(
                 "ohmo session interrupted channel=%s chat_id=%s session_key=%s reason=%s",

--- a/ohmo/gateway/models.py
+++ b/ohmo/gateway/models.py
@@ -13,6 +13,7 @@ class GatewayConfig(BaseModel):
     session_routing: str = "chat-thread"
     send_progress: bool = True
     send_tool_hints: bool = True
+    remote_output_mode: str = "user"
     permission_mode: str = "default"
     sandbox_enabled: bool = False
     allow_remote_admin_commands: bool = False

--- a/ohmo/gateway/output_normalizer.py
+++ b/ohmo/gateway/output_normalizer.py
@@ -1,0 +1,274 @@
+"""User-facing output normalization for ohmo gateway channels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+
+from ohmo.gateway.runtime import GatewayStreamUpdate
+
+REMOTE_CHANNELS = {
+    "discord",
+    "dingtalk",
+    "email",
+    "feishu",
+    "matrix",
+    "qq",
+    "slack",
+    "telegram",
+    "wechat",
+    "whatsapp",
+}
+
+_LOCAL_PATH_RE = re.compile(
+    r"(?P<path>(?:(?<![A-Za-z0-9])[A-Za-z]:[\\/]|(?<![:/])/)(?:[^\r\n`\"'<>|?*\x00])+)",
+)
+_PATH_CODE_BLOCK_RE = re.compile(
+    r"```(?:text|txt|powershell|shell|bash)?\s*\n(?P<body>.*?)\n```",
+    re.IGNORECASE | re.DOTALL,
+)
+_URL_RE = re.compile(r"https?://[^\s`<>\"']+")
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
+
+
+@dataclass
+class GatewayOutputState:
+    """Per-message state for channel-facing output normalization."""
+
+    stage_keys: set[str] = field(default_factory=set)
+    media_paths: set[str] = field(default_factory=set)
+    has_image_media: bool = False
+    saw_media: bool = False
+
+
+def normalize_gateway_update(
+    update: GatewayStreamUpdate,
+    *,
+    channel: str,
+    content: str,
+    mode: str,
+    state: GatewayOutputState,
+) -> list[GatewayStreamUpdate]:
+    """Return channel-facing updates for one runtime update."""
+    normalized_mode = _normalize_mode(mode)
+    if normalized_mode == "debug" or channel not in REMOTE_CHANNELS:
+        _remember_update_media(state, update)
+        return [update]
+    if update.kind == "media":
+        _remember_update_media(state, update)
+        return [_strip_media_caption(update)]
+    if update.kind == "final":
+        _remember_update_media(state, update)
+        final_text = normalize_final_reply(update.text, state=state)
+        if not final_text:
+            return []
+        metadata = dict(update.metadata or {})
+        return [
+            GatewayStreamUpdate(
+                kind=update.kind,
+                text=final_text,
+                metadata=metadata,
+                media=list(getattr(update, "media", None) or metadata.get("_media") or []),
+            )
+        ]
+    if update.kind == "error":
+        return [update]
+    if normalized_mode == "silent":
+        return []
+    if update.kind == "progress":
+        return _normalize_progress(update, content=content, state=state)
+    if update.kind == "tool_hint":
+        return _normalize_tool_hint(update, content=content, state=state)
+    return [update]
+
+
+def normalize_final_reply(reply: str, *, state: GatewayOutputState) -> str:
+    """Remove local paths already represented as media from a final reply."""
+    text, urls = _protect_urls(reply or "")
+    text = _remove_path_code_blocks(text, state)
+    text = _LOCAL_PATH_RE.sub(lambda match: _replace_local_path(match.group("path"), state), text)
+    text = _restore_urls(text, urls)
+    text = _clean_text(text)
+    if not text and state.saw_media:
+        return "已生成图片。" if state.has_image_media else "已生成文件。"
+    if state.has_image_media and _only_acknowledges_generated_image(text):
+        return "已生成图片。"
+    return text
+
+
+def _normalize_progress(
+    update: GatewayStreamUpdate,
+    *,
+    content: str,
+    state: GatewayOutputState,
+) -> list[GatewayStreamUpdate]:
+    if "thinking" in state.stage_keys:
+        return []
+    state.stage_keys.add("thinking")
+    return [_copy_with_text(update, "正在处理..." if _prefers_chinese(content) else "Working on it...")]
+
+
+def _normalize_tool_hint(
+    update: GatewayStreamUpdate,
+    *,
+    content: str,
+    state: GatewayOutputState,
+) -> list[GatewayStreamUpdate]:
+    metadata = update.metadata or {}
+    tool_name = str(metadata.get("_tool_name") or "").strip()
+    stage = _stage_for_tool(tool_name)
+    if not stage:
+        return []
+    if stage in state.stage_keys:
+        return []
+    state.stage_keys.add(stage)
+    text = _stage_text(stage, content)
+    return [_copy_with_text(update, text)]
+
+
+def _stage_for_tool(tool_name: str) -> str | None:
+    normalized = tool_name.strip().lower().replace("-", "_")
+    if normalized in {"web_search", "web_fetch"}:
+        return "searching"
+    if normalized == "image_generation":
+        return "generating_image"
+    if normalized in {"shell", "bash", "python", "run_command"}:
+        return "processing_files"
+    return None
+
+
+def _stage_text(stage: str, content: str) -> str:
+    zh = _prefers_chinese(content)
+    if stage == "searching":
+        return "正在检索资料..." if zh else "Searching..."
+    if stage == "generating_image":
+        return "正在生成图片..." if zh else "Generating image..."
+    if stage == "processing_files":
+        return "正在处理文件..." if zh else "Processing files..."
+    return "正在处理..." if zh else "Working on it..."
+
+
+def _copy_with_text(update: GatewayStreamUpdate, text: str) -> GatewayStreamUpdate:
+    return GatewayStreamUpdate(
+        kind=update.kind,
+        text=text,
+        metadata=dict(update.metadata or {}),
+        media=list(getattr(update, "media", None) or []),
+    )
+
+
+def _strip_media_caption(update: GatewayStreamUpdate) -> GatewayStreamUpdate:
+    return GatewayStreamUpdate(
+        kind=update.kind,
+        text="",
+        metadata=dict(update.metadata or {}),
+        media=list(getattr(update, "media", None) or []),
+    )
+
+
+def _remember_update_media(state: GatewayOutputState, update: GatewayStreamUpdate) -> None:
+    raw_media = getattr(update, "media", None) or (update.metadata or {}).get("_media") or []
+    if isinstance(raw_media, str):
+        candidates = [raw_media]
+    elif isinstance(raw_media, list):
+        candidates = [str(item) for item in raw_media if isinstance(item, str) and item.strip()]
+    else:
+        candidates = []
+    for raw in candidates:
+        state.saw_media = True
+        resolved = _normalize_path(raw)
+        state.media_paths.add(resolved)
+        if Path(raw).suffix.lower() in _IMAGE_SUFFIXES:
+            state.has_image_media = True
+
+
+def _remove_path_code_blocks(text: str, state: GatewayOutputState) -> str:
+    def replace(match: re.Match[str]) -> str:
+        body = match.group("body").strip()
+        lines = [line.strip() for line in body.splitlines() if line.strip()]
+        if lines and all(_looks_like_local_path(line) for line in lines):
+            kept = [_replace_local_path(line, state) for line in lines]
+            kept = [item for item in kept if item]
+            return "\n".join(kept)
+        return match.group(0)
+
+    return _PATH_CODE_BLOCK_RE.sub(replace, text)
+
+
+def _replace_local_path(path_text: str, state: GatewayOutputState) -> str:
+    cleaned = path_text.strip().rstrip(".,;:，。；：、)]}")
+    normalized = _normalize_path(cleaned)
+    if normalized in state.media_paths:
+        return ""
+    path = Path(cleaned)
+    return path.name if path.name else ""
+
+
+def _normalize_path(path_text: str) -> str:
+    try:
+        return str(Path(path_text).expanduser().resolve(strict=False))
+    except Exception:
+        return path_text
+
+
+def _looks_like_local_path(text: str) -> bool:
+    return bool(_LOCAL_PATH_RE.fullmatch(text.strip()))
+
+
+def _clean_text(text: str) -> str:
+    lines = [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    cleaned: list[str] = []
+    blank = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if cleaned and not blank:
+                cleaned.append("")
+            blank = True
+            continue
+        cleaned.append(stripped)
+        blank = False
+    return "\n".join(cleaned).strip()
+
+
+def _protect_urls(text: str) -> tuple[str, dict[str, str]]:
+    urls: dict[str, str] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        key = f"__OHMO_URL_{len(urls)}__"
+        urls[key] = match.group(0)
+        return key
+
+    return _URL_RE.sub(replace, text), urls
+
+
+def _restore_urls(text: str, urls: dict[str, str]) -> str:
+    for key, value in urls.items():
+        text = text.replace(key, value)
+    return text
+
+
+def _only_acknowledges_generated_image(text: str) -> bool:
+    normalized = re.sub(r"\s+", "", text or "")
+    return normalized in {
+        "已生成图片：",
+        "已生成图片:",
+        "已生成图片。",
+        "已生成图片",
+        "已生成信息图：",
+        "已生成信息图:",
+        "已生成信息图。",
+        "已生成信息图",
+    }
+
+
+def _prefers_chinese(content: str) -> bool:
+    return bool(re.search(r"[\u4e00-\u9fff]", content or ""))
+
+
+def _normalize_mode(mode: str) -> str:
+    normalized = (mode or "user").strip().lower()
+    if normalized in {"debug", "silent", "user"}:
+        return normalized
+    return "user"

--- a/ohmo/gateway/runtime.py
+++ b/ohmo/gateway/runtime.py
@@ -124,6 +124,10 @@ class OhmoSessionRuntimePool:
     def active_sessions(self) -> int:
         return len(self._bundles)
 
+    @property
+    def remote_output_mode(self) -> str:
+        return self._gateway_config.remote_output_mode
+
     def _remote_admin_allowed(self, command) -> bool:
         if not getattr(command, "remote_admin_opt_in", False):
             return False
@@ -585,6 +589,8 @@ class OhmoSessionRuntimePool:
                     "_progress": True,
                     "_tool_hint": True,
                     "_session_key": session_key,
+                    "_tool_name": event.tool_name,
+                    "_tool_summary": summary,
                 },
             )
             return

--- a/ohmo/workspace.py
+++ b/ohmo/workspace.py
@@ -286,6 +286,7 @@ def initialize_workspace(workspace: str | Path | None = None) -> Path:
                     "session_routing": "chat-thread",
                     "send_progress": True,
                     "send_tool_hints": True,
+                    "remote_output_mode": "user",
                     "permission_mode": "default",
                     "sandbox_enabled": False,
                     "allow_remote_admin_commands": False,

--- a/tests/test_ohmo/test_cli.py
+++ b/tests/test_ohmo/test_cli.py
@@ -102,6 +102,7 @@ def test_ohmo_init_interactive_writes_gateway_config(tmp_path: Path, monkeypatch
             "n",  # feishu
             "y",  # send_progress
             "y",  # send_tool_hints
+            "1",  # remote_output_mode -> user
             "n",  # allow_remote_admin_commands
         ]
     )
@@ -111,6 +112,7 @@ def test_ohmo_init_interactive_writes_gateway_config(tmp_path: Path, monkeypatch
     assert config["enabled_channels"] == ["telegram"]
     assert config["channel_configs"]["telegram"]["token"] == "telegram-token"
     assert config["channel_configs"]["telegram"]["allow_from"] == ["123456"]
+    assert config["remote_output_mode"] == "user"
 
 
 def test_ohmo_init_interactive_allows_blank_allow_from_for_secure_default(tmp_path: Path, monkeypatch):
@@ -130,6 +132,7 @@ def test_ohmo_init_interactive_allows_blank_allow_from_for_secure_default(tmp_pa
             "n",  # feishu
             "y",  # send_progress
             "y",  # send_tool_hints
+            "1",  # remote_output_mode -> user
             "n",  # allow_remote_admin_commands
         ]
     )
@@ -164,6 +167,7 @@ def test_ohmo_init_interactive_writes_feishu_gateway_config(tmp_path: Path, monk
             "",          # bot_open_id
             "y",         # send_progress
             "n",         # send_tool_hints
+            "1",         # remote_output_mode -> user
             "n",         # allow_remote_admin_commands
         ]
     )
@@ -179,6 +183,7 @@ def test_ohmo_init_interactive_writes_feishu_gateway_config(tmp_path: Path, monk
     assert config["channel_configs"]["feishu"]["react_emoji"] == "OK"
     assert config["channel_configs"]["feishu"]["group_policy"] == "managed_or_mention"
     assert config["channel_configs"]["feishu"]["bot_names"] == ["ohmo", "openclaw"]
+    assert config["remote_output_mode"] == "user"
 
 
 def test_ohmo_config_interactive_can_restart_gateway(tmp_path: Path, monkeypatch):
@@ -209,6 +214,7 @@ def test_ohmo_config_interactive_can_restart_gateway(tmp_path: Path, monkeypatch
             "",           # bot_open_id
             "y",          # send_progress
             "y",          # send_tool_hints
+            "1",          # remote_output_mode -> user
             "n",          # allow_remote_admin_commands
             "y",          # restart gateway
         ]
@@ -251,6 +257,7 @@ def test_ohmo_config_keeps_existing_channel_when_not_reconfigured(tmp_path: Path
             "n",  # reconfigure feishu? keep existing
             "y",  # send_progress
             "y",  # send_tool_hints
+            "1",  # remote_output_mode -> user
             "n",  # allow_remote_admin_commands
         ]
     )

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -1785,16 +1785,18 @@ def test_runtime_pool_includes_group_speaker_context():
 
 
 @pytest.mark.asyncio
-async def test_gateway_bridge_publishes_media_updates():
+async def test_gateway_bridge_publishes_media_updates(tmp_path):
     bus = MessageBus()
+    image_path = tmp_path / "generated.png"
+    image_path.write_bytes(b"png")
 
     class FakeRuntimePool:
         async def stream_message(self, message, session_key):
             yield SimpleNamespace(
                 kind="media",
                 text="已生成图片：generated.png",
-                media=["/tmp/generated.png"],
-                metadata={"_session_key": session_key, "_media": ["/tmp/generated.png"]},
+                media=[str(image_path)],
+                metadata={"_session_key": session_key, "_media": [str(image_path)]},
             )
 
     bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
@@ -1810,21 +1812,23 @@ async def test_gateway_bridge_publishes_media_updates():
         except asyncio.CancelledError:
             pass
 
-    assert outbound.content == "已生成图片：generated.png"
-    assert outbound.media == ["/tmp/generated.png"]
+    assert outbound.content == ""
+    assert outbound.media == [str(image_path)]
 
 
 @pytest.mark.asyncio
-async def test_gateway_bridge_publishes_final_media_updates():
+async def test_gateway_bridge_publishes_final_media_updates(tmp_path):
     bus = MessageBus()
+    image_path = tmp_path / "generated.png"
+    image_path.write_bytes(b"png")
 
     class FakeRuntimePool:
         async def stream_message(self, message, session_key):
             yield SimpleNamespace(
                 kind="final",
-                text="已生成图片：generated.png",
-                media=["/tmp/generated.png"],
-                metadata={"_session_key": session_key, "_media": ["/tmp/generated.png"]},
+                text=f"已生成图片：\n```text\n{image_path}\n```",
+                media=[str(image_path)],
+                metadata={"_session_key": session_key, "_media": [str(image_path)]},
             )
 
     bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
@@ -1840,8 +1844,47 @@ async def test_gateway_bridge_publishes_final_media_updates():
         except asyncio.CancelledError:
             pass
 
-    assert outbound.content == "已生成图片：generated.png"
-    assert outbound.media == ["/tmp/generated.png"]
+    assert outbound.content == "已生成图片。"
+    assert outbound.media == [str(image_path)]
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_cleans_local_final_paths_but_keeps_urls(tmp_path):
+    bus = MessageBus()
+    image_path = tmp_path / "generated.png"
+    image_path.write_bytes(b"png")
+
+    class FakeRuntimePool:
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="final",
+                text=(
+                    "已生成信息图：\n"
+                    f"{image_path}\n\n"
+                    "参考来源：\n"
+                    "1. https://example.com/articles/ai-trism\n"
+                    "2. Gartner overview"
+                ),
+                media=[str(image_path)],
+                metadata={"_session_key": session_key, "_media": [str(image_path)]},
+            )
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="请画信息图"))
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert str(image_path) not in outbound.content
+    assert "https://example.com/articles/ai-trism" in outbound.content
+    assert "Gartner overview" in outbound.content
 
 
 @pytest.mark.asyncio
@@ -1851,14 +1894,23 @@ async def test_gateway_bridge_publishes_progress_updates():
     class FakeRuntimePool:
         async def stream_message(self, message, session_key):
             yield SimpleNamespace(kind="progress", text="🤔 想一想…", metadata={"_progress": True, "_session_key": session_key})
-            yield SimpleNamespace(kind="tool_hint", text="🛠️ 正在使用 web_fetch: https://example.com", metadata={"_progress": True, "_tool_hint": True, "_session_key": session_key})
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ 正在使用 web_fetch: https://example.com",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "web_fetch",
+                    "_session_key": session_key,
+                },
+            )
             yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
 
     bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
     task = asyncio.create_task(bridge.run())
     try:
         await bus.publish_inbound(
-            InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="hi")
+            InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="请查一下")
         )
         first = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
         second = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
@@ -1871,12 +1923,214 @@ async def test_gateway_bridge_publishes_progress_updates():
         except asyncio.CancelledError:
             pass
 
-    assert first.content.startswith(("🤔", "🧠", "✨", "🔎", "🪄"))
+    assert first.content == "正在处理..."
     assert first.metadata["_progress"] is True
     assert second.metadata["_tool_hint"] is True
-    assert second.content.startswith("🛠️ ")
-    assert "web_fetch" in second.content
+    assert second.content == "正在检索资料..."
     assert third.content == "Done"
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_debug_mode_keeps_raw_tool_hints():
+    bus = MessageBus()
+
+    class FakeRuntimePool:
+        remote_output_mode = "debug"
+
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ Using image_generation: {\"background\": null}",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "image_generation",
+                    "_session_key": session_key,
+                },
+            )
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="draw"))
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert "Using image_generation" in outbound.content
+    assert "background" in outbound.content
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_user_mode_hides_internal_file_tool_hints(tmp_path):
+    bus = MessageBus()
+    skill_path = tmp_path / "skills" / "pat-infographic" / "SKILL.md"
+
+    class FakeRuntimePool:
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text=f"🛠️ Using read_file: {skill_path}",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "read_file",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text=f"🛠️ Using glob: {tmp_path / 'prompts' / 'infographic.md'}",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "glob",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="请画图"))
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert outbound.content == "Done"
+    assert str(tmp_path) not in outbound.content
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_user_mode_deduplicates_search_stage_hints():
+    bus = MessageBus()
+
+    class FakeRuntimePool:
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ Using web_search: Gartner AI TRiSM",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "web_search",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ Using web_fetch: https://example.com",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "web_fetch",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="查一下"))
+        first = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+        second = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert first.content == "正在检索资料..."
+    assert second.content == "Done"
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_user_mode_summarizes_image_generation_without_json():
+    bus = MessageBus()
+
+    class FakeRuntimePool:
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text='🛠️ Using image_generation: {"background": null, "image_paths": []}',
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "image_generation",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="画图"))
+        first = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+        second = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert first.content == "正在生成图片..."
+    assert "background" not in first.content
+    assert "image_paths" not in first.content
+    assert second.content == "Done"
+
+
+@pytest.mark.asyncio
+async def test_gateway_bridge_silent_mode_suppresses_progress_and_tool_hints():
+    bus = MessageBus()
+
+    class FakeRuntimePool:
+        remote_output_mode = "silent"
+
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(kind="progress", text="Thinking...", metadata={"_progress": True, "_session_key": session_key})
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ Using web_search: Gartner AI TRiSM",
+                metadata={
+                    "_progress": True,
+                    "_tool_hint": True,
+                    "_tool_name": "web_search",
+                    "_session_key": session_key,
+                },
+            )
+            yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
+
+    bridge = OhmoGatewayBridge(bus=bus, runtime_pool=FakeRuntimePool())
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="查一下"))
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert outbound.content == "Done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Normalize OHMO gateway updates for remote chat channels so users see concise progress stages instead of raw tool traces.
- Hide internal file/glob hints, local paths, and image generation JSON in user-facing mode while preserving debug mode for troubleshooting.
- Clean final replies that contain local media paths while keeping real content and source URLs.

## Notes
- Adds `remote_output_mode` with `user`, `debug`, and `silent` modes. The default is `user`.
- Tests use temporary paths only and do not depend on any local developer workspace path.

## Tests
- `uv run ruff check src tests scripts ohmo`
- `uv run pytest tests/test_ohmo/test_gateway.py -k "not stop_gateway_process_kills_matching_workspace_processes"`
- `uv run pytest tests/test_ohmo/test_cli.py`