### PR TITLE
fix(config): coerce list/dict/model values in ConfigTool instead of storing raw strings

### DIFF
--- a/src/openharness/tools/config_tool.py
+++ b/src/openharness/tools/config_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -48,6 +49,44 @@ class ConfigTool(BaseTool):
                 value = int(arguments.value)
             elif isinstance(current, float):
                 value = float(arguments.value)
+            elif isinstance(current, dict):
+                try:
+                    value = json.loads(arguments.value)
+                    if not isinstance(value, dict):
+                        return ToolResult(
+                            output=f"Expected a JSON object for {arguments.key}",
+                            is_error=True,
+                        )
+                except json.JSONDecodeError as exc:
+                    return ToolResult(
+                        output=f"Invalid JSON for {arguments.key}: {exc}",
+                        is_error=True,
+                    )
+            elif isinstance(current, list):
+                raw = arguments.value.strip()
+                if raw.startswith("["):
+                    try:
+                        value = json.loads(raw)
+                        if not isinstance(value, list):
+                            return ToolResult(
+                                output=f"Expected a JSON array for {arguments.key}",
+                                is_error=True,
+                            )
+                    except json.JSONDecodeError as exc:
+                        return ToolResult(
+                            output=f"Invalid JSON for {arguments.key}: {exc}",
+                            is_error=True,
+                        )
+                else:
+                    value = [item.strip() for item in raw.split(",") if item.strip()]
+            elif isinstance(current, BaseModel):
+                try:
+                    value = type(current).model_validate(json.loads(arguments.value))
+                except Exception as exc:
+                    return ToolResult(
+                        output=f"Invalid value for {arguments.key}: {exc}",
+                        is_error=True,
+                    )
             setattr(target, leaf, value)
             save_settings(settings)
             return ToolResult(output=f"Updated {arguments.key}")


### PR DESCRIPTION
## Summary

Closes #298

`ConfigTool.execute()` only coerced `bool`, `int`, and `float` when the
model sent a `set` action. For `list`, `dict`, and nested Pydantic model
fields the raw input string was stored directly via `setattr`, causing
`TypeError` or silent misbehavior downstream (e.g. code iterating over
what it expected to be a list, but instead got a string).

**New branches added:**

| Field type | Input handling |
|---|---|
| `dict` | JSON-parsed; non-object payload returns a clear error |
| `list` | JSON array if input starts with `[`; otherwise split on commas (`"a, b"` → `["a", "b"]`) |
| `BaseModel` subfield | JSON-parsed then validated with `model_validate()` |

**Example (before):**
```
set web.synthetic_dns_cidrs to "10.0.0.0/8, 192.168.0.0/16"
# stored: "10.0.0.0/8, 192.168.0.0/16"  ← raw string, breaks iteration
```

**Example (after):**
```
set web.synthetic_dns_cidrs to "10.0.0.0/8, 192.168.0.0/16"
# stored: ["10.0.0.0/8", "192.168.0.0/16"]  ← correct list
```

## Test plan
- [ ] `set web.synthetic_dns_cidrs` to `"10.0.0.0/8, 192.168.0.0/16"` — verify stored value is `["10.0.0.0/8", "192.168.0.0/16"]`
- [ ] `set web.synthetic_dns_cidrs` to `'["10.0.0.0/8"]'` (JSON array form) — verify stored value is `["10.0.0.0/8"]`
- [ ] `set sandbox.docker.extra_env` to `'{"KEY": "val"}'` — verify stored value is `{"KEY": "val"}`
- [ ] `set sandbox.docker.extra_env` to an invalid JSON string — verify an error is returned instead of storing raw string
- [ ] Existing `bool`/`int`/`float` coercions continue to work