### PR TITLE
fix(api): disable qwen3 thinking mode when tools are injected (Ollama)

### DIFF
--- a/src/openharness/api/openai_client.py
+++ b/src/openharness/api/openai_client.py
@@ -41,6 +41,17 @@ MAX_RETRIES = 3
 BASE_DELAY = 1.0
 MAX_DELAY = 30.0
 _MAX_COMPLETION_TOKEN_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+_QWEN3_MODEL_PREFIXES = ("qwen3",)
+
+
+def _is_qwen3_model(model: str) -> bool:
+    """Return True for qwen3-family models (Ollama or HuggingFace naming)."""
+    normalized = model.strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    # Strip quantisation tag (e.g. "qwen3:14b-64k" → "qwen3")
+    normalized = normalized.split(":")[0]
+    return normalized.startswith(_QWEN3_MODEL_PREFIXES)
 
 
 def _token_limit_param_for_model(model: str, max_tokens: int) -> dict[str, int]:
@@ -331,6 +342,13 @@ class OpenAICompatibleClient:
             # tools are present – avoids triggering model-side thinking mode
             # that requires reasoning_content on every assistant message.
             params.pop("stream_options", None)
+            # qwen3 enables thinking mode via its chat template, not via
+            # stream_options.  With 30+ tools injected the reasoning trace
+            # grows very large and the streaming connection times out before
+            # the final token arrives.  Disable thinking mode explicitly when
+            # tools are in use so the model answers directly.
+            if _is_qwen3_model(request.model):
+                params["chat_template_kwargs"] = {"enable_thinking": False}
 
         # Collect full response while streaming text deltas
         collected_content = ""


### PR DESCRIPTION
## Summary

Closes #320

`qwen3`-family models on Ollama enable **thinking mode** via their Jinja chat template, not via `stream_options` (which is already stripped when tools are present to work around a Kimi issue). When 30+ built-in tools are injected into the prompt the reasoning trace grows very large, and the OpenAI streaming connection times out before the final token arrives — surfacing as a generic `"Request timed out"` error even though the model and Ollama server are healthy.

**Diagnosis:** `--bare` skips tools and returns in ~3 s; direct `curl` with no tools also works. Only the combination of qwen3 + tools triggers the hang.

**Fix:** When the model is in the qwen3 family and tools are present, add `chat_template_kwargs={"enable_thinking": False}` to the request params. Ollama forwards `chat_template_kwargs` to the model's Jinja chat template, which suppresses the `<think>` block so the model answers directly without a long reasoning trace.

Adds `_is_qwen3_model()` to detect:
- Ollama tags: `qwen3`, `qwen3:14b-64k`, `qwen3:7b`, …
- HuggingFace namespaced names: `Qwen/Qwen3-7B`, `Qwen/Qwen3-14B-Instruct`, …

## Test plan
- [ ] `oh -p "..." --model qwen3:14b-64k --api-format openai --base-url http://localhost:11434/v1` with tools — verify no timeout and model responds directly.
- [ ] Same with `qwen2.5-coder:7b` (non-qwen3) — verify `chat_template_kwargs` is NOT added.
- [ ] `--bare` mode still works unchanged (tools not injected → `chat_template_kwargs` not added regardless of model).
- [ ] `Qwen/Qwen3-7B` (HuggingFace namespace) is also detected.