### PR TITLE
feat(sandbox): in-process filesystem path policy (L1) + enforcement

### DIFF
--- a/plans/os-sandbox.plan.md
+++ b/plans/os-sandbox.plan.md
@@ -1,0 +1,193 @@
+<plan id="oh-os-sandbox" title="OS-level sandboxing mapped to OH permission modes">
+
+<status>DESIGN PLAN — NON-SHIPPING. This file is a plan, not the feature. No
+runtime behavior changes until tasks T1–T6 land (each separately reviewed +
+verified). Committing this file alone changes nothing.</status>
+
+<context>
+OH gates tool calls through `PermissionChecker.evaluate()` (permissions/checker.py:75)
+in three modes — `default` / `plan` / `full_auto` (permissions/modes.py) — called from
+the ONE tool-execution chokepoint `engine/query.py::_execute_tool_call()` (~887–981),
+just before `tool.execute()` (~970).
+
+What already exists:
+- <item>`SandboxSettings` (config/settings.py:104–114): `enabled` (default False), `backend`
+  ("srt"|"docker"), `network` (allow/deny domains), `filesystem` (allow_read/deny_read/
+  allow_write/deny_write; default allow_write=["."]), docker limits.</item>
+- <item>An optional **`srt`** (sandbox-runtime npm CLI) integration that wraps the BASH
+  SUBPROCESS only: `utils/shell.py::create_shell_subprocess()` → `wrap_command_for_sandbox()`
+  (sandbox/adapter.py:105) prepends `srt --settings <json> -c <cmd>`, which on macOS uses
+  `sandbox-exec` and on Linux `bwrap`. Disabled by default; requires the npm CLI present.</item>
+- <item>`platforms.py::detect_platform()` + `get_platform_capabilities()` already report
+  `supports_sandbox_runtime` / `supports_docker_sandbox` per OS.</item>
+
+The two gaps that matter:
+- <gap id="G1">**File-write/edit tools ignore the path policy.** `tools/file_write_tool.py:59` and
+  `file_edit_tool.py:67` call `path.write_text(...)` IN-PROCESS and only run Docker path
+  validation — they never consult `SandboxSettings.filesystem.allow_write/deny_write`, nor the
+  permission checker's path intent. A `full_auto` (or even `default` after one approval) agent can
+  write anywhere the user can.</gap>
+- <gap id="G2">**No OS sandbox by default, and none at all for in-process tools.** The only OS
+  isolation is opt-in `srt` around bash. File reads/writes, grep, etc. run unsandboxed in the OH
+  process.</gap>
+</context>
+
+<key-design-decision id="why-two-layers">
+A full syscall sandbox (Apple Seatbelt / Linux Landlock+seccomp) of OH is **fundamentally partial**
+because most tools run IN-PROCESS:
+- <item>`sandbox-exec` (Seatbelt) wraps a process **at spawn** — it cannot retroactively confine an
+  already-running Python interpreter, so it can only sandbox the bash SUBPROCESS, not in-process
+  `write_text`.</item>
+- <item>Landlock CAN self-restrict the current process, but it is **irreversible per-thread and
+  monotonic** — applying it would also confine OH's own legitimate I/O (session storage under
+  `~/.openharness`, config, logs) for the rest of the run. You cannot "enter then exit" a Landlock
+  ruleset around a single tool call.</item>
+
+Therefore the enforceable, robust design is **two layers**, not one:
+1. <layer id="L1">**Policy at the tool boundary (in-process).** Enforce `allow_write`/`deny_write`/
+   `deny_read` + the always-blocked sensitive paths in the file tools themselves, derived from the
+   permission mode. This closes G1 and is the real guarantee for in-process side effects.</layer>
+2. <layer id="L2">**OS sandbox where it is actually enforceable (the bash subprocess).** Apply a
+   native Seatbelt profile (macOS) / Landlock+seccomp via `bwrap` or a small launcher (Linux) to the
+   bash child, mapped to the mode — without depending on the external `srt` npm CLI. Keep `srt` as an
+   optional backend; add a native backend so the default install is sandboxed out of the box.</layer>
+
+This is the honest version of "Codex-style read-only / workspace-write / danger-full-access": Codex
+gets full syscall confinement because its agent process IS the sandbox boundary; OH's agent is
+in-process, so L1 carries the in-process guarantee and L2 confines the one real subprocess.
+</key-design-decision>
+
+<goal>
+Make `plan` / `default` / `full_auto` enforce a real, consistent filesystem+network policy across
+BOTH in-process file tools and the bash subprocess, on by default, with no external runtime
+dependency — mapped to read-only / workspace-write / full-access tiers.
+</goal>
+
+<non-goals>
+- <item>Full seccomp syscall filtering of the entire OH interpreter (breaks OH's own I/O; see
+  why-two-layers). Landlock/seccomp apply to the bash child only.</item>
+- <item>Network egress filtering for in-process HTTP (the LLM/API calls OH itself makes). L2 network
+  policy applies to bash-spawned processes; in-process domain control is a separate, later effort.</item>
+- <item>Windows OS sandboxing (no Seatbelt/Landlock equivalent wired). Windows keeps L1 path policy
+  only; document the gap.</item>
+- <item>Removing the existing `srt`/docker backends. They remain selectable; we ADD a native backend
+  and the L1 enforcement.</item>
+</non-goals>
+
+<decisions>
+<decision id="D1" status="resolved">
+  <q>Where does the in-process filesystem guarantee live?</q>
+  <a>In the file tools (L1), enforced via a shared `permissions` path-policy helper, NOT via OS
+  syscalls. The file tools already receive the resolved path; they must check it against the
+  mode-derived allow/deny set before `write_text`. This is the only point that can confine in-process
+  writes.</a>
+</decision>
+<decision id="D2" status="resolved">
+  <q>Native OS sandbox vs the existing `srt` dependency for bash?</q>
+  <a>Add a NATIVE backend (`backend="native"`, becomes default): macOS emits a generated
+  `sandbox-exec` profile; Linux uses `bwrap` if present else a Landlock+seccomp launcher. Keep
+  `srt`/`docker` as opt-in backends. Native default means the protection ships without an npm install.</a>
+</decision>
+<decision id="D3" status="resolved">
+  <q>Mode → policy mapping.</q>
+  <a>`plan` → read-only (no writes anywhere; L1 already blocks mutating tools, L2 read-only profile is
+  defense-in-depth). `default` → workspace-write (writes restricted to cwd + `allow_write`, minus
+  `deny_write` and sensitive paths; per-call confirmation unchanged). `full_auto` → full-access
+  (no path restriction beyond the always-blocked sensitive paths — see D5).</a>
+</decision>
+<decision id="D4" status="resolved">
+  <q>Does `full_auto` keep the hardcoded sensitive-path denylist (.ssh, .aws/credentials, .gnupg…)?</q>
+  <a>RESOLVED (user-confirmed): yes — even full-access blocks the sensitive-path set (checker.py:18–37)
+  in BOTH layers, so "dangerously skip permissions" still can't exfiltrate SSH/cloud creds by default.
+  A separate explicit opt-in would be required to disable even that. Implemented in L1 (path_policy).</a>
+</decision>
+<decision id="D5" status="resolved">
+  <q>Fail-open or fail-closed when the OS sandbox is unavailable (no bwrap, Landlock unsupported
+  kernel, etc.)?</q>
+  <a>RESOLVED (user-confirmed): L1 (in-process path policy) ALWAYS applies (pure Python, always
+  available). L2 (bash OS sandbox) honors `SandboxSettings.fail_if_unavailable`: default fail-OPEN with
+  a one-time warning (bash runs unsandboxed but L1 still constrains file tools), opt-in fail-CLOSED.</a>
+</decision>
+<decision id="D6" status="resolved">
+  <q>How aggressive is the default-on posture?</q>
+  <a>RESOLVED (user-confirmed): L1 (file-tool path enforcement) is ON by default — the bigger real
+  security win and low-surprise. L2 (OS bash sandbox) stays OPT-IN so it can't surprise users whose
+  bash relies on broad filesystem access.</a>
+</decision>
+</decisions>
+
+<architecture>
+<module id="path-policy">New `openharness/permissions/path_policy.py`: `resolve_write_policy(mode, sandbox_settings, cwd)
+→ PathPolicy` with `is_write_allowed(path)` / `is_read_allowed(path)`, folding in the sensitive-path
+denylist + `allow_write`/`deny_write` + workspace root. Pure, unit-testable, platform-independent.</module>
+<wire id="L1-file-tools">file_write_tool.py / file_edit_tool.py call `path_policy.is_write_allowed()`
+before `write_text`; on deny return the existing tool-error shape (no write). Same for any future
+mutating file tool.</wire>
+<module id="os-sandbox">New `openharness/sandbox/os_sandbox.py`: `build_native_bash_wrapper(argv, cwd, mode, sandbox_settings)
+→ wrapped_argv` (+ temp profile cleanup). macOS: write a `sandbox-exec -p <profile>` profile string for
+the tier; Linux: `bwrap` arg set, or a Landlock+seccomp pre-exec launcher. Selected by `platforms.py`.</module>
+<wire id="L2-bash">utils/shell.py::create_shell_subprocess routes to the native wrapper when
+`backend=="native"` (new default), keeping the existing `srt`/`docker` branches.</wire>
+</architecture>
+
+<resolved-questions audience="user">
+<q id="Q1" answer="yes">D4: sensitive-path denylist stays enforced even under `full_auto`.</q>
+<q id="Q2" answer="fail-open+warn">D5: bash OS-sandbox unavailable → fail-open with a one-time warning (L1 still applies); opt-in fail-closed.</q>
+<q id="Q3" answer="L1-on, L2-opt-in">D6: L1 file-tool path enforcement is on by default; the OS bash sandbox stays opt-in.</q>
+</resolved-questions>
+
+<tasks>
+<task id="T1" depends="none">
+  <title>path_policy module + unit tests</title>
+  <what>Add `permissions/path_policy.py` (resolve_write_policy / is_write_allowed / is_read_allowed)
+  folding sensitive-path denylist + allow_write/deny_write + cwd workspace root, per mode.</what>
+  <files>src/openharness/permissions/path_policy.py, tests/test_permissions/test_path_policy.py</files>
+  <verification>Unit: plan→all writes denied; default→cwd allowed, ~/.ssh denied, deny_write honored;
+  full_auto→cwd+outside allowed but sensitive paths still denied (D4). Symlink-escape of cwd denied.</verification>
+</task>
+<task id="T2" depends="T1">
+  <title>L1: enforce path policy in file-write/edit tools (closes G1)</title>
+  <what>file_write_tool/file_edit_tool consult path_policy before write_text; deny → tool error, no
+  write. Thread the active mode + SandboxSettings into the tools.</what>
+  <files>src/openharness/tools/file_write_tool.py, file_edit_tool.py, (tool ctx plumbing)</files>
+  <verification>A write outside policy returns an error and leaves the FS unchanged (assert file absent);
+  an in-policy write succeeds. Regression: existing file-tool tests still pass.</verification>
+</task>
+<task id="T3" depends="none">
+  <title>Native bash sandbox wrapper (macOS Seatbelt)</title>
+  <what>os_sandbox.build_native_bash_wrapper for macOS: generate a sandbox-exec profile per tier
+  (read-only / workspace-write / full-access).</what>
+  <files>src/openharness/sandbox/os_sandbox.py, tests/test_sandbox/test_os_sandbox.py</files>
+  <verification>On macOS: plan-tier wrapped bash cannot write a temp file (nonzero); workspace-write can
+  write under cwd but not ~/; full-access writes both. Skipped on non-macOS.</verification>
+</task>
+<task id="T4" depends="T3">
+  <title>Native bash sandbox (Linux bwrap / Landlock+seccomp)</title>
+  <what>Linux arm of build_native_bash_wrapper: bwrap arg set if present, else Landlock+seccomp
+  pre-exec launcher; same three tiers.</what>
+  <files>src/openharness/sandbox/os_sandbox.py, tests/test_sandbox/test_os_sandbox.py</files>
+  <verification>On Linux: same write-confinement assertions per tier; graceful fallback path covered.</verification>
+</task>
+<task id="T5" depends="T3,T4">
+  <title>Wire native backend into shell + default flip</title>
+  <what>create_shell_subprocess routes backend=="native" to the wrapper; map permission mode → tier;
+  honor fail_if_unavailable (D5). Make native the default backend per D2/Q3 (pending user answer).</what>
+  <files>src/openharness/utils/shell.py, src/openharness/sandbox/adapter.py, config/settings.py (default)</files>
+  <verification>Integration: a `default`-mode bash session writing outside cwd is blocked by L2 on
+  macOS+Linux; unavailable-sandbox path fails open with a single warning (or closed if configured).</verification>
+</task>
+<task id="T6" depends="T2,T5">
+  <title>Docs + mode/tier mapping reference</title>
+  <what>Document the two-layer model, the Windows L1-only gap, and the D4/D5 defaults in OH docs.</what>
+  <files>docs/ (sandbox reference)</files>
+  <verification>Doc lists each mode→tier→both-layer behavior + platform support matrix.</verification>
+</task>
+</tasks>
+
+<verification-summary>
+Feature ships only when T1–T5 are implemented + verified. T1+T2 (L1 path enforcement) deliver the
+biggest real security gain independent of OS support and should land first; T3–T5 (L2 OS sandbox)
+add subprocess confinement and the default flip.
+</verification-summary>
+
+</plan>

--- a/src/openharness/permissions/active_policy.py
+++ b/src/openharness/permissions/active_policy.py
@@ -1,0 +1,35 @@
+"""Process-level registry for the active in-process path policy (sandbox L1).
+
+Mirrors ``sandbox.session``'s Docker registry: a single policy is installed at
+session start (``ui.runtime.build_runtime``) and read by the in-process file
+tools before they write. When NO policy is installed — e.g. unit tests that call
+a tool directly, or non-session callers — enforcement is skipped (fail-open), so
+the policy never affects code paths that don't run a real session.
+
+Single-policy-per-process (same constraint as the Docker session registry): fine
+because in-process OH runs one session per process; the swarm runs its workers as
+separate subprocesses, each with its own registry.
+"""
+
+from __future__ import annotations
+
+from openharness.permissions.path_policy import PathPolicy
+
+_active_policy: PathPolicy | None = None
+
+
+def set_active_path_policy(policy: PathPolicy | None) -> None:
+    """Install (or clear, with ``None``) the process-wide active path policy."""
+    global _active_policy  # noqa: PLW0603
+    _active_policy = policy
+
+
+def get_active_path_policy() -> PathPolicy | None:
+    """Return the active path policy, or ``None`` when none is installed."""
+    return _active_policy
+
+
+def clear_active_path_policy() -> None:
+    """Remove the active path policy (session teardown)."""
+    global _active_policy  # noqa: PLW0603
+    _active_policy = None

--- a/src/openharness/permissions/path_policy.py
+++ b/src/openharness/permissions/path_policy.py
@@ -1,0 +1,136 @@
+"""In-process filesystem path policy (sandbox layer L1).
+
+Single, platform-independent answer to "may a tool write/read this path?",
+derived from the permission mode + the sandbox filesystem settings. This is the
+enforcement layer that the in-process file tools (write_file / edit_file) must
+consult before touching the filesystem — today they don't, so an approved
+mutating tool can write anywhere the user can. It does NOT do OS-level syscall
+sandboxing (that is the bash-subprocess layer, L2); see
+``plans/os-sandbox.plan.md`` for the full two-layer design.
+
+Tier mapping (plan decision D3):
+    plan      -> read-only       (no writes anywhere)
+    default   -> workspace-write  (writes within allow_write roots, minus deny_write)
+    full_auto -> full-access      (writes anywhere EXCEPT the sensitive denylist)
+
+The built-in ``SENSITIVE_PATH_PATTERNS`` denylist (~/.ssh, ~/.aws/credentials,
+~/.gnupg, OH's own credential stores, …) is enforced in EVERY tier, including
+``full_auto`` (decision D4), as defence-in-depth against prompt-injection-directed
+credential access. Disabling even that would require a separate explicit opt-in.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from pathlib import Path
+
+from openharness.config.settings import SandboxFilesystemSettings, SandboxSettings
+from openharness.permissions.checker import SENSITIVE_PATH_PATTERNS
+from openharness.permissions.modes import PermissionMode
+
+
+@dataclass(frozen=True)
+class PathDecision:
+    """Whether a path operation is permitted, with a human-readable reason."""
+
+    allowed: bool
+    reason: str = ""
+
+
+def _match_forms(path_str: str) -> tuple[str, ...]:
+    """Path forms used for glob matching.
+
+    Mirror ``permissions.checker._policy_match_paths``: append a trailing slash so
+    directory-rooted patterns like ``*/.ssh/*`` also match the directory itself.
+    """
+    normalized = path_str.rstrip("/")
+    if not normalized:
+        return (path_str,)
+    return (normalized, normalized + "/")
+
+
+def _first_match(path_forms: tuple[str, ...], patterns: list[str] | tuple[str, ...]) -> str | None:
+    for candidate in path_forms:
+        for pattern in patterns:
+            if isinstance(pattern, str) and fnmatch.fnmatch(candidate, pattern):
+                return pattern
+    return None
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+class PathPolicy:
+    """Resolved per-session filesystem policy (mode + sandbox fs settings + cwd)."""
+
+    def __init__(
+        self,
+        mode: PermissionMode,
+        filesystem: SandboxFilesystemSettings,
+        cwd: str | Path,
+    ) -> None:
+        self._mode = mode
+        self._fs = filesystem
+        self._cwd = Path(cwd).resolve()
+        # allow_write entries ("." and other relative ones) resolve against cwd.
+        self._write_roots = [self._resolve(entry) for entry in (filesystem.allow_write or [])]
+
+    def _resolve(self, file_path: str | Path) -> Path:
+        p = Path(file_path)
+        if not p.is_absolute():
+            p = self._cwd / p
+        # Resolve symlinks + ".." so an escape like cwd/../../etc/x can't slip past
+        # the workspace-root containment check. strict=False: target may not exist.
+        return p.resolve()
+
+    def is_write_allowed(self, file_path: str | Path) -> PathDecision:
+        resolved = self._resolve(file_path)
+        forms = _match_forms(str(resolved))
+
+        # 1. Sensitive denylist — enforced in EVERY tier, incl. full_auto (D4).
+        hit = _first_match(forms, SENSITIVE_PATH_PATTERNS)
+        if hit is not None:
+            return PathDecision(False, f"{resolved} is a sensitive credential path (pattern '{hit}')")
+
+        # 2. Explicit deny_write globs — always deny.
+        hit = _first_match(forms, self._fs.deny_write or [])
+        if hit is not None:
+            return PathDecision(False, f"{resolved} matches deny_write pattern '{hit}'")
+
+        # 3. Tier.
+        if self._mode == PermissionMode.PLAN:
+            return PathDecision(False, "plan mode is read-only; writes are blocked")
+        if self._mode == PermissionMode.FULL_AUTO:
+            return PathDecision(True, "full-access mode")
+        # default -> workspace-write: must live under an allow_write root.
+        if any(_is_within(resolved, root) for root in self._write_roots):
+            return PathDecision(True, "within an allowed write root")
+        roots = [str(r) for r in self._write_roots]
+        return PathDecision(False, f"{resolved} is outside the allowed write roots {roots}")
+
+    def is_read_allowed(self, file_path: str | Path) -> PathDecision:
+        resolved = self._resolve(file_path)
+        forms = _match_forms(str(resolved))
+
+        hit = _first_match(forms, SENSITIVE_PATH_PATTERNS)
+        if hit is not None:
+            return PathDecision(False, f"{resolved} is a sensitive credential path (pattern '{hit}')")
+        hit = _first_match(forms, self._fs.deny_read or [])
+        if hit is not None:
+            return PathDecision(False, f"{resolved} matches deny_read pattern '{hit}'")
+        return PathDecision(True, "reads allowed")
+
+
+def build_path_policy(
+    mode: PermissionMode,
+    sandbox: SandboxSettings,
+    cwd: str | Path,
+) -> PathPolicy:
+    """Construct a :class:`PathPolicy` from a ``SandboxSettings`` + mode + cwd."""
+    return PathPolicy(mode, sandbox.filesystem, cwd)

--- a/src/openharness/tools/file_edit_tool.py
+++ b/src/openharness/tools/file_edit_tool.py
@@ -33,6 +33,19 @@ class FileEditTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        # Sandbox layer L1: in-process path policy (no-op when no session policy
+        # is installed). Blocks edits outside the workspace + on sensitive paths.
+        from openharness.permissions.active_policy import get_active_path_policy
+
+        policy = get_active_path_policy()
+        if policy is not None:
+            decision = policy.is_write_allowed(path)
+            if not decision.allowed:
+                return ToolResult(
+                    output=f"Edit blocked by sandbox policy: {decision.reason}",
+                    is_error=True,
+                )
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():

--- a/src/openharness/tools/file_write_tool.py
+++ b/src/openharness/tools/file_write_tool.py
@@ -32,6 +32,20 @@ class FileWriteTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        # Sandbox layer L1: in-process path policy (no-op when no session policy
+        # is installed). Confines writes to the workspace + blocks sensitive
+        # credential paths per the active permission mode.
+        from openharness.permissions.active_policy import get_active_path_policy
+
+        policy = get_active_path_policy()
+        if policy is not None:
+            decision = policy.is_write_allowed(path)
+            if not decision.allowed:
+                return ToolResult(
+                    output=f"Write blocked by sandbox policy: {decision.reason}",
+                    is_error=True,
+                )
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -436,6 +436,17 @@ async def build_runtime(
         )
         engine.load_messages(restored)
 
+    # Sandbox layer L1: install the in-process filesystem path policy (on by
+    # default). Confines file-tool writes to the workspace + always blocks
+    # sensitive credential paths, per the active permission mode. The OS bash
+    # sandbox (L2) and Docker backend remain opt-in. See plans/os-sandbox.plan.md.
+    from openharness.permissions.active_policy import set_active_path_policy
+    from openharness.permissions.path_policy import build_path_policy
+
+    set_active_path_policy(
+        build_path_policy(settings.permission.mode, settings.sandbox, cwd)
+    )
+
     # Start Docker sandbox if configured
     if settings.sandbox.enabled and settings.sandbox.backend == "docker":
         from openharness.sandbox.session import start_docker_sandbox
@@ -482,8 +493,10 @@ async def start_runtime(bundle: RuntimeBundle) -> None:
 async def close_runtime(bundle: RuntimeBundle) -> None:
     """Close runtime-owned resources."""
     from openharness.sandbox.session import stop_docker_sandbox
+    from openharness.permissions.active_policy import clear_active_path_policy
 
     await stop_docker_sandbox()
+    clear_active_path_policy()
     # Extract local environment rules from session before closing
     try:
         from openharness.personalization.session_hook import update_rules_from_session

--- a/tests/test_permissions/test_file_tool_policy.py
+++ b/tests/test_permissions/test_file_tool_policy.py
@@ -1,0 +1,90 @@
+"""File tools honor the active sandbox path policy (L1 enforcement, sandbox T2)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from openharness.config.settings import SandboxFilesystemSettings
+from openharness.permissions.active_policy import (
+    clear_active_path_policy,
+    set_active_path_policy,
+)
+from openharness.permissions.modes import PermissionMode
+from openharness.permissions.path_policy import PathPolicy
+from openharness.tools.base import ToolExecutionContext
+from openharness.tools.file_edit_tool import FileEditTool, FileEditToolInput
+from openharness.tools.file_write_tool import FileWriteTool, FileWriteToolInput
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy():
+    clear_active_path_policy()
+    yield
+    clear_active_path_policy()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _install(mode: PermissionMode, cwd: Path, **fs) -> None:
+    set_active_path_policy(PathPolicy(mode, SandboxFilesystemSettings(**fs), cwd))
+
+
+def test_write_allowed_within_workspace(tmp_path: Path):
+    _install(PermissionMode.DEFAULT, tmp_path)
+    ctx = ToolExecutionContext(cwd=tmp_path)
+    result = _run(FileWriteTool().execute(FileWriteToolInput(path="out.txt", content="hi"), ctx))
+    assert result.is_error is False
+    assert (tmp_path / "out.txt").read_text() == "hi"
+
+
+def test_write_blocked_outside_workspace(tmp_path: Path):
+    _install(PermissionMode.DEFAULT, tmp_path)
+    ctx = ToolExecutionContext(cwd=tmp_path)
+    outside = tmp_path.parent / "escape.txt"
+    result = _run(FileWriteTool().execute(FileWriteToolInput(path=str(outside), content="x"), ctx))
+    assert result.is_error is True
+    assert "blocked by sandbox policy" in result.output
+    assert not outside.exists()
+
+
+def test_write_blocks_sensitive_under_full_auto(tmp_path: Path):
+    # Decision D4: even full-access cannot write credential paths.
+    _install(PermissionMode.FULL_AUTO, tmp_path)
+    ctx = ToolExecutionContext(cwd=tmp_path)
+    result = _run(FileWriteTool().execute(FileWriteToolInput(path=".ssh/id_rsa", content="K"), ctx))
+    assert result.is_error is True
+    assert not (tmp_path / ".ssh" / "id_rsa").exists()
+
+
+def test_no_policy_means_no_enforcement(tmp_path: Path):
+    # Without an installed policy (direct callers / unit tests) writes are
+    # unaffected — guards against regressing existing behavior.
+    outside = tmp_path.parent / "free.txt"
+    ctx = ToolExecutionContext(cwd=tmp_path)
+    result = _run(FileWriteTool().execute(FileWriteToolInput(path=str(outside), content="y"), ctx))
+    assert result.is_error is False
+    assert outside.read_text() == "y"
+    outside.unlink()
+
+
+def test_edit_blocked_outside_workspace(tmp_path: Path):
+    outside = tmp_path.parent / "ext.txt"
+    outside.write_text("hello world")
+    try:
+        _install(PermissionMode.DEFAULT, tmp_path)
+        ctx = ToolExecutionContext(cwd=tmp_path)
+        result = _run(
+            FileEditTool().execute(
+                FileEditToolInput(path=str(outside), old_str="hello", new_str="bye"), ctx
+            )
+        )
+        assert result.is_error is True
+        assert "blocked by sandbox policy" in result.output
+        assert outside.read_text() == "hello world"  # unchanged
+    finally:
+        outside.unlink()

--- a/tests/test_permissions/test_path_policy.py
+++ b/tests/test_permissions/test_path_policy.py
@@ -1,0 +1,85 @@
+"""Tests for openharness.permissions.path_policy (sandbox layer L1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openharness.config.settings import SandboxFilesystemSettings, SandboxSettings
+from openharness.permissions.modes import PermissionMode
+from openharness.permissions.path_policy import PathPolicy, build_path_policy
+
+
+def _policy(mode: PermissionMode, cwd: Path, **fs) -> PathPolicy:
+    return PathPolicy(mode, SandboxFilesystemSettings(**fs), cwd)
+
+
+def test_plan_mode_blocks_all_writes(tmp_path: Path):
+    p = _policy(PermissionMode.PLAN, tmp_path)
+    assert p.is_write_allowed(tmp_path / "file.txt").allowed is False
+
+
+def test_default_mode_allows_within_cwd(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path)
+    assert p.is_write_allowed(tmp_path / "sub" / "file.txt").allowed is True
+
+
+def test_default_mode_blocks_outside_cwd(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path)
+    assert p.is_write_allowed(tmp_path.parent / "outside.txt").allowed is False
+
+
+def test_default_mode_blocks_parent_escape(tmp_path: Path):
+    # cwd/../escape resolves outside the workspace root -> denied.
+    p = _policy(PermissionMode.DEFAULT, tmp_path)
+    assert p.is_write_allowed(tmp_path / ".." / "escape.txt").allowed is False
+
+
+def test_full_auto_allows_outside_cwd(tmp_path: Path):
+    p = _policy(PermissionMode.FULL_AUTO, tmp_path)
+    assert p.is_write_allowed(tmp_path.parent / "anywhere.txt").allowed is True
+
+
+def test_sensitive_paths_blocked_in_every_tier(tmp_path: Path):
+    sensitive = tmp_path / ".ssh" / "id_rsa"
+    for mode in (PermissionMode.DEFAULT, PermissionMode.FULL_AUTO, PermissionMode.PLAN):
+        decision = _policy(mode, tmp_path).is_write_allowed(sensitive)
+        assert decision.allowed is False, mode
+        assert "sensitive" in decision.reason
+
+
+def test_full_auto_still_blocks_sensitive(tmp_path: Path):
+    # Decision D4: even full-access cannot write SSH/cloud credential paths.
+    p = _policy(PermissionMode.FULL_AUTO, tmp_path)
+    assert p.is_write_allowed(tmp_path / ".aws" / "credentials").allowed is False
+
+
+def test_deny_write_glob_blocks_even_within_cwd(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path, allow_write=["."], deny_write=["*/secret/*"])
+    assert p.is_write_allowed(tmp_path / "secret" / "key.txt").allowed is False
+
+
+def test_deny_write_overrides_full_auto(tmp_path: Path):
+    p = _policy(PermissionMode.FULL_AUTO, tmp_path, deny_write=["*/protected/*"])
+    assert p.is_write_allowed(tmp_path.parent / "protected" / "x").allowed is False
+
+
+def test_reads_allowed_by_default(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path)
+    assert p.is_read_allowed(tmp_path.parent / "anything.txt").allowed is True
+
+
+def test_reads_block_sensitive(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path)
+    assert p.is_read_allowed(tmp_path / ".gnupg" / "secring.gpg").allowed is False
+
+
+def test_deny_read_glob(tmp_path: Path):
+    p = _policy(PermissionMode.DEFAULT, tmp_path, deny_read=["*.env"])
+    assert p.is_read_allowed(tmp_path / "prod.env").allowed is False
+
+
+def test_build_path_policy_from_sandbox_settings(tmp_path: Path):
+    # SandboxSettings default allow_write=["."] -> cwd writable, outside not.
+    policy = build_path_policy(PermissionMode.DEFAULT, SandboxSettings(), tmp_path)
+    assert policy.is_write_allowed(tmp_path / "f.txt").allowed is True
+    assert policy.is_write_allowed(tmp_path.parent / "f.txt").allowed is False


### PR DESCRIPTION
Add `permissions/path_policy.py` and wire it into `write_file`/`edit_file`: confines writes to the workspace (default), blocks all writes (plan), and hard-blocks sensitive credential paths in **every** tier incl. full_auto. Installed at session start; no policy installed = no enforcement (non-regression). Includes `plans/os-sandbox.plan.md` (two-layer design; opt-in L2 OS bash sandbox remains). 50 permissions + 124 tool + 93 ui/engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)