### PR TITLE
fix(gateway): verify process is alive after restart before reporting success

### DIFF
--- a/ohmo/cli.py
+++ b/ohmo/cli.py
@@ -404,7 +404,11 @@ def _maybe_restart_gateway(*, cwd: str | Path, workspace: str | Path) -> None:
         print("Configuration saved. Restart later with `ohmo gateway restart`.")
         return
     stop_gateway_process(cwd, workspace)
-    pid = start_gateway_process(cwd, workspace)
+    try:
+        pid = start_gateway_process(cwd, workspace)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        return
     print(f"ohmo gateway restarted (pid={pid})")
 
 
@@ -697,7 +701,11 @@ def gateway_restart_cmd(
     workspace: str | None = typer.Option(None, "--workspace", help=_WORKSPACE_HELP),
 ) -> None:
     stop_gateway_process(cwd, workspace)
-    pid = start_gateway_process(cwd, workspace)
+    try:
+        pid = start_gateway_process(cwd, workspace)
+    except RuntimeError as exc:
+        typer.echo(f"ERROR: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     print(f"ohmo gateway restarted (pid={pid})")
 
 

--- a/ohmo/gateway/service.py
+++ b/ohmo/gateway/service.py
@@ -11,6 +11,7 @@ import os.path
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 if sys.platform == "win32":
@@ -294,7 +295,19 @@ def start_gateway_process(cwd: str | Path | None = None, workspace: str | Path |
             ],
             **popen_kwargs,
         )
-    return process.pid
+
+    # Verify the process actually started rather than crashing immediately.
+    # Poll for up to ~1.5 s in increasing intervals to give the process time
+    # to initialise before declaring it alive.
+    for delay in (0.1, 0.2, 0.4, 0.8):
+        time.sleep(delay)
+        if _pid_is_running(process.pid):
+            return process.pid
+
+    raise RuntimeError(
+        f"Gateway process (pid={process.pid}) exited immediately after start. "
+        f"Check {service.log_file} for details."
+    )
 
 
 def _pid_is_running(pid: int) -> bool:


### PR DESCRIPTION
## Summary

Closes #301

`ohmo gateway restart` called `start_gateway_process()` and immediately
printed `"restarted (pid=N)"` — no verification that the subprocess was
still alive. If the gateway crashed on startup (bad config, port
conflict, missing dependency), the command silently reported success
while the service stayed down, requiring a manual container restart.

**Root cause in `start_gateway_process`:**
- `stdout`/`stderr` are redirected to `gateway.log` so no output
  appears in the calling terminal.
- `subprocess.Popen` returns a handle instantly; the PID is returned
  immediately without checking whether the process survived.

**Fix:** After spawning, poll `_pid_is_running(process.pid)` for up to
~1.5 s in increasing intervals (`0.1 s → 0.2 s → 0.4 s → 0.8 s`).
This gives the process enough time to initialise before declaring it
healthy, while still catching immediate crashes. If no poll succeeds,
raise `RuntimeError` with the PID and log file path.

Update `gateway_restart_cmd` and `_maybe_restart_gateway` to catch that
error and surface a clear message (non-zero exit for the CLI command).

## Test plan
- [ ] Start gateway normally — verify `ohmo gateway restart` still prints `restarted (pid=N)` and the service is up.
- [ ] Simulate a startup failure (e.g. invalid gateway config) — verify `restart` now prints an error pointing to the log file instead of falsely reporting success.
- [ ] Verify `gateway start` (not modified) still works unchanged.