### PR TITLE
fix(engine): handle float-string offset/limit in _record_tool_carryover

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -407,8 +407,8 @@ def _record_tool_carryover(
     if resolved_file_path is not None:
         _remember_active_artifact(context.tool_metadata, resolved_file_path)
     if tool_name == "read_file" and resolved_file_path is not None:
-        offset = int(tool_input.get("offset") or 0)
-        limit = int(tool_input.get("limit") or 200)
+        offset = int(float(tool_input.get("offset") or 0))
+        limit = int(float(tool_input.get("limit") or 200))
         _remember_read_file(
             context.tool_metadata,
             path=resolved_file_path,


### PR DESCRIPTION
## Problem

`_record_tool_carryover()` in `src/openharness/engine/query.py` crashes when the `offset` or `limit` parameter is a float-formatted string (e.g. `"250.0"`):

```
ValueError: invalid literal for int() with base 10: '250.0'
```

This happens because `int("250.0")` is invalid in Python — `int()` only accepts clean integer strings. When the LLM serializes a tool call with `offset: "250.0"` instead of `offset: "250"`, the Gateway crashes and requires a restart to recover.

**Affected lines:**
```python
# Line 410 – offset
offset = int(tool_input.get("offset") or 0)        # ❌ fails on "250.0"

# Line 411 – limit
limit = int(tool_input.get("limit") or 200)         # ❌ fails on "100.0"
```

## Solution

Wrap both conversions with `float()` before `int()`:

```python
offset = int(float(tool_input.get("offset") or 0))  # ✅ handles all formats
limit = int(float(tool_input.get("limit") or 200))   # ✅ handles all formats
```

This safely handles every input variant:

| Input type | Example | `int(x)` | `int(float(x))` |
|---|---|---|---|
| Integer | `250` | ✅ | ✅ |
| Float | `250.0` | ✅ | ✅ |
| String integer | `"250"` | ✅ | ✅ |
| String float | `"250.0"` | ❌ **ValueError** | ✅ |
| None / missing | `None` | ✅ | ✅ |

## Test plan

Added `tests/test_engine/test_issue_302.py` with 5 test cases:

- `test_offset_float_string_works` — the reported bug scenario (`offset="250.0"`)
- `test_limit_float_string_works` — same bug for `limit="100.0"`
- `test_offset_int_works` — no regression for integer input
- `test_offset_string_int_works` — no regression for string integer input
- `test_offset_missing_works` — no regression for missing/None input

All 5 tests pass:
```
tests/test_engine/test_issue_302.py   5 passed in 0.77s
```

Closes #302