### PR TITLE
feat(profiles): per-profile permission_mode + effort defaults

### DIFF
--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -356,6 +356,8 @@ class AuthManager:
         allowed_models: list[str] | None = None,
         context_window_tokens: int | None = None,
         auto_compact_threshold_tokens: int | None = None,
+        permission_mode: str | None = None,
+        effort: str | None = None,
     ) -> None:
         """Update a profile in-place."""
         profiles = self.settings.merged_profiles()
@@ -384,6 +386,10 @@ class AuthManager:
                 if auto_compact_threshold_tokens is not None
                 else current.auto_compact_threshold_tokens
             ),
+            "permission_mode": (
+                permission_mode if permission_mode is not None else current.permission_mode
+            ),
+            "effort": effort if effort is not None else current.effort,
         }
         profiles[name] = current.model_copy(update=updates)
         updated = self.settings.model_copy(update={"profiles": profiles})

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -2068,6 +2068,31 @@ def provider_use(
     print(f"Activated provider profile: {name}", flush=True)
 
 
+_VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+
+
+def _validate_profile_session_defaults(permission_mode: str | None, effort: str | None) -> None:
+    """Validate optional per-profile session defaults; exit(1) on bad input."""
+    if permission_mode is not None:
+        from openharness.permissions.modes import PermissionMode
+
+        try:
+            PermissionMode(permission_mode)
+        except ValueError:
+            valid = ", ".join(m.value for m in PermissionMode)
+            print(
+                f"Error: invalid --permission-mode {permission_mode!r}; choose one of: {valid}",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
+    if effort is not None and effort not in _VALID_EFFORTS:
+        print(
+            f"Error: invalid --effort {effort!r}; choose one of: {', '.join(sorted(_VALID_EFFORTS))}",
+            file=sys.stderr,
+        )
+        raise typer.Exit(1)
+
+
 @provider_app.command("add")
 def provider_add(
     name: str = typer.Argument(..., help="Provider profile name"),
@@ -2082,11 +2107,14 @@ def provider_add(
     allowed_models: list[str] | None = typer.Option(None, "--allowed-model", help="Allowed model values for this profile"),
     context_window_tokens: int | None = typer.Option(None, "--context-window-tokens", help="Optional context window override for auto-compact"),
     auto_compact_threshold_tokens: int | None = typer.Option(None, "--auto-compact-threshold-tokens", help="Optional explicit auto-compact threshold override"),
+    permission_mode: str | None = typer.Option(None, "--permission-mode", help="Per-profile default permission mode (default, plan, full_auto)"),
+    effort: str | None = typer.Option(None, "--effort", help="Per-profile default effort (low, medium, high, xhigh/max)"),
 ) -> None:
     """Create a provider profile."""
     from openharness.auth.manager import AuthManager
     from openharness.config.settings import ProviderProfile
 
+    _validate_profile_session_defaults(permission_mode, effort)
     manager = AuthManager()
     manager.upsert_profile(
         name,
@@ -2102,6 +2130,8 @@ def provider_add(
             allowed_models=allowed_models or ([model] if credential_slot or _default_credential_slot_for_profile(name, auth_source) else []),
             context_window_tokens=context_window_tokens,
             auto_compact_threshold_tokens=auto_compact_threshold_tokens,
+            permission_mode=permission_mode,
+            effort=effort,
         ),
     )
     if api_key is not None:
@@ -2126,10 +2156,13 @@ def provider_edit(
     allowed_models: list[str] | None = typer.Option(None, "--allowed-model", help="Allowed model values for this profile"),
     context_window_tokens: int | None = typer.Option(None, "--context-window-tokens", help="Optional context window override for auto-compact"),
     auto_compact_threshold_tokens: int | None = typer.Option(None, "--auto-compact-threshold-tokens", help="Optional explicit auto-compact threshold override"),
+    permission_mode: str | None = typer.Option(None, "--permission-mode", help="Per-profile default permission mode (default, plan, full_auto)"),
+    effort: str | None = typer.Option(None, "--effort", help="Per-profile default effort (low, medium, high, xhigh/max)"),
 ) -> None:
     """Edit a provider profile."""
     from openharness.auth.manager import AuthManager
 
+    _validate_profile_session_defaults(permission_mode, effort)
     manager = AuthManager()
     try:
         manager.update_profile(
@@ -2145,6 +2178,8 @@ def provider_edit(
             allowed_models=allowed_models,
             context_window_tokens=context_window_tokens,
             auto_compact_threshold_tokens=auto_compact_threshold_tokens,
+            permission_mode=permission_mode,
+            effort=effort,
         )
         if api_key is not None:
             manager = AuthManager()

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -135,6 +135,12 @@ class ProviderProfile(BaseModel):
     allowed_models: list[str] = Field(default_factory=list)
     context_window_tokens: int | None = None
     auto_compact_threshold_tokens: int | None = None
+    # Codex-style per-profile session defaults. When set, these become the
+    # session's permission mode / effort UNLESS overridden by a CLI flag
+    # (CLI > profile > global). `None` means "inherit the global default" —
+    # so existing profiles behave exactly as before.
+    permission_mode: str | None = None
+    effort: str | None = None
 
     @property
     def resolved_model(self) -> str:
@@ -640,6 +646,20 @@ class Settings(BaseModel):
         """Project the active profile back onto legacy flat settings fields."""
         profile_name, profile = self.resolve_profile()
         configured_model = (profile.last_model or "").strip() or profile.default_model
+        # Per-profile session defaults (Codex-style). Only override the global
+        # value when the profile sets a VALID one — an unset/invalid field
+        # leaves today's behavior byte-identical (and an invalid value never
+        # crashes load_settings). CLI flags still win: merge_cli_overrides runs
+        # after this and overrides only when its flag is non-None.
+        permission = self.permission
+        if profile.permission_mode:
+            try:
+                permission = self.permission.model_copy(
+                    update={"mode": PermissionMode(profile.permission_mode)}
+                )
+            except ValueError:
+                permission = self.permission
+        effort = profile.effort or self.effort
         return self.model_copy(
             update={
                 "active_profile": profile_name,
@@ -649,6 +669,8 @@ class Settings(BaseModel):
                 "base_url": profile.base_url,
                 "context_window_tokens": profile.context_window_tokens,
                 "auto_compact_threshold_tokens": profile.auto_compact_threshold_tokens,
+                "permission": permission,
+                "effort": effort,
                 "model": resolve_model_setting(
                     configured_model,
                     profile.provider,

--- a/tests/test_commands/test_cli.py
+++ b/tests/test_commands/test_cli.py
@@ -557,3 +557,48 @@ def test_autopilot_export_dashboard_cli(monkeypatch, tmp_path: Path):
 
     assert result.exit_code == 0
     assert "Exported autopilot dashboard" in result.output
+
+
+def test_provider_add_stores_session_defaults(tmp_path: Path, monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path))
+
+    result = runner.invoke(
+        app,
+        [
+            "provider", "add", "custom-claude",
+            "--label", "Custom Claude",
+            "--provider", "anthropic",
+            "--api-format", "anthropic",
+            "--auth-source", "anthropic_api_key",
+            "--model", "claude-sonnet-4-6",
+            "--permission-mode", "plan",
+            "--effort", "high",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    profile = load_settings().profiles["custom-claude"]
+    assert profile.permission_mode == "plan"
+    assert profile.effort == "high"
+
+
+def test_provider_add_rejects_invalid_permission_mode(tmp_path: Path, monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path))
+
+    result = runner.invoke(
+        app,
+        [
+            "provider", "add", "bad",
+            "--label", "Bad",
+            "--provider", "anthropic",
+            "--api-format", "anthropic",
+            "--auth-source", "anthropic_api_key",
+            "--model", "claude-sonnet-4-6",
+            "--permission-mode", "nope",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "invalid --permission-mode" in result.output

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -912,3 +912,60 @@ class TestModelScopeProvider:
         assert materialized.model == "deepseek-ai/DeepSeek-V4-Flash"
         assert materialized.provider == "modelscope"
         assert materialized.api_format == "openai"
+
+
+class TestProfileSessionDefaults:
+    """Codex-style per-profile permission_mode / effort defaults (slice #3)."""
+
+    def _profile(self, **overrides) -> ProviderProfile:
+        base = dict(
+            label="Custom",
+            provider="anthropic",
+            api_format="anthropic",
+            auth_source="anthropic_api_key",
+            default_model="claude-sonnet-4-6",
+        )
+        base.update(overrides)
+        return ProviderProfile(**base)
+
+    def test_round_trips_through_json(self):
+        s = Settings(
+            active_profile="custom",
+            profiles={"custom": self._profile(permission_mode="plan", effort="high")},
+        )
+        restored = Settings.model_validate(json.loads(s.model_dump_json()))
+        prof = restored.profiles["custom"]
+        assert prof.permission_mode == "plan"
+        assert prof.effort == "high"
+
+    def test_defaults_are_none(self):
+        prof = self._profile()
+        assert prof.permission_mode is None
+        assert prof.effort is None
+
+    def test_materialize_projects_profile_defaults(self):
+        s = Settings(
+            active_profile="custom",
+            profiles={"custom": self._profile(permission_mode="plan", effort="high")},
+        )
+        materialized = s.materialize_active_profile()
+        assert materialized.permission.mode.value == "plan"
+        assert materialized.effort == "high"
+
+    def test_materialize_leaves_globals_when_profile_unset(self):
+        # Regression guard: a profile that sets neither field must not change
+        # the global permission mode / effort (byte-identical to old behavior).
+        s = Settings(active_profile="custom", profiles={"custom": self._profile()})
+        materialized = s.materialize_active_profile()
+        assert materialized.permission.mode.value == "default"
+        assert materialized.effort == "medium"
+
+    def test_materialize_ignores_invalid_permission_mode(self):
+        # An invalid profile value must never crash load/materialize; the
+        # global default is kept.
+        s = Settings(
+            active_profile="custom",
+            profiles={"custom": self._profile(permission_mode="bogus")},
+        )
+        materialized = s.materialize_active_profile()
+        assert materialized.permission.mode.value == "default"


### PR DESCRIPTION
Codex-style named-profile session defaults: `ProviderProfile` gains optional `permission_mode` + `effort`, projected at session start with **CLI > profile > global** precedence (unset/invalid = no-op, never crashes load). `oh provider add/edit` gain validated `--permission-mode`/`--effort` flags. 84 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)