### PR TITLE
fix(permissions): deny rules now take precedence over allowed_tools

### DIFF
--- a/src/openharness/permissions/checker.py
+++ b/src/openharness/permissions/checker.py
@@ -101,11 +101,8 @@ class PermissionChecker:
         if tool_name in self._settings.denied_tools:
             return PermissionDecision(allowed=False, reason=f"{tool_name} is explicitly denied")
 
-        # Explicit tool allow list
-        if tool_name in self._settings.allowed_tools:
-            return PermissionDecision(allowed=True, reason=f"{tool_name} is explicitly allowed")
-
-        # Check path-level rules
+        # Check path-level rules — evaluated before the allow list so that a
+        # path deny rule cannot be bypassed by listing the tool in allowed_tools.
         if file_path and self._path_rules:
             for candidate_path in _policy_match_paths(file_path):
                 for rule in self._path_rules:
@@ -116,7 +113,8 @@ class PermissionChecker:
                                 reason=f"Path {file_path} matches deny rule: {rule.pattern}",
                             )
 
-        # Check command deny patterns (e.g. deny "rm -rf /")
+        # Check command deny patterns (e.g. deny "rm -rf /") — also evaluated
+        # before the allow list for the same reason as path deny rules above.
         if command:
             for pattern in getattr(self._settings, "denied_commands", []):
                 if isinstance(pattern, str) and fnmatch.fnmatch(command, pattern):
@@ -124,6 +122,11 @@ class PermissionChecker:
                         allowed=False,
                         reason=f"Command matches deny pattern: {pattern}",
                     )
+
+        # Explicit tool allow list — checked after all deny rules so that deny
+        # always wins when both an allow-list entry and a deny rule match.
+        if tool_name in self._settings.allowed_tools:
+            return PermissionDecision(allowed=True, reason=f"{tool_name} is explicitly allowed")
 
         # Full auto: allow everything
         if self._settings.mode == PermissionMode.FULL_AUTO:


### PR DESCRIPTION
## Summary

Closes #313

`PermissionChecker.evaluate()` short-circuited to `allowed=True` when a
tool appeared in `allowed_tools` **before** evaluating either
`path_rules` deny entries or `denied_commands` patterns. This meant:

- A path deny rule like `*/etc/*` had no effect for any tool listed in
  `allowed_tools`.
- A denied command pattern (e.g. `rm -rf /`) was also bypassed.

The fix moves the `allowed_tools` allow-check to **after** both deny
blocks, preserving the intended deny-wins semantics.

**Before:**
```
denied_tools → [early return False]
allowed_tools → [early return True]  ← bypassed path/command deny below
path deny rules
denied_commands
```

**After:**
```
denied_tools → [early return False]
path deny rules → [early return False if matched]
denied_commands → [early return False if matched]
allowed_tools → [early return True]
```

## Test plan
- [ ] Configure `allowed_tools: ["bash"]` + a path deny rule for `*/etc/*`. Verify that `bash` with a file path under `/etc/` is still denied.
- [ ] Configure `allowed_tools: ["bash"]` + `denied_commands: ["rm -rf *"]`. Verify the command is denied even though bash is allowed.
- [ ] Verify existing allow-list behaviour (tool in `allowed_tools`, no conflicting deny rule) still returns `allowed=True`.