### PR TITLE
fix(prompts): disambiguate skills from tools to prevent direct-call failures

### DIFF
--- a/src/openharness/prompts/context.py
+++ b/src/openharness/prompts/context.py
@@ -39,13 +39,21 @@ def _build_skills_section(
     skills = [skill for skill in registry.list_skills() if not skill.disable_model_invocation]
     if not skills:
         return None
+    # Build an example using the first skill name so the model sees a concrete
+    # invocation pattern rather than the abstract placeholder "<skill_name>".
+    first_name = (skills[0].command_name or skills[0].name) if skills else "example-skill"
     lines = [
         "# Available Skills",
         "",
-        "The following skills are available via the `skill` tool. "
-        "When a user's request matches a skill, invoke it with `skill(name=\"<skill_name>\")` "
-        "to load detailed instructions before proceeding. "
-        "User-invocable skills can also be run directly by the user as `/<skill-name>`.",
+        "IMPORTANT: Skills are NOT tools. Do NOT call them as direct function calls.",
+        "Skills must be accessed exclusively through the `skill` tool:",
+        f'  skill(name="{first_name}")',
+        "",
+        "When a user's request matches a skill below, call `skill(name=\"<skill_name>\")` "
+        "to load the full instructions, then follow them. "
+        "Calling a skill name directly as a tool will fail with 'unknown tool'.",
+        "",
+        "Available skills (access each via `skill(name=\"<name>\")`):",
         "",
     ]
     for skill in skills:


### PR DESCRIPTION
## Summary

Closes #292

Weaker models (Qwen72B and similar) read the skills listing in the system prompt and call the skill name directly as a tool — e.g. `tavily-search(query="...")` — instead of the correct `skill(name="tavily-search")`. The call fails with `"unknown tool: tavily_search"` because skills are not registered as tools; they are accessed exclusively through the `skill` built-in tool.

**Root cause (confirmed in issue comment):** The previous instruction said:
> "invoke it with `skill(name="<skill_name>")`"

The abstract placeholder `<skill_name>` is easy for a model to treat as a formatting hint rather than a literal pattern. Combined with the listing format `- **tavily-search**: Search the web...`, the model mistakes the skill name for a registered tool name.

**Fix:** Three changes to `_build_skills_section()`:

1. **Lead with an explicit prohibition** — `IMPORTANT: Skills are NOT tools. Do NOT call them as direct function calls.`
2. **Show a concrete invocation example** using the first real skill name instead of `<skill_name>`, so the model sees `skill(name="tavily-search")` verbatim.
3. **Explain the failure mode** — "Calling a skill name directly as a tool will fail with 'unknown tool'" — giving the model a clear signal to remember.

**Before:**
```
# Available Skills

The following skills are available via the `skill` tool. When a user's request matches a skill, invoke it with skill(name="<skill_name>") to load detailed instructions…

- **tavily-search**: Search the web with Tavily
```

**After:**
```
# Available Skills

IMPORTANT: Skills are NOT tools. Do NOT call them as direct function calls.
Skills must be accessed exclusively through the `skill` tool:
  skill(name="tavily-search")

When a user's request matches a skill below, call `skill(name="<skill_name>")` to load the full instructions…
Calling a skill name directly as a tool will fail with 'unknown tool'.

Available skills (access each via `skill(name="<name>")`):

- **tavily-search**: Search the web with Tavily
```

## Test plan
- [ ] With a weaker model (Qwen72B or similar), install a tavily-search skill and ask a question that matches it — verify the model calls `skill(name="tavily-search")` instead of `tavily-search(query="...")`.
- [ ] With a stronger model (claude-sonnet, gpt-4o), verify existing skill invocation still works correctly.
- [ ] Verify that when no skills are installed, the section is still omitted from the system prompt.