### PR TITLE
[codex] Add project scratch directory guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ frontend/terminal/node_modules/
 # User data (never commit API keys or session data)
 .openharness/
 react_tui_smoke.txt
+openharness_tmp/
 
 # OS
 .DS_Store

--- a/src/openharness/prompts/context.py
+++ b/src/openharness/prompts/context.py
@@ -21,6 +21,22 @@ from openharness.prompts.claudemd import load_claude_md_prompt
 from openharness.prompts.system_prompt import build_system_prompt
 from openharness.skills.loader import load_skill_registry
 
+PROJECT_TMP_DIRNAME = "openharness_tmp"
+
+
+def _build_project_scratch_section(_cwd: str | Path) -> str:
+    scratch_dir = f"./{PROJECT_TMP_DIRNAME}/"
+    return "\n".join(
+        [
+            "# Project Scratch Space",
+            "- Put throwaway scripts, query dumps, evidence bundles, scratch outputs, "
+            f"and other temporary artifacts under `{scratch_dir}`.",
+            "- Do not write `.tmp*` files or one-off helper files directly in the project root.",
+            "- Keep durable deliverables in the user-requested or project-conventional location; "
+            "use the scratch directory only for disposable work.",
+        ]
+    )
+
 
 def _build_skills_section(
     cwd: str | Path,
@@ -118,6 +134,7 @@ def build_runtime_system_prompt(
         sections[0] = build_system_prompt(cwd=str(cwd))
 
     sections.append(_build_permission_mode_section(settings))
+    sections.append(_build_project_scratch_section(cwd))
 
     if settings.fast_mode:
         sections.append(

--- a/tests/test_ohmo/test_prompts.py
+++ b/tests/test_ohmo/test_prompts.py
@@ -55,6 +55,8 @@ def test_ohmo_runtime_prompt_can_exclude_project_memory(tmp_path: Path, monkeypa
 
     assert "ohmo-only personal fact" in runtime_prompt
     assert "project memory should not leak" not in runtime_prompt
+    assert "./openharness_tmp/" in runtime_prompt
+    assert "Do not write `.tmp*` files" in runtime_prompt
 
 
 def test_ohmo_memory_uses_schema_and_soft_delete(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add runtime guidance that disposable scripts, query dumps, evidence bundles, and scratch outputs should go under `./openharness_tmp/`
- ignore `openharness_tmp/` so scratch artifacts do not pollute git status
- cover the prompt guidance in the ohmo runtime prompt tests

## Why
Temporary helper files were being written directly into the project root, which made cleanup and `git status` noisy. This keeps disposable artifacts in one project-relative directory without using machine-specific absolute paths.

## Validation
- `uv run pytest tests/test_ohmo/test_prompts.py -q`
- `uv run ruff check src/openharness/prompts/context.py tests/test_ohmo/test_prompts.py`
