### PR TITLE
fix(network_guard): detect TUN/fake-IP and surface actionable config hint

### DIFF
--- a/src/openharness/utils/network_guard.py
+++ b/src/openharness/utils/network_guard.py
@@ -20,6 +20,22 @@ _IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 _SYNTHETIC_DNS_CIDRS_SETTING = "web.synthetic_dns_cidrs"
 _RESOLUTION_MODE_SETTING = "web.resolution_mode"
 _PROXY_SETTING = "web.proxy"
+
+# Well-known fake-IP ranges used by TUN-mode VPN/proxy clients (e.g. Clash,
+# Surge, sing-box).  These clients intercept DNS queries and return a synthetic
+# address from one of these reserved ranges; the TUN driver then routes the
+# real TCP/UDP flow to the intended remote host.  Python's `ipaddress` library
+# classifies these ranges as non-global / private, which causes the network
+# guard to reject them even though outbound connectivity is perfectly healthy.
+# We surface a targeted error message so users know exactly which setting to
+# configure instead of seeing a cryptic "non-public address" failure.
+_TUN_FAKEIP_CIDRS: tuple[ipaddress.IPv4Network, ...] = (
+    ipaddress.IPv4Network("198.18.0.0/15"),   # IANA benchmarking (Clash / sing-box default)
+    ipaddress.IPv4Network("198.51.100.0/24"),  # TEST-NET-2 (RFC 5737)
+    ipaddress.IPv4Network("203.0.113.0/24"),   # TEST-NET-3 (RFC 5737)
+    ipaddress.IPv4Network("100.64.0.0/10"),    # Shared Address Space (RFC 6598, used by some stacks)
+)
+
 _LOCAL_HOSTNAMES = {
     "localhost",
     "localhost.localdomain",
@@ -333,8 +349,39 @@ def _format_blocked_addresses(
         rendered += ", ..."
     message = f"target resolves to non-public address(es): {rendered}"
     if include_synthetic_dns_hint:
-        message += (
-            "; if this domain intentionally resolves through synthetic DNS, configure "
-            "web.resolution_mode=synthetic_dns and web.synthetic_dns_cidrs=<cidr>"
-        )
+        fakeip_cidrs = _detect_fakeip_cidrs(blocked)
+        if fakeip_cidrs:
+            cidrs_str = ",".join(fakeip_cidrs)
+            message += (
+                "; these addresses look like TUN/fake-IP responses from a local VPN or proxy "
+                "(e.g. Clash, Surge, sing-box). Enable synthetic DNS mode so the guard skips "
+                "the fake address check: set OPENHARNESS_WEB_RESOLUTION_MODE=synthetic_dns "
+                f"and OPENHARNESS_WEB_SYNTHETIC_DNS_CIDRS={cidrs_str}"
+            )
+        else:
+            message += (
+                "; if this domain intentionally resolves through synthetic DNS, configure "
+                "web.resolution_mode=synthetic_dns and web.synthetic_dns_cidrs=<cidr>"
+            )
     return message
+
+
+def _detect_fakeip_cidrs(blocked_addresses: list[str]) -> list[str]:
+    """Return the fake-IP CIDR(s) that cover the given blocked addresses.
+
+    Used to provide a precise, copy-paste-ready configuration hint when a
+    TUN/fake-IP VPN client is detected.
+    """
+    matched: list[str] = []
+    seen: set[str] = set()
+    for addr_str in blocked_addresses:
+        try:
+            addr = ipaddress.ip_address(addr_str)
+        except ValueError:
+            continue
+        for cidr in _TUN_FAKEIP_CIDRS:
+            cidr_str = str(cidr)
+            if cidr_str not in seen and isinstance(addr, ipaddress.IPv4Address) and addr in cidr:
+                matched.append(cidr_str)
+                seen.add(cidr_str)
+    return matched

--- a/tests/test_utils/test_network_guard.py
+++ b/tests/test_utils/test_network_guard.py
@@ -152,3 +152,70 @@ async def test_fetch_public_http_response_rejects_non_public_redirect_in_proxy_m
 
     with pytest.raises(ValueError, match="non-public"):
         await fetch_public_http_response("https://example.com/")
+
+
+# ---------------------------------------------------------------------------
+# TUN / fake-IP detection tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fakeip",
+    [
+        "198.18.0.1",    # Clash / sing-box default (198.18.0.0/15)
+        "198.19.255.1",  # upper end of 198.18.0.0/15
+        "198.51.100.5",  # TEST-NET-2 (RFC 5737)
+        "203.0.113.42",  # TEST-NET-3 (RFC 5737)
+        "100.64.0.1",    # Shared Address Space (RFC 6598)
+    ],
+)
+async def test_direct_mode_fakeip_error_includes_tun_hint(monkeypatch, fakeip):
+    """When DNS returns a well-known fake-IP address the error message should
+    name TUN/fake-IP and give copy-paste env-var instructions."""
+    async def fake_resolve(host: str, port: int):
+        return {ipaddress.ip_address(fakeip)}
+
+    monkeypatch.setattr("openharness.utils.network_guard._resolve_host_addresses", fake_resolve)
+
+    with pytest.raises(ValueError) as exc_info:
+        await fetch_public_http_response("https://example.com/")
+
+    message = str(exc_info.value)
+    assert "TUN" in message or "fake-IP" in message or "fake-ip" in message.lower(), message
+    assert "OPENHARNESS_WEB_RESOLUTION_MODE=synthetic_dns" in message, message
+    assert "OPENHARNESS_WEB_SYNTHETIC_DNS_CIDRS=" in message, message
+
+
+@pytest.mark.asyncio
+async def test_direct_mode_private_non_fakeip_uses_generic_hint(monkeypatch):
+    """Private addresses outside known fake-IP ranges should use the generic
+    synthetic DNS hint, not the TUN-specific one."""
+    async def fake_resolve(host: str, port: int):
+        return {ipaddress.ip_address("10.0.0.1")}
+
+    monkeypatch.setattr("openharness.utils.network_guard._resolve_host_addresses", fake_resolve)
+
+    with pytest.raises(ValueError) as exc_info:
+        await fetch_public_http_response("https://example.com/")
+
+    message = str(exc_info.value)
+    # generic hint present
+    assert "synthetic DNS" in message, message
+    # TUN-specific hint NOT present
+    assert "OPENHARNESS_WEB_RESOLUTION_MODE=synthetic_dns" not in message, message
+
+
+@pytest.mark.asyncio
+async def test_synthetic_dns_mode_allows_fakeip_cidr(monkeypatch):
+    """synthetic_dns mode with 198.18.0.0/15 declared must allow Clash fake-IP."""
+    async def fake_resolve(host: str, port: int):
+        return {ipaddress.ip_address("198.18.0.1")}
+
+    monkeypatch.setenv("OPENHARNESS_WEB_RESOLUTION_MODE", "synthetic_dns")
+    monkeypatch.setenv("OPENHARNESS_WEB_SYNTHETIC_DNS_CIDRS", "198.18.0.0/15")
+    monkeypatch.setattr("openharness.utils.network_guard._resolve_host_addresses", fake_resolve)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    response = await fetch_public_http_response("https://example.com/")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Problem

When a TUN-mode VPN or proxy client (Clash, Surge, sing-box, etc.) is active, DNS queries return synthetic addresses from reserved ranges such as `198.18.0.0/15` rather than the real public IP. Python's `ipaddress` library classifies these ranges as **non-global/private**, so `network_guard` raised a `NetworkGuardError` with a cryptic message even though outbound connectivity was perfectly healthy.

Example error seen by affected users:
```
web_search failed: target resolves to non-public address(es): 198.18.0.11
```

The existing `synthetic_dns` resolution mode already solves this, but users have no way of knowing they need it — the error message gives no actionable guidance.

## Root Cause

IANA benchmarking range `198.18.0.0/15` (and similar RFC-reserved ranges) are used as fake-IP placeholders by popular TUN-mode clients:

| CIDR | Used by |
|------|---------|
| `198.18.0.0/15` | Clash Meta / sing-box (default) |
| `198.51.100.0/24` | TEST-NET-2 (RFC 5737) |
| `203.0.113.0/24` | TEST-NET-3 (RFC 5737) |
| `100.64.0.0/10` | Shared Address Space (RFC 6598), some stacks |

`ipaddress.ip_address('198.18.0.1').is_global` returns `False`, triggering the guard's block.

## Fix

- Add `_TUN_FAKEIP_CIDRS` constant listing the well-known fake-IP ranges.
- Add `_detect_fakeip_cidrs()` helper that matches blocked addresses against those ranges.
- Improve `_format_blocked_addresses()`: when a fake-IP range is detected the error now reads:

  > *these addresses look like TUN/fake-IP responses from a local VPN or proxy (e.g. Clash, Surge, sing-box). Enable synthetic DNS mode so the guard skips the fake address check: set **`OPENHARNESS_WEB_RESOLUTION_MODE=synthetic_dns`** and **`OPENHARNESS_WEB_SYNTHETIC_DNS_CIDRS=198.18.0.0/15`***

  — giving users a **copy-paste-ready fix** instead of a generic failure.
- Non-fake-IP private addresses (e.g. `10.x.x.x`) keep the existing generic synthetic-DNS hint unchanged.

## Tests

7 new parametrised tests added to `tests/test_utils/test_network_guard.py`:

- All four fake-IP CIDR families trigger the TUN-specific hint.
- Ordinary private address (`10.0.0.1`) keeps the generic hint and does **not** show the TUN message.
- `synthetic_dns` mode correctly allows a declared `198.18.0.0/15` CIDR.

All 16 tests pass (`pytest tests/test_utils/test_network_guard.py -v`).

## How to reproduce

1. Enable TUN mode in Clash / sing-box (default fake-IP pool `198.18.0.0/15`).
2. Run `oh` and call `web_search` or `web_fetch` — you will hit the error above.
3. With this fix the error message tells you exactly what env vars to set.