### PR TITLE
fix(permissions): hide denied tools from API schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Denied tools are no longer included in the tool schemas sent to the model, so
+  `permission.denied_tools` hides blocked tools from model selection in addition
+  to blocking them at execution time.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -731,7 +731,9 @@ async def run_query(
                     messages=messages,
                     system_prompt=context.system_prompt,
                     max_tokens=effective_max_tokens,
-                    tools=context.tool_registry.to_api_schema(),
+                    tools=context.tool_registry.to_api_schema(
+                        denied_tools=context.permission_checker.denied_tools
+                    ),
                     effort=context.effort,
                 )
             ):

--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -72,6 +72,11 @@ class PermissionChecker:
                     rule,
                 )
 
+    @property
+    def denied_tools(self) -> tuple[str, ...]:
+        """Return tool names that should be hidden and blocked."""
+        return tuple(self._settings.denied_tools)
+
     def evaluate(
         self,
         tool_name: str,

--- a/src/openharness/tools/base.py
+++ b/src/openharness/tools/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -75,6 +76,7 @@ class ToolRegistry:
         """Return all registered tools."""
         return list(self._tools.values())
 
-    def to_api_schema(self) -> list[dict[str, Any]]:
-        """Return all tool schemas in API format."""
-        return [tool.to_api_schema() for tool in self._tools.values()]
+    def to_api_schema(self, *, denied_tools: Collection[str] | None = None) -> list[dict[str, Any]]:
+        """Return available tool schemas in API format."""
+        denied = set(denied_tools or ())
+        return [tool.to_api_schema() for tool in self._tools.values() if tool.name not in denied]

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -1198,6 +1198,44 @@ class _BoomTool(BaseTool):
         raise RuntimeError("boom")
 
 
+def test_tool_registry_to_api_schema_filters_denied_tools():
+    registry = ToolRegistry()
+    registry.register(_OkTool())
+    registry.register(_BoomTool())
+
+    schemas = registry.to_api_schema(denied_tools=["boom_tool"])
+
+    assert [schema["name"] for schema in schemas] == ["ok_tool"]
+
+
+@pytest.mark.asyncio
+async def test_query_engine_omits_denied_tools_from_api_schema(tmp_path: Path):
+    registry = ToolRegistry()
+    registry.register(_OkTool())
+    registry.register(_BoomTool())
+    api_client = RecordingApiClient()
+
+    engine = QueryEngine(
+        api_client=api_client,
+        tool_registry=registry,
+        permission_checker=PermissionChecker(
+            PermissionSettings(
+                mode=PermissionMode.FULL_AUTO,
+                denied_tools=["boom_tool"],
+            )
+        ),
+        cwd=tmp_path,
+        model="claude-test",
+        system_prompt="system",
+    )
+
+    events = [event async for event in engine.submit_message("hello")]
+
+    assert isinstance(events[-1], AssistantTurnComplete)
+    assert len(api_client.requests) == 1
+    assert [tool["name"] for tool in api_client.requests[0].tools] == ["ok_tool"]
+
+
 @pytest.mark.asyncio
 async def test_query_engine_synthesizes_tool_result_when_single_tool_raises(tmp_path: Path):
     registry = ToolRegistry()


### PR DESCRIPTION
## Summary

- **Problem:** `permission.denied_tools` only blocked tools at execution time. The query loop still sent every registered tool schema to the model, so denied tools stayed visible and the model could select tools that would immediately be rejected by `PermissionChecker`.

- **Change:** `ToolRegistry.to_api_schema()` now accepts an optional `denied_tools` filter, `PermissionChecker` exposes its denied tool names as a read-only tuple, and `run_query()` applies that filter before sending tool schemas to the API. Execution-time permission checks remain unchanged as the enforcement backstop.

- Added regression coverage for both the registry filter and the query engine request payload, and added an `Unreleased` changelog entry for the user-visible permissions behavior change.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q` — `1155 passed, 6 skipped` when run with inherited `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` cleared so auth tests are not biased by the local Codex session environment.
- [x] `cd frontend/terminal && npx tsc --noEmit` — not applicable; no frontend files touched.

## Notes

- Related issue: N/A
- Follow-up work: None.
