### PR TITLE
Fix int() crash on float strings and model alias suffix stripping

### DIFF
--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -350,7 +350,9 @@ def resolve_model_setting(
     if provider in {"openai", "openai_codex", "copilot"} and normalized in {"default", "best"}:
         return "gpt-5.4"
 
-    return configured
+    # Strip display-only context-window suffixes like [1M] or [750K] that some
+    # model aliases carry in the UI but that external provider APIs reject.
+    return re.sub(r"\[\d+[KMkm]\]$", "", configured).strip()
 
 
 def auth_source_provider_name(auth_source: str) -> str:

--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -407,8 +407,8 @@ def _record_tool_carryover(
     if resolved_file_path is not None:
         _remember_active_artifact(context.tool_metadata, resolved_file_path)
     if tool_name == "read_file" and resolved_file_path is not None:
-        offset = int(tool_input.get("offset") or 0)
-        limit = int(tool_input.get("limit") or 200)
+        offset = int(float(tool_input.get("offset") or 0))
+        limit = int(float(tool_input.get("limit") or 200))
         _remember_read_file(
             context.tool_metadata,
             path=resolved_file_path,

--- a/src/openharness/tasks/manager.py
+++ b/src/openharness/tasks/manager.py
@@ -280,6 +280,7 @@ class BackgroundTaskManager:
             async with self._output_locks[task_id]:
                 with self._tasks[task_id].output_file.open("ab") as handle:
                     handle.write(chunk)
+                    handle.flush()
 
     def _require_task(self, task_id: str) -> TaskRecord:
         task = self._tasks.get(task_id)


### PR DESCRIPTION
Fixes #302, #308, #312

## Changes

### Fix 1: `_record_tool_carryover()` crashes on float-format numeric strings (fixes #302)

**File:** `src/openharness/engine/query.py`

Some LLMs emit JSON integer fields as floats (e.g. `250.0` instead of `250`). `int()` raises `ValueError` on such strings. Wrapping with `float()` first handles both integer and float-formatted numeric strings:

```python
# Before
offset = int(tool_input.get("offset") or 0)
limit = int(tool_input.get("limit") or 200)

# After
offset = int(float(tool_input.get("offset") or 0))
limit = int(float(tool_input.get("limit") or 200))
```

### Fix 2: Async subprocess stdout data loss between chunks (fixes #308)

**File:** `src/openharness/tasks/manager.py`

`_copy_output()` writes 4 KB chunks to disk but never calls `flush()`. If the subprocess exits abruptly between iterations, data sitting in the Python file buffer is lost. Added `handle.flush()` after `handle.write(chunk)`.

### Fix 3: MiniMax `[1M]` model alias suffix rejected by API (fixes #312)

**File:** `src/openharness/config/settings.py`

`resolve_model_setting()` was passing display aliases like `MiniMax-M3[1M]` raw to the provider API, causing a `400 unknown model` error. Added a regex strip for any trailing `[N K/M]` context-window suffix before returning the resolved model ID. This is consistent with how Claude handles similar display variants.