### PR TITLE
fix(tools): add workspace containment to grep and glob tools

### DIFF
--- a/src/openharness/tools/glob_tool.py
+++ b/src/openharness/tools/glob_tool.py
@@ -35,6 +35,14 @@ class GlobTool(BaseTool):
 
     async def execute(self, arguments: GlobToolInput, context: ToolExecutionContext) -> ToolResult:
         root, pattern = _resolve_glob_request(context.cwd, arguments.root, arguments.pattern)
+        cwd_resolved = context.cwd.resolve()
+        try:
+            root.relative_to(cwd_resolved)
+        except ValueError:
+            return ToolResult(
+                output=f"Access denied: {root} is outside the workspace root ({cwd_resolved}).",
+                is_error=True,
+            )
         matches = await _glob(root, pattern, limit=arguments.limit)
         if not matches:
             return ToolResult(output="(no matches)")

--- a/src/openharness/tools/grep_tool.py
+++ b/src/openharness/tools/grep_tool.py
@@ -39,6 +39,14 @@ class GrepTool(BaseTool):
 
     async def execute(self, arguments: GrepToolInput, context: ToolExecutionContext) -> ToolResult:
         root = _resolve_path(context.cwd, arguments.root) if arguments.root else context.cwd
+        cwd_resolved = context.cwd.resolve()
+        try:
+            root.relative_to(cwd_resolved)
+        except ValueError:
+            return ToolResult(
+                output=f"Access denied: {root} is outside the workspace root ({cwd_resolved}).",
+                is_error=True,
+            )
         if not root.exists():
             return ToolResult(
                 output=(


### PR DESCRIPTION
## Summary

Extends #310 / relates to #328

The read-only search tools (`grep`, `glob`) accepted a model-controlled `root` path argument with no check that it resolved inside the project directory. A model (or prompt-injection attack) could direct these tools at arbitrary host paths (e.g. `/etc/`, `/home/`, `/var/log/`) and read their contents — an information-leakage risk parallel to the write-path issue described in #310.

**`grep_tool`** — `root = _resolve_path(context.cwd, arguments.root)` accepts an absolute path or a `../` traversal, then searches it recursively and returns matching content.

**`glob_tool`** — `_resolve_glob_request()` handles absolute-looking patterns but still allows `root_arg` to escape via `_resolve_path()`.

**Fix:** both tools now call `root.relative_to(cwd.resolve())` after resolving the root, and return `is_error=True` if the path escapes the workspace — before any filesystem read occurs.

## Test plan
- [ ] `grep` with `root="/etc"` — verify `is_error=True` with containment message.
- [ ] `glob` with `root="../../"` — verify same denial.
- [ ] Normal `grep`/`glob` within workspace — verify no regression.
- [ ] `grep` with no `root` (defaults to `context.cwd`) — verify it still works.