### PR TITLE
feat(cli): add 'oh plugin enable' and 'oh plugin disable' subcommands

### DIFF
--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -881,6 +881,38 @@ def plugin_uninstall(
     print(f"Uninstalled plugin: {name}")
 
 
+@plugin_app.command("enable")
+def plugin_enable(
+    name: str = typer.Argument(..., help="Plugin name to enable"),
+) -> None:
+    """Enable an installed plugin."""
+    from openharness.config import load_settings, save_settings
+
+    settings = load_settings()
+    if name not in settings.enabled_plugins:
+        typer.echo(f"Plugin '{name}' is not installed. Run 'oh plugin list' to see available plugins.", err=True)
+        raise typer.Exit(code=1)
+    settings.enabled_plugins[name] = True
+    save_settings(settings)
+    print(f"Enabled plugin '{name}'. Restart session to reload.")
+
+
+@plugin_app.command("disable")
+def plugin_disable(
+    name: str = typer.Argument(..., help="Plugin name to disable"),
+) -> None:
+    """Disable an installed plugin."""
+    from openharness.config import load_settings, save_settings
+
+    settings = load_settings()
+    if name not in settings.enabled_plugins:
+        typer.echo(f"Plugin '{name}' is not installed. Run 'oh plugin list' to see available plugins.", err=True)
+        raise typer.Exit(code=1)
+    settings.enabled_plugins[name] = False
+    save_settings(settings)
+    print(f"Disabled plugin '{name}'. Restart session to reload.")
+
+
 # ---- cron subcommands ----
 
 @cron_app.command("start")


### PR DESCRIPTION
## Summary

Closes #291

The README documents `oh plugin enable <name>` / `oh plugin disable <name>` but those subcommands did not exist. After `oh plugin install <source>` a plugin was registered in `settings.enabled_plugins` as `False`, and the only way to flip it was to open the TUI and run `/plugin enable foo` — which doesn't work for headless (`oh -p "..."`), CI, Docker, or SSH sessions.

**What's added:**

```
oh plugin enable <name>    # sets enabled_plugins[name] = True, saves settings
oh plugin disable <name>   # sets enabled_plugins[name] = False, saves settings
```

Both commands:
- Load current settings, validate the plugin name exists (non-zero exit + helpful error if not)
- Update `settings.enabled_plugins` exactly as the `/plugin` slash handler in `commands/registry.py` does
- Print `"Enabled/Disabled plugin 'X'. Restart session to reload."` to match the TUI message

## Test plan
- [ ] `oh plugin install <path>` then `oh plugin enable <name>` — verify `settings.enabled_plugins[name]` is `True` in `settings.json`
- [ ] `oh plugin disable <name>` — verify it's set to `False`
- [ ] `oh plugin enable nonexistent` — verify non-zero exit and helpful error message
- [ ] `oh plugin list` — verify enabled/disabled state reflects the change