### PR TITLE
fix(tools): add workspace containment to todo_write and notebook_edit

### DIFF
--- a/src/openharness/tools/notebook_edit_tool.py
+++ b/src/openharness/tools/notebook_edit_tool.py
@@ -35,6 +35,14 @@ class NotebookEditTool(BaseTool):
         context: ToolExecutionContext,
     ) -> ToolResult:
         path = _resolve_path(context.cwd, arguments.path)
+        cwd_resolved = context.cwd.resolve()
+        try:
+            path.relative_to(cwd_resolved)
+        except ValueError:
+            return ToolResult(
+                output=f"Access denied: {path} is outside the workspace root ({cwd_resolved}).",
+                is_error=True,
+            )
         notebook = _load_notebook(path, create_if_missing=arguments.create_if_missing)
         if notebook is None:
             return ToolResult(output=f"Notebook not found: {path}", is_error=True)

--- a/src/openharness/tools/todo_write_tool.py
+++ b/src/openharness/tools/todo_write_tool.py
@@ -25,7 +25,15 @@ class TodoWriteTool(BaseTool):
     input_model = TodoWriteToolInput
 
     async def execute(self, arguments: TodoWriteToolInput, context: ToolExecutionContext) -> ToolResult:
-        path = Path(context.cwd) / arguments.path
+        path = (Path(context.cwd) / arguments.path).resolve()
+        cwd_resolved = Path(context.cwd).resolve()
+        try:
+            path.relative_to(cwd_resolved)
+        except ValueError:
+            return ToolResult(
+                output=f"Access denied: {path} is outside the workspace root ({cwd_resolved}).",
+                is_error=True,
+            )
         existing = path.read_text(encoding="utf-8") if path.exists() else "# TODO\n"
 
         unchecked_line = f"- [ ] {arguments.item}"


### PR DESCRIPTION
## Summary

Extends #310 / relates to #328

The workspace containment checks added to `read_file`/`write_file`/`edit_file` missed two additional writing tools that accept model-controlled path arguments:

**`todo_write`** — `path` defaults to `"TODO.md"` but accepts any string. The tool joined it with `context.cwd` but never resolved the result to check for `../` traversal. A path like `"../../../../root/.ssh/authorized_keys"` would resolve and write outside the workspace.

**`notebook_edit`** — uses the same `_resolve_path()` pattern as the three file tools: expand → make absolute → `resolve()`. Accepts absolute paths and `../` traversal sequences with no containment check.

**Fix:** both tools now call `path.relative_to(cwd.resolve())` immediately after path resolution and return `is_error=True` if the resolved path escapes the workspace root — consistent with the check added to the core file tools.

## Test plan
- [ ] `todo_write` with `path="../../etc/passwd"` — verify `is_error=True` with containment message.
- [ ] `notebook_edit` with an absolute path outside `cwd` — verify same denial.
- [ ] Normal `todo_write` with default `TODO.md` still works.
- [ ] Normal `notebook_edit` within the workspace still works.