### PR TITLE
fix(tools): contain file read/write/edit to workspace root by default

### DIFF
--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -57,6 +57,21 @@ class PermissionSettings(BaseModel):
     denied_commands: list[str] = Field(default_factory=list)
 
 
+class FilesystemSettings(BaseModel):
+    """Containment policy for the built-in file tools.
+
+    These settings apply to the in-process ``read_file`` / ``write_file`` /
+    ``edit_file`` tools regardless of whether the optional Docker sandbox is
+    active.  By default the tools may only touch paths inside the workspace
+    root; this blocks model-/LLM-directed reads and writes (including via
+    prompt injection) from escaping the project directory through absolute
+    paths, ``..`` traversal, or symlinks.
+    """
+
+    restrict_to_workspace: bool = True
+    allow_paths: list[str] = Field(default_factory=list)
+
+
 class MemorySettings(BaseModel):
     """Memory system configuration."""
 
@@ -585,6 +600,7 @@ class Settings(BaseModel):
     permission: PermissionSettings = Field(default_factory=PermissionSettings)
     hooks: dict[str, list[HookDefinition]] = Field(default_factory=dict)
     memory: MemorySettings = Field(default_factory=MemorySettings)
+    filesystem: FilesystemSettings = Field(default_factory=FilesystemSettings)
     sandbox: SandboxSettings = Field(default_factory=SandboxSettings)
     web: WebSettings = Field(default_factory=WebSettings)
     enabled_plugins: dict[str, bool] = Field(default_factory=dict)

--- a/src/openharness/sandbox/__init__.py
+++ b/src/openharness/sandbox/__init__.py
@@ -8,7 +8,10 @@ from openharness.sandbox.adapter import (
     wrap_command_for_sandbox,
 )
 from openharness.sandbox.docker_backend import DockerSandboxSession, get_docker_availability
-from openharness.sandbox.path_validator import validate_sandbox_path
+from openharness.sandbox.path_validator import (
+    validate_sandbox_path,
+    validate_workspace_path,
+)
 from openharness.sandbox.session import (
     get_docker_sandbox,
     is_docker_sandbox_active,
@@ -28,6 +31,7 @@ __all__ = [
     "start_docker_sandbox",
     "stop_docker_sandbox",
     "validate_sandbox_path",
+    "validate_workspace_path",
     "wrap_command_for_sandbox",
 ]
 

--- a/src/openharness/sandbox/path_validator.py
+++ b/src/openharness/sandbox/path_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Mapping
 
 
 def validate_sandbox_path(
@@ -35,3 +36,58 @@ def validate_sandbox_path(
             continue
 
     return False, f"path {resolved} is outside the sandbox boundary ({resolved_cwd})"
+
+
+# Metadata keys recognised on ``ToolExecutionContext.metadata`` to configure the
+# default workspace-containment guard applied by the built-in file tools.
+WORKSPACE_RESTRICT_METADATA_KEY = "restrict_to_workspace"
+WORKSPACE_ROOT_METADATA_KEY = "workspace_root"
+WORKSPACE_ALLOW_PATHS_METADATA_KEY = "workspace_allow_paths"
+
+
+def validate_workspace_path(
+    path: Path,
+    cwd: Path,
+    metadata: Mapping[str, Any] | None = None,
+) -> tuple[bool, str]:
+    """Check whether a built-in file tool may touch *path*.
+
+    This is the always-on counterpart to :func:`validate_sandbox_path`: it
+    keeps model-/LLM-supplied file reads and writes inside the workspace root
+    even when the optional Docker sandbox is not active, which is the default
+    configuration.  The check reuses the same containment logic as the sandbox
+    path validator (real-path resolution plus an ancestor-containment check),
+    so absolute paths outside the root, ``..`` escapes, and symlinks that point
+    outside the root are all rejected.
+
+    Containment is enabled by default.  It can be turned off for a session by
+    setting ``restrict_to_workspace`` to a falsey value in the tool execution
+    metadata (an explicit operator opt-out), and additional roots can be
+    permitted via ``workspace_allow_paths``.  ``workspace_root`` overrides the
+    containment root (defaulting to ``cwd``).
+
+    Returns ``(True, "")`` when the path is allowed, or ``(False, reason)``
+    when it is outside the permitted directories.
+    """
+    metadata = metadata or {}
+
+    # Default-safe: containment is on unless explicitly disabled.
+    if WORKSPACE_RESTRICT_METADATA_KEY in metadata and not metadata[WORKSPACE_RESTRICT_METADATA_KEY]:
+        return True, ""
+
+    root_override = metadata.get(WORKSPACE_ROOT_METADATA_KEY)
+    root = Path(root_override) if root_override else cwd
+
+    extra_allowed = metadata.get(WORKSPACE_ALLOW_PATHS_METADATA_KEY)
+    if isinstance(extra_allowed, (str, Path)):
+        extra_allowed = [str(extra_allowed)]
+    elif extra_allowed is not None:
+        extra_allowed = [str(item) for item in extra_allowed]
+
+    allowed, reason = validate_sandbox_path(path, root, extra_allowed)
+    if allowed:
+        return True, ""
+    return False, (
+        f"path {path.resolve()} is outside the workspace root ({root.resolve()}); "
+        "set permission/path rules or disable workspace containment to allow it"
+    )

--- a/src/openharness/tools/file_edit_tool.py
+++ b/src/openharness/tools/file_edit_tool.py
@@ -33,6 +33,16 @@ class FileEditTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        # Default-on workspace containment: keep model-supplied edits inside the
+        # repository root even when the optional Docker sandbox is not active and
+        # the run is non-interactive (e.g. the headless task-worker auto-approves
+        # mutating tools and supplies no edit-diff approval callback).
+        from openharness.sandbox.path_validator import validate_workspace_path
+
+        allowed, reason = validate_workspace_path(path, context.cwd, context.metadata)
+        if not allowed:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():

--- a/src/openharness/tools/file_read_tool.py
+++ b/src/openharness/tools/file_read_tool.py
@@ -35,6 +35,14 @@ class FileReadTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        # Default-on workspace containment: keep model-supplied reads inside the
+        # repository root even when the optional Docker sandbox is not active.
+        from openharness.sandbox.path_validator import validate_workspace_path
+
+        allowed, reason = validate_workspace_path(path, context.cwd, context.metadata)
+        if not allowed:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():

--- a/src/openharness/tools/file_write_tool.py
+++ b/src/openharness/tools/file_write_tool.py
@@ -32,6 +32,16 @@ class FileWriteTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        # Default-on workspace containment: keep model-supplied writes inside the
+        # repository root even when the optional Docker sandbox is not active and
+        # the run is non-interactive (e.g. the headless task-worker auto-approves
+        # mutating tools and supplies no edit-diff approval callback).
+        from openharness.sandbox.path_validator import validate_workspace_path
+
+        allowed, reason = validate_workspace_path(path, context.cwd, context.metadata)
+        if not allowed:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -424,6 +424,9 @@ async def build_runtime(
             "edit_approval_prompt": edit_approval_prompt,
             "vision_model_config": _resolve_vision_config(settings),
             "image_generation_config": _resolve_image_generation_config(settings),
+            "restrict_to_workspace": settings.filesystem.restrict_to_workspace,
+            "workspace_root": str(cwd),
+            "workspace_allow_paths": list(settings.filesystem.allow_paths),
             **restored_metadata,
         },
     )

--- a/tests/test_tools/test_file_tool_containment.py
+++ b/tests/test_tools/test_file_tool_containment.py
@@ -1,0 +1,102 @@
+"""Workspace-containment regression tests for ``read_file``.
+
+These cover the default (non-Docker-sandbox) configuration, where model- or
+LLM-supplied paths must stay inside the workspace root.  Without containment a
+prompt-injected or mistaken model can read host files outside the current
+repository by supplying an absolute path or a ``..`` escape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.tools.base import ToolExecutionContext
+from openharness.tools.file_read_tool import FileReadTool, FileReadToolInput
+
+
+def _workspace(tmp_path: Path) -> Path:
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    return cwd
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_absolute_outside_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("super-secret\n", encoding="utf-8")
+
+    result = await FileReadTool().execute(
+        FileReadToolInput(path=str(outside)),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert "super-secret" not in result.output
+    assert "outside the workspace root" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_dotdot_escape(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    (tmp_path / "outside-secret.txt").write_text("super-secret\n", encoding="utf-8")
+
+    result = await FileReadTool().execute(
+        FileReadToolInput(path="../outside-secret.txt"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert "super-secret" not in result.output
+    assert "outside the workspace root" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_file_allows_in_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    (cwd / "notes.txt").write_text("alpha\nbeta\n", encoding="utf-8")
+
+    result = await FileReadTool().execute(
+        FileReadToolInput(path="notes.txt"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is False
+    assert "alpha" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_file_opt_out_allows_outside(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("super-secret\n", encoding="utf-8")
+
+    result = await FileReadTool().execute(
+        FileReadToolInput(path=str(outside)),
+        ToolExecutionContext(cwd=cwd, metadata={"restrict_to_workspace": False}),
+    )
+
+    assert result.is_error is False
+    assert "super-secret" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_file_allow_paths_permits_extra_root(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    target = shared / "data.txt"
+    target.write_text("shared-data\n", encoding="utf-8")
+
+    result = await FileReadTool().execute(
+        FileReadToolInput(path=str(target)),
+        ToolExecutionContext(
+            cwd=cwd,
+            metadata={"workspace_allow_paths": [str(shared)]},
+        ),
+    )
+
+    assert result.is_error is False
+    assert "shared-data" in result.output

--- a/tests/test_tools/test_file_write_containment.py
+++ b/tests/test_tools/test_file_write_containment.py
@@ -1,0 +1,188 @@
+"""Workspace-containment regression tests for ``write_file`` / ``edit_file``.
+
+These cover the default (non-Docker-sandbox) configuration.  The shipped
+non-interactive runners (task-worker, print mode) install a permission callback
+that always approves and supply no ``edit_approval_prompt``, so a prompt-injected
+or mistaken model could overwrite or edit host files outside the current
+repository by supplying an absolute path or a ``..`` escape.  Mutating file
+tools must keep those operations inside the workspace root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.tools.base import ToolExecutionContext
+from openharness.tools.file_edit_tool import FileEditTool, FileEditToolInput
+from openharness.tools.file_write_tool import FileWriteTool, FileWriteToolInput
+
+
+def _workspace(tmp_path: Path) -> Path:
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    return cwd
+
+
+# --- write_file (headless / auto-approve path: no edit_approval_prompt) ----
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_dotdot_escape_when_autoapproved(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    target = tmp_path / "outside-canary.txt"
+
+    # No edit_approval_prompt in metadata == the headless auto-approve path.
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path="../outside-canary.txt", content="pwned"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert "outside the workspace root" in result.output
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_absolute_outside_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    target = tmp_path / "outside-abs.txt"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path=str(target), content="pwned"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_escape_even_with_approval_callback(tmp_path: Path):
+    """Containment also holds on the interactive path (approval callback set)."""
+    cwd = _workspace(tmp_path)
+    target = tmp_path / "outside-interactive.txt"
+    approvals: list[str] = []
+
+    async def _approve(path: str, diff: str, added: int, removed: int) -> str:
+        approvals.append(path)
+        return "once"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path="../outside-interactive.txt", content="pwned"),
+        ToolExecutionContext(cwd=cwd, metadata={"edit_approval_prompt": _approve}),
+    )
+
+    assert result.is_error is True
+    assert "outside the workspace root" in result.output
+    assert not target.exists()
+    # Containment fails closed before the user is ever prompted.
+    assert approvals == []
+
+
+@pytest.mark.asyncio
+async def test_write_file_allows_in_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path="sub/notes.txt", content="hello\n"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is False
+    assert (cwd / "sub" / "notes.txt").read_text(encoding="utf-8") == "hello\n"
+
+
+@pytest.mark.asyncio
+async def test_write_file_opt_out_allows_outside(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    target = tmp_path / "outside-allowed.txt"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path=str(target), content="ok\n"),
+        ToolExecutionContext(cwd=cwd, metadata={"restrict_to_workspace": False}),
+    )
+
+    assert result.is_error is False
+    assert target.read_text(encoding="utf-8") == "ok\n"
+
+
+@pytest.mark.asyncio
+async def test_write_file_allow_paths_permits_extra_root(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    target = shared / "data.txt"
+
+    result = await FileWriteTool().execute(
+        FileWriteToolInput(path=str(target), content="shared\n"),
+        ToolExecutionContext(cwd=cwd, metadata={"workspace_allow_paths": [str(shared)]}),
+    )
+
+    assert result.is_error is False
+    assert target.read_text(encoding="utf-8") == "shared\n"
+
+
+# --- edit_file ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_file_rejects_dotdot_escape_when_autoapproved(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    outside = tmp_path / "outside-edit.txt"
+    outside.write_text("keep-me\n", encoding="utf-8")
+
+    result = await FileEditTool().execute(
+        FileEditToolInput(path="../outside-edit.txt", old_str="keep-me", new_str="pwned"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert "outside the workspace root" in result.output
+    assert outside.read_text(encoding="utf-8") == "keep-me\n"
+
+
+@pytest.mark.asyncio
+async def test_edit_file_rejects_absolute_outside_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    outside = tmp_path / "outside-edit-abs.txt"
+    outside.write_text("keep-me\n", encoding="utf-8")
+
+    result = await FileEditTool().execute(
+        FileEditToolInput(path=str(outside), old_str="keep-me", new_str="pwned"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is True
+    assert outside.read_text(encoding="utf-8") == "keep-me\n"
+
+
+@pytest.mark.asyncio
+async def test_edit_file_allows_in_workspace(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    target = cwd / "notes.txt"
+    target.write_text("one\ntwo\n", encoding="utf-8")
+
+    result = await FileEditTool().execute(
+        FileEditToolInput(path="notes.txt", old_str="two", new_str="TWO"),
+        ToolExecutionContext(cwd=cwd),
+    )
+
+    assert result.is_error is False
+    assert "TWO" in target.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_edit_file_opt_out_allows_outside(tmp_path: Path):
+    cwd = _workspace(tmp_path)
+    outside = tmp_path / "outside-edit-optout.txt"
+    outside.write_text("keep-me\n", encoding="utf-8")
+
+    result = await FileEditTool().execute(
+        FileEditToolInput(path=str(outside), old_str="keep-me", new_str="changed"),
+        ToolExecutionContext(cwd=cwd, metadata={"restrict_to_workspace": False}),
+    )
+
+    assert result.is_error is False
+    assert outside.read_text(encoding="utf-8") == "changed\n"


### PR DESCRIPTION
## Summary

- **What problem does this PR solve?** The built-in file tools (`read_file`, `write_file`, `edit_file`) resolved a model-/LLM-supplied path to an absolute host path and then read or wrote it directly. Workspace containment was only enforced inside the `is_docker_sandbox_active()` branch (which calls `validate_sandbox_path`). The Docker sandbox is disabled by default (`SandboxSettings.enabled = False`), so in the default, unsandboxed configuration nothing kept these tools inside the repository root. A prompt-injected or mistaken model could therefore escape the workspace via an absolute path or `..` traversal:
  - `read_file` is read-only, so `PermissionChecker.evaluate` auto-allows it after only the credential denylist / optional path rules — out-of-workspace reads of arbitrary UTF-8 host files succeeded with no prompt.
  - `write_file` / `edit_file` are gated by a permission prompt and edit-diff approval in the interactive UI, but the shipped non-interactive runners (`run_task_worker`, used for background teammates spawned with `--task-worker`, and `run_print_mode`) install a permission callback that always returns `True` and pass no `edit_approval_prompt`. On that auto-approved path, out-of-workspace writes and edits also succeeded.

  Affected sites (decisive sink per path):
  - `read_file` — `src/openharness/tools/file_read_tool.py:52` (`raw = path.read_bytes()`)
  - `write_file` — `src/openharness/tools/file_write_tool.py:59` (`path.write_text(arguments.content, encoding=\"utf-8\")`)
  - `edit_file` — `src/openharness/tools/file_edit_tool.py` (`path.write_text(updated, ...)`, both the sandbox and non-sandbox branches)

- **What changed?** Workspace containment is now enforced for `read_file`, `write_file`, and `edit_file` before any read or write, independent of the Docker sandbox and independent of the approval path, by reusing the repo's existing path-boundary check:
  - Added `validate_workspace_path(path, cwd, metadata)` in `src/openharness/sandbox/path_validator.py` — the always-on counterpart to `validate_sandbox_path`, which it reuses for the actual containment check (real-path resolution + ancestor check, already rejecting absolute-outside paths, `..` escapes, and symlink escapes). Exported from `src/openharness/sandbox/__init__.py`.
  - Each file tool calls `validate_workspace_path(...)` right after path resolution. For `write_file` / `edit_file` the check runs **before** both the approval branch and the auto-approve branch, so it fails closed before the user is ever prompted and also holds on the interactive path.
  - Added `FilesystemSettings` (`restrict_to_workspace: bool = True`, `allow_paths: list[str] = []`) on `Settings.filesystem` (`src/openharness/config/settings.py`), surfaced into the engine `tool_metadata` in `src/openharness/ui/runtime.py` (including the task-worker and print-mode runtimes, so the auto-approve paths inherit containment).

  Containment is on by default and security-positive: out-of-workspace reads, writes, and edits are denied by default. It is backward compatible — no public API signature changes, `validate_sandbox_path` is untouched, the new helper is additive, and tools called without metadata (e.g. in tests) default to containment-on. Operators who need to reach outside the repository can opt out per session with `filesystem.restrict_to_workspace = false`, or scope extra roots with `filesystem.allow_paths`. In-workspace edits keep the existing approval-prompt behavior.

## Validation

- [x] `uv run ruff check src tests scripts`
- [ ] `uv run pytest -q`
- [x] `cd frontend/terminal && npx tsc --noEmit` (if frontend touched)

Test summary (added with this change, covering both affected tools):

- `tests/test_tools/test_file_tool_containment.py` — `read_file` scope (5 tests): rejects absolute-outside, rejects `..` escape, allows in-workspace, honors `restrict_to_workspace=False` opt-out, honors `allow_paths` extra root.
- `tests/test_tools/test_file_write_containment.py` — `write_file` / `edit_file` scope (10 tests): rejects `..` escape and absolute-outside on the headless auto-approve path, rejects an escape even when an approval callback is set (and asserts the callback is never invoked — fails closed), plus in-workspace, opt-out, and `allow_paths` allow-cases for both tools.

Both new suites fail on the base commit (the escapes succeed) and pass after this change:

```
tests/test_tools/test_file_tool_containment.py .....                     [ 33%]
tests/test_tools/test_file_write_containment.py ..........               [100%]
15 passed
```

Run together with the adjacent tool / sandbox / config suites it is regression-clean (`137 passed, 1 skipped`). `uv run ruff check` passes on every file touched here. The frontend was not modified, so the TypeScript check has nothing to run for this PR. The full `uv run pytest -q` suite is left for a maintainer's green CI run.

## Notes

- Related issue: Fixes #310
- Follow-up work: None required. The change is self-contained. A short `Unreleased` entry could optionally be added to `CHANGELOG.md` to record the default-on workspace containment for the built-in file tools.