### PR TITLE
fix(tools): enforce workspace containment for read_file/write_file/edit_file

### DIFF
--- a/src/openharness/tools/file_edit_tool.py
+++ b/src/openharness/tools/file_edit_tool.py
@@ -33,6 +33,10 @@ class FileEditTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        contained, reason = _check_workspace_containment(path, context.cwd)
+        if not contained:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():
@@ -73,6 +77,19 @@ def _resolve_path(base: Path, candidate: str) -> Path:
     if not path.is_absolute():
         path = base / path
     return path.resolve()
+
+
+def _check_workspace_containment(path: Path, cwd: Path) -> tuple[bool, str]:
+    """Return (True, "") if path is within cwd, or (False, reason) if not."""
+    resolved_cwd = cwd.resolve()
+    try:
+        path.relative_to(resolved_cwd)
+        return True, ""
+    except ValueError:
+        return False, (
+            f"Access denied: {path} is outside the workspace root ({resolved_cwd}). "
+            "Use a path within the project directory."
+        )
 
 
 def _compute_diff(filename: str, original: str, updated: str) -> tuple[str, int, int]:

--- a/src/openharness/tools/file_read_tool.py
+++ b/src/openharness/tools/file_read_tool.py
@@ -35,6 +35,10 @@ class FileReadTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        contained, reason = _check_workspace_containment(path, context.cwd)
+        if not contained:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():
@@ -70,3 +74,16 @@ def _resolve_path(base: Path, candidate: str) -> Path:
     if not path.is_absolute():
         path = base / path
     return path.resolve()
+
+
+def _check_workspace_containment(path: Path, cwd: Path) -> tuple[bool, str]:
+    """Return (True, "") if path is within cwd, or (False, reason) if not."""
+    resolved_cwd = cwd.resolve()
+    try:
+        path.relative_to(resolved_cwd)
+        return True, ""
+    except ValueError:
+        return False, (
+            f"Access denied: {path} is outside the workspace root ({resolved_cwd}). "
+            "Use an absolute path within the project directory."
+        )

--- a/src/openharness/tools/file_write_tool.py
+++ b/src/openharness/tools/file_write_tool.py
@@ -32,6 +32,10 @@ class FileWriteTool(BaseTool):
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
 
+        contained, reason = _check_workspace_containment(path, context.cwd)
+        if not contained:
+            return ToolResult(output=reason, is_error=True)
+
         from openharness.sandbox.session import is_docker_sandbox_active
 
         if is_docker_sandbox_active():
@@ -65,6 +69,19 @@ def _resolve_path(base: Path, candidate: str) -> Path:
     if not path.is_absolute():
         path = base / path
     return path.resolve()
+
+
+def _check_workspace_containment(path: Path, cwd: Path) -> tuple[bool, str]:
+    """Return (True, "") if path is within cwd, or (False, reason) if not."""
+    resolved_cwd = cwd.resolve()
+    try:
+        path.relative_to(resolved_cwd)
+        return True, ""
+    except ValueError:
+        return False, (
+            f"Access denied: {path} is outside the workspace root ({resolved_cwd}). "
+            "Use a path within the project directory."
+        )
 
 
 def _compute_diff(filename: str, original: str, updated: str) -> tuple[str, int, int]:


### PR DESCRIPTION
## Summary

Closes #310

The built-in file tools (`read_file`, `write_file`, `edit_file`) resolved a model-supplied path to an absolute host path and then operated on it directly — with no check that the result stayed inside the project (workspace) root. A model that supplied an absolute path or enough `../` segments could reach any readable/writable file on the host.

The existing `validate_sandbox_path()` containment boundary only ran inside the `is_docker_sandbox_active()` branch, which is **disabled by default**. On the non-interactive runners (`--task-worker`, print-mode) that auto-approve tool calls, writes could go through with no human gate either.

**Fix:** Add a `_check_workspace_containment(path, cwd)` helper in each file tool that runs **unconditionally**, before the sandbox check, and returns `is_error=True` with a clear message when the resolved path is not relative to `context.cwd`. The check calls `path.relative_to(cwd.resolve())` so symlink escapes are caught after `resolve()` normalises the path.

```
# Before (no guard):
path = _resolve_path(context.cwd, arguments.path)
# … read/write directly …

# After:
path = _resolve_path(context.cwd, arguments.path)
contained, reason = _check_workspace_containment(path, context.cwd)
if not contained:
    return ToolResult(output=reason, is_error=True)
# … sandbox check, then read/write …
```

## Test plan
- [ ] `read_file` with a relative `../` path that escapes the workspace — verify it returns `is_error=True` with an "outside workspace root" message.
- [ ] `read_file` with an absolute path outside the workspace (e.g. `/etc/hosts`) — verify same denial.
- [ ] `write_file` / `edit_file` with an out-of-workspace path — verify denial.
- [ ] Normal operations within the workspace continue to work unchanged.
- [ ] Docker sandbox path still gets validated by `validate_sandbox_path` when active (double-checked by the existing sandbox branch).