### PR TITLE
fix(permissions): enforce deny rules over the allow list (fixes #313)

### DIFF
--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -101,11 +101,15 @@ class PermissionChecker:
         if tool_name in self._settings.denied_tools:
             return PermissionDecision(allowed=False, reason=f"{tool_name} is explicitly denied")
 
-        # Explicit tool allow list
-        if tool_name in self._settings.allowed_tools:
-            return PermissionDecision(allowed=True, reason=f"{tool_name} is explicitly allowed")
+        # Deny rules take precedence over the allow list below.  A user who has
+        # allow-listed a broad tool (e.g. ``bash`` or ``write_file``) still
+        # expects an explicit ``denied_commands`` pattern or path deny-rule to
+        # block a dangerous invocation.  Evaluating the deny rules first keeps
+        # the allow list from silently bypassing the user's own deny policy,
+        # mirroring how ``denied_tools`` and built-in sensitive paths are
+        # already checked before the allow list.
 
-        # Check path-level rules
+        # Check path-level deny rules
         if file_path and self._path_rules:
             for candidate_path in _policy_match_paths(file_path):
                 for rule in self._path_rules:
@@ -124,6 +128,10 @@ class PermissionChecker:
                         allowed=False,
                         reason=f"Command matches deny pattern: {pattern}",
                     )
+
+        # Explicit tool allow list
+        if tool_name in self._settings.allowed_tools:
+            return PermissionDecision(allowed=True, reason=f"{tool_name} is explicitly allowed")
 
         # Full auto: allow everything
         if self._settings.mode == PermissionMode.FULL_AUTO:

--- a/tests/test_permissions/test_checker.py
+++ b/tests/test_permissions/test_checker.py
@@ -129,6 +129,58 @@ def test_pattern_with_surrounding_whitespace_is_stripped():
     assert decision.allowed is False
 
 
+# --- deny precedence over allow list ---
+
+
+class TestDenyPrecedenceOverAllowList:
+    """Deny rules must take precedence over an explicit allow-list entry."""
+
+    def test_denied_command_blocks_allow_listed_tool(self):
+        """A denied_commands pattern blocks an allow-listed tool (e.g. bash)."""
+        settings = PermissionSettings.model_construct(
+            mode=PermissionMode.DEFAULT,
+            allowed_tools=["bash"],
+            denied_tools=[],
+            denied_commands=["*rm -rf /*"],
+            path_rules=[],
+        )
+        decision = PermissionChecker(settings).evaluate(
+            "bash", is_read_only=False, command="rm -rf / --no-preserve-root"
+        )
+        assert decision.allowed is False
+        assert "deny pattern" in decision.reason
+
+    def test_path_deny_rule_blocks_allow_listed_tool(self):
+        """A path deny-rule blocks an allow-listed tool (e.g. write_file)."""
+        settings = PermissionSettings.model_construct(
+            mode=PermissionMode.DEFAULT,
+            allowed_tools=["write_file"],
+            denied_tools=[],
+            denied_commands=[],
+            path_rules=[PathRuleConfig(pattern="/etc/*", allow=False)],
+        )
+        decision = PermissionChecker(settings).evaluate(
+            "write_file", is_read_only=False, file_path="/etc/passwd"
+        )
+        assert decision.allowed is False
+        assert "deny rule" in decision.reason
+
+    def test_allow_listed_tool_still_runs_when_no_deny_matches(self):
+        """The allow-list still grants tools that no deny rule blocks."""
+        settings = PermissionSettings.model_construct(
+            mode=PermissionMode.DEFAULT,
+            allowed_tools=["bash"],
+            denied_tools=[],
+            denied_commands=["*rm -rf /*"],
+            path_rules=[PathRuleConfig(pattern="/etc/*", allow=False)],
+        )
+        decision = PermissionChecker(settings).evaluate(
+            "bash", is_read_only=False, command="echo hello"
+        )
+        assert decision.allowed is True
+        assert "explicitly allowed" in decision.reason
+
+
 # --- built-in sensitive path protection tests ---
 
 


### PR DESCRIPTION
## Summary

- **Problem:** `PermissionChecker.evaluate()` returned **allow** for any tool in `allowed_tools` *before* it evaluated the user-configured `path_rules` deny-rules and `denied_commands` patterns. Allow-listing a broad tool such as `bash` or `write_file` therefore silently disabled the user's own deny policy — a configured `denied_commands: ["*rm -rf /*"]` or a `/etc/*` path deny-rule provided no protection once the tool was allow-listed. This is inconsistent with the rest of the checker, where deny already wins: `denied_tools` and the built-in sensitive-path patterns are both evaluated before the allow-list (and `test_allowed_tools_does_not_bypass_sensitive_paths` asserts exactly that for sensitive paths).

- **Change:** Move the path deny-rule check and the `denied_commands` check ahead of the `allowed_tools` short-circuit in `evaluate()`, so deny consistently takes precedence over allow. Behavior is otherwise unchanged: an allow-listed tool still runs when no deny rule matches.

- Added regression tests covering both deny paths and a control asserting the allow-list still grants a tool when no deny rule applies.

Fixes #313.

## Before / after

```python
from openharness.config.settings import PathRuleConfig, PermissionSettings
from openharness.permissions import PermissionChecker, PermissionMode

s = PermissionSettings.model_construct(
    mode=PermissionMode.DEFAULT, allowed_tools=["bash"], denied_tools=[],
    denied_commands=["*rm -rf /*"], path_rules=[],
)
PermissionChecker(s).evaluate("bash", is_read_only=False,
    command="rm -rf / --no-preserve-root").allowed
# before: True   after: False
```

## Validation

- [x] `uv run ruff check src tests scripts` — passes
- [x] `uv run pytest -q tests/test_permissions` — 35 passed (3 new)
- [x] `uv run pytest -q` — full suite passes except two pre-existing failures unrelated to this change (`test_bundled_user_invocable_skill_registers_as_slash_command`, `test_load_skill_registry_includes_bundled`); both fail identically on a clean `main`.
- [x] `cd frontend/terminal && npx tsc --noEmit` — not applicable (no frontend changes)

## Notes

- Related issue: #313
- Scope kept minimal: this only reorders the deny checks ahead of the allow-list. Path rules with `allow=True` remain advisory (no behavior change), matching current semantics.
