### PR TITLE
fix(tasks): fall back to settings.json api_key when spawning local agents

### DIFF
--- a/src/openharness/tasks/manager.py
+++ b/src/openharness/tasks/manager.py
@@ -135,8 +135,13 @@ class BackgroundTaskManager:
         if command is None and argv is None:
             effective_api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
             if not effective_api_key:
+                from openharness.config.settings import load_settings
+
+                effective_api_key = load_settings().api_key or None
+            if not effective_api_key:
                 raise ValueError(
-                    "Local agent tasks require ANTHROPIC_API_KEY or an explicit command/argv override"
+                    "Local agent tasks require an API key. Set ANTHROPIC_API_KEY, configure "
+                    "api_key in settings.json, or supply an explicit command/argv override."
                 )
             argv = ["python", "-m", "openharness", "--api-key", effective_api_key]
             if model:


### PR DESCRIPTION
## Summary

Closes #309

`create_agent_task()` raised `ValueError` ("Local agent tasks require
ANTHROPIC_API_KEY...") when a user's API key was configured in
`settings.json` but not exported as an environment variable. The check
only looked at the explicit `api_key` argument and `os.environ`.

Add a lazy fallback that reads `settings.json` before raising:

```python
effective_api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
if not effective_api_key:
    from openharness.config.settings import load_settings
    effective_api_key = load_settings().api_key or None
if not effective_api_key:
    raise ValueError(...)
```

The import is lazy (inside the branch) to avoid any circular-import risk
at module load time.

## Test plan
- [ ] Set `api_key` in `~/.openharness/settings.json`, unset `ANTHROPIC_API_KEY`. Verify that spawning a local agent task succeeds.
- [ ] Verify that an explicit `api_key` argument still takes precedence over both env var and settings.
- [ ] Verify that `ANTHROPIC_API_KEY` still takes precedence over settings when both are set.
- [ ] Verify that the `ValueError` is still raised when none of the three sources provides a key.