### PR TITLE
fix(api): detect GPT-5 multimodal models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Multimodal model detection now recognizes OpenAI `gpt-4.1` and `gpt-5`
+  family model names, including `gpt-5.5`, so image inputs are sent natively
+  instead of being routed through the image-to-text fallback.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/api/provider.py
+++ b/src/openharness/api/provider.py
@@ -136,8 +136,10 @@ _MULTIMODAL_MODEL_PATTERNS: list[re.Pattern[str]] = [
     # Anthropic Claude 3+ (all Claude 3 and later support images)
     re.compile(r"^claude-3(?:\.\d+)?(?:-sonnet|-opus|-haiku)?"),
     re.compile(r"^claude-(?:sonnet|opus|haiku)-\d"),
-    # OpenAI GPT-4o / o-series
+    # OpenAI multimodal GPT / o-series
+    re.compile(r"^gpt-4\.1(?:$|[-.])"),
     re.compile(r"^gpt-4o"),
+    re.compile(r"^gpt-5(?:$|[-.])"),
     re.compile(r"^o[1349]-"),
     # Google Gemini
     re.compile(r"^gemini-(?:pro-)?vision"),

--- a/tests/test_tools/test_image_to_text_tool.py
+++ b/tests/test_tools/test_image_to_text_tool.py
@@ -27,8 +27,14 @@ from openharness.tools.image_to_text_tool import ImageToTextTool, ImageToTextToo
         ("claude-3-opus-20240229", True),
         ("claude-3-haiku-20240307", True),
         # OpenAI multimodal
+        ("gpt-4.1", True),
+        ("gpt-4.1-mini", True),
         ("gpt-4o", True),
         ("gpt-4o-mini", True),
+        ("gpt-5", True),
+        ("gpt-5.4", True),
+        ("gpt-5.5", True),
+        ("gpt-5.5 xhigh", True),
         ("o1-mini", True),
         ("o3-mini", True),
         ("o4-mini", True),
@@ -64,6 +70,7 @@ from openharness.tools.image_to_text_tool import ImageToTextTool, ImageToTextToo
         ("", False),
         # With provider prefix
         ("anthropic/claude-sonnet-4-6", True),
+        ("openai/gpt-5.5", True),
         ("openai/gpt-4o", True),
         ("openai/gpt-4", False),
     ],


### PR DESCRIPTION
## Summary

- Recognize newer OpenAI model names when checking multimodal capability, including `gpt-4.1` and the `gpt-5` family.
- Add regression coverage for `gpt-5`, `gpt-5.4`, `gpt-5.5`, provider-prefixed `openai/gpt-5.5`, and the existing `gpt-5.5 xhigh` style input.
- Update the Unreleased changelog entry for the image-input behavior fix.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest tests/test_tools/test_image_to_text_tool.py -q`
- [x] `env -u ANTHROPIC_AUTH_TOKEN -u OPENHARNESS_BASE_URL -u ANTHROPIC_BASE_URL -u OPENAI_BASE_URL -u OPENHARNESS_MODEL -u ANTHROPIC_MODEL -u ANTHROPIC_API_KEY -u OPENAI_API_KEY uv run pytest -q` (`1160 passed, 6 skipped`)
- `cd frontend/terminal && npx tsc --noEmit` not run; frontend not touched.

## Notes

- Related issue: none found.
- Follow-up work: none.
