### PR TITLE
Add Atlas Cloud provider profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Any provider implementing the OpenAI `/v1/chat/completions` style API works:
 |---------|----------|----------------|
 | **OpenAI** | `https://api.openai.com/v1` | `gpt-5.4`, `gpt-4.1` |
 | **OpenRouter** | `https://openrouter.ai/api/v1` | provider-specific |
+| **Atlas Cloud** | `https://api.atlascloud.ai/v1` | `qwen/qwen3.5-flash`, `deepseek-ai/deepseek-v4-pro` |
 | **Alibaba DashScope** | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen3.5-flash`, `qwen3-max`, `deepseek-r1` |
 | **DeepSeek** | `https://api.deepseek.com` | `deepseek-chat`, `deepseek-reasoner` |
 | **GitHub Models** | `https://models.inference.ai.azure.com` | `gpt-4o`, `Meta-Llama-3.1-405B-Instruct` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,7 +223,7 @@ OpenHarness 现在把 provider 视为 **workflow + profile**，而不是只暴�
 |----------|------|
 | `Anthropic-Compatible API` | Anthropic 风格接口，适合 Claude/Kimi/GLM/MiniMax 等 |
 | `Claude Subscription` | 复用本地 `~/.claude/.credentials.json` |
-| `OpenAI-Compatible API` | OpenAI 风格接口，适合 OpenAI/OpenRouter/各种兼容网关 |
+| `OpenAI-Compatible API` | OpenAI 风格接口，适合 OpenAI/OpenRouter/Atlas Cloud/各种兼容网关 |
 | `Codex Subscription` | 复用本地 `~/.codex/auth.json` |
 | `GitHub Copilot` | GitHub Copilot OAuth workflow |
 

--- a/src/openharness/auth/manager.py
+++ b/src/openharness/auth/manager.py
@@ -37,6 +37,7 @@ _KNOWN_PROVIDERS = [
     "moonshot",
     "gemini",
     "minimax",
+    "atlascloud",
     "modelscope",
 ]
 
@@ -52,6 +53,7 @@ _AUTH_SOURCES = [
     "moonshot_api_key",
     "gemini_api_key",
     "minimax_api_key",
+    "atlascloud_api_key",
     "modelscope_api_key",
 ]
 
@@ -64,6 +66,7 @@ _PROFILE_BY_PROVIDER = {
     "moonshot": "moonshot",
     "gemini": "gemini",
     "minimax": "minimax",
+    "atlascloud": "atlascloud",
     "modelscope": "modelscope",
 }
 
@@ -169,6 +172,17 @@ class AuthManager:
                     configured = True
                     origin = "file"
                     state = "configured"
+            elif source == "atlascloud_api_key":
+                if os.environ.get("OPENHARNESS_ATLASCLOUD_API_KEY") or os.environ.get(
+                    "ATLASCLOUD_API_KEY"
+                ):
+                    configured = True
+                    origin = "env"
+                    state = "configured"
+                elif load_credential(storage_provider, "api_key"):
+                    configured = True
+                    origin = "file"
+                    state = "configured"
             elif load_credential(storage_provider, "api_key"):
                 configured = True
                 origin = "file"
@@ -262,6 +276,16 @@ class AuthManager:
                     configured = True
                     source = "env"
                 elif load_credential("minimax", "api_key"):
+                    configured = True
+                    source = "file"
+
+            elif provider == "atlascloud":
+                if os.environ.get("OPENHARNESS_ATLASCLOUD_API_KEY") or os.environ.get(
+                    "ATLASCLOUD_API_KEY"
+                ):
+                    configured = True
+                    source = "env"
+                elif load_credential("atlascloud", "api_key"):
                     configured = True
                     source = "file"
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -1247,6 +1247,7 @@ _PROVIDER_LABELS: dict[str, str] = {
     "moonshot": "Moonshot (Kimi)",
     "gemini": "Google Gemini",
     "minimax": "MiniMax",
+    "atlascloud": "Atlas Cloud",
     "modelscope": "ModelScope",
 }
 
@@ -1262,6 +1263,7 @@ _AUTH_SOURCE_LABELS: dict[str, str] = {
     "moonshot_api_key": "Moonshot API key",
     "gemini_api_key": "Gemini API key",
     "minimax_api_key": "MiniMax API key",
+    "atlascloud_api_key": "Atlas Cloud API key",
     "modelscope_api_key": "ModelScope API key",
 }
 
@@ -1593,24 +1595,33 @@ def _specialize_setup_target(manager, target: str) -> str:
             [
                 ("openai-compatible", "OpenAI official"),
                 ("openrouter", "OpenRouter"),
+                ("atlascloud", "Atlas Cloud"),
             ],
             default_value="openai-compatible",
         )
         if choice == "openai-compatible":
             return choice
-        base_url = _text_prompt("Base URL", default="https://openrouter.ai/api/v1").strip()
+        defaults = {
+            "openrouter": ("OpenRouter", "https://openrouter.ai/api/v1", ""),
+            "atlascloud": ("Atlas Cloud", "https://api.atlascloud.ai/v1", "qwen/qwen3.5-flash"),
+        }
+        label, suggested_base_url, suggested_model = defaults[choice]
+        base_url = _text_prompt("Base URL", default=suggested_base_url).strip()
         if not base_url:
             raise typer.BadParameter("Base URL cannot be empty.")
-        model = _text_prompt("Default model", default="").strip()
+        model = _text_prompt("Default model", default=suggested_model).strip()
         if not model:
             raise typer.BadParameter("Default model cannot be empty.")
         return _ensure_preset_profile(
             manager,
-            name="openrouter",
-            label="OpenRouter",
-            provider="openai",
+            name=choice,
+            label=label,
+            provider=choice if choice == "atlascloud" else "openai",
             api_format="openai",
-            auth_source=default_auth_source_for_provider("openai", "openai"),
+            auth_source=default_auth_source_for_provider(
+                choice if choice == "atlascloud" else "openai",
+                "openai",
+            ),
             base_url=base_url,
             model=model,
             lock_model=False,
@@ -1729,7 +1740,19 @@ def _login_provider(provider: str) -> None:
         _bind_external_provider(provider)
         return
 
-    if provider in ("anthropic", "openai", "dashscope", "bedrock", "vertex", "moonshot", "gemini", "minimax", "modelscope"):
+    api_key_providers = {
+        "anthropic",
+        "openai",
+        "dashscope",
+        "bedrock",
+        "vertex",
+        "moonshot",
+        "gemini",
+        "minimax",
+        "atlascloud",
+        "modelscope",
+    }
+    if provider in api_key_providers:
         label = _PROVIDER_LABELS.get(provider, provider)
         flow = ApiKeyFlow(provider=provider, prompt_text=f"Enter your {label} API key")
         try:
@@ -1814,7 +1837,9 @@ def auth_login(
     """Interactively authenticate with a provider.
 
     Run without arguments to choose a provider from a menu.
-    Supported providers: anthropic, anthropic_claude, openai, openai_codex, copilot, dashscope, bedrock, vertex, moonshot, minimax, modelscope.
+    Supported providers include anthropic, anthropic_claude, openai,
+    openai_codex, copilot, dashscope, bedrock, vertex, moonshot,
+    minimax, atlascloud, and modelscope.
     """
     if provider is None:
         print("Select a provider to authenticate:", flush=True)

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -263,6 +263,14 @@ def default_provider_profiles() -> dict[str, ProviderProfile]:
             default_model="openai/gpt-oss-120b",
             base_url="https://integrate.api.nvidia.com/v1",
         ),
+        "atlascloud": ProviderProfile(
+            label="Atlas Cloud",
+            provider="atlascloud",
+            api_format="openai",
+            auth_source="atlascloud_api_key",
+            default_model="qwen/qwen3.5-flash",
+            base_url="https://api.atlascloud.ai/v1",
+        ),
         "qwen": ProviderProfile(
             label="Qwen (DashScope)",
             provider="dashscope",
@@ -368,6 +376,7 @@ def auth_source_provider_name(auth_source: str) -> str:
         "gemini_api_key": "gemini",
         "minimax_api_key": "minimax",
         "nvidia_api_key": "nvidia",
+        "atlascloud_api_key": "atlascloud",
         "modelscope_api_key": "modelscope",
     }
     return mapping.get(auth_source, auth_source)
@@ -388,6 +397,7 @@ def auth_source_env_var_candidates(auth_source: str) -> tuple[str, ...]:
         "gemini_api_key": ("OPENHARNESS_GEMINI_API_KEY", "GEMINI_API_KEY"),
         "minimax_api_key": ("OPENHARNESS_MINIMAX_API_KEY", "MINIMAX_API_KEY"),
         "nvidia_api_key": ("OPENHARNESS_NVIDIA_API_KEY", "NVIDIA_API_KEY"),
+        "atlascloud_api_key": ("OPENHARNESS_ATLASCLOUD_API_KEY", "ATLASCLOUD_API_KEY"),
         "modelscope_api_key": ("OPENHARNESS_MODELSCOPE_API_KEY", "MODELSCOPE_API_KEY"),
     }
     return mapping.get(auth_source, ())
@@ -436,6 +446,8 @@ def default_auth_source_for_provider(provider: str, api_format: str | None = Non
         return "minimax_api_key"
     if provider == "nvidia":
         return "nvidia_api_key"
+    if provider == "atlascloud":
+        return "atlascloud_api_key"
     if provider == "modelscope":
         return "modelscope_api_key"
     if provider == "openai" or api_format == "openai":

--- a/src/openharness/ui/backend_host.py
+++ b/src/openharness/ui/backend_host.py
@@ -742,6 +742,13 @@ class ReactBackendHost:
                     ("MiniMax-M2.7-highspeed", "MiniMax fast"),
                 ]
             )
+        elif provider_name == "atlascloud":
+            families.extend(
+                [
+                    ("qwen/qwen3.5-flash", "Fast Atlas Cloud model"),
+                    ("deepseek-ai/deepseek-v4-pro", "Atlas Cloud reasoning model"),
+                ]
+            )
 
         seen: set[str] = set()
         options: list[dict[str, object]] = []

--- a/tests/test_commands/test_cli.py
+++ b/tests/test_commands/test_cli.py
@@ -154,6 +154,53 @@ def test_setup_flow_creates_kimi_profile_with_profile_scoped_key(tmp_path: Path,
     assert load_credential("profile:kimi-anthropic", "api_key") == "sk-kimi-test"
 
 
+def test_setup_flow_creates_atlascloud_profile_with_profile_scoped_key(tmp_path: Path, monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.delenv("OPENHARNESS_ATLASCLOUD_API_KEY", raising=False)
+
+    selections = iter(["openai-compatible", "atlascloud"])
+    prompts = iter(
+        [
+            "https://api.atlascloud.ai/v1",
+            "qwen/qwen3.5-flash",
+        ]
+    )
+
+    monkeypatch.setattr(
+        "openharness.cli._select_setup_workflow",
+        lambda *args, **kwargs: next(selections),
+    )
+    monkeypatch.setattr(
+        "openharness.cli._select_from_menu",
+        lambda *args, **kwargs: next(selections),
+    )
+    monkeypatch.setattr("openharness.cli._text_prompt", lambda *args, **kwargs: next(prompts))
+    monkeypatch.setattr("openharness.auth.flows.ApiKeyFlow.run", lambda self: "apikey-atlas-test")
+    monkeypatch.setattr(
+        "openharness.cli._prompt_model_for_profile",
+        lambda profile: "qwen/qwen3.5-flash",
+    )
+
+    result = runner.invoke(app, ["setup"])
+    assert result.exit_code == 0
+    assert "Setup complete:" in result.output
+    assert "- profile: atlascloud" in result.output
+
+    settings = load_settings()
+    assert settings.active_profile == "atlascloud"
+    profile = settings.resolve_profile()[1]
+    assert profile.provider == "atlascloud"
+    assert profile.base_url == "https://api.atlascloud.ai/v1"
+    assert profile.default_model == "qwen/qwen3.5-flash"
+    assert profile.credential_slot is None
+
+    from openharness.auth.storage import load_credential
+
+    assert load_credential("atlascloud", "api_key") == "apikey-atlas-test"
+
+
 def test_provider_add_can_store_profile_api_key(tmp_path: Path, monkeypatch):
     runner = CliRunner()
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path))

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -912,3 +912,67 @@ class TestModelScopeProvider:
         assert materialized.model == "deepseek-ai/DeepSeek-V4-Flash"
         assert materialized.provider == "modelscope"
         assert materialized.api_format == "openai"
+
+
+class TestAtlasCloudProvider:
+    """Tests for Atlas Cloud provider profile and auth integration."""
+
+    def test_atlascloud_in_default_provider_profiles(self):
+        from openharness.config.settings import default_provider_profiles
+
+        profiles = default_provider_profiles()
+        assert "atlascloud" in profiles
+        profile = profiles["atlascloud"]
+        assert profile.provider == "atlascloud"
+        assert profile.api_format == "openai"
+        assert profile.auth_source == "atlascloud_api_key"
+        assert profile.default_model == "qwen/qwen3.5-flash"
+        assert profile.base_url == "https://api.atlascloud.ai/v1"
+
+    def test_auth_source_provider_name_atlascloud(self):
+        from openharness.config.settings import auth_source_provider_name
+
+        assert auth_source_provider_name("atlascloud_api_key") == "atlascloud"
+
+    def test_default_auth_source_for_atlascloud_provider(self):
+        from openharness.config.settings import default_auth_source_for_provider
+
+        assert default_auth_source_for_provider("atlascloud") == "atlascloud_api_key"
+
+    def test_resolve_auth_reads_atlascloud_api_key_env(self, monkeypatch):
+        monkeypatch.setenv("ATLASCLOUD_API_KEY", "atlascloud-test-key")
+        settings = Settings(
+            active_profile="atlascloud",
+            profiles={
+                "atlascloud": ProviderProfile(
+                    label="Atlas Cloud",
+                    provider="atlascloud",
+                    api_format="openai",
+                    auth_source="atlascloud_api_key",
+                    default_model="qwen/qwen3.5-flash",
+                    base_url="https://api.atlascloud.ai/v1",
+                )
+            },
+        )
+        resolved = settings.resolve_auth()
+        assert resolved.value == "atlascloud-test-key"
+        assert "ATLASCLOUD_API_KEY" in resolved.source
+
+    def test_atlascloud_profile_materializes_default_model(self):
+        settings = Settings(
+            active_profile="atlascloud",
+            profiles={
+                "atlascloud": ProviderProfile(
+                    label="Atlas Cloud",
+                    provider="atlascloud",
+                    api_format="openai",
+                    auth_source="atlascloud_api_key",
+                    default_model="qwen/qwen3.5-flash",
+                    base_url="https://api.atlascloud.ai/v1",
+                )
+            },
+        )
+        materialized = settings.materialize_active_profile()
+        assert materialized.model == "qwen/qwen3.5-flash"
+        assert materialized.provider == "atlascloud"
+        assert materialized.api_format == "openai"


### PR DESCRIPTION
## Summary
- add an Atlas Cloud OpenAI-compatible provider profile with its own `atlascloud_api_key` auth source
- support `ATLASCLOUD_API_KEY` / `OPENHARNESS_ATLASCLOUD_API_KEY` in auth resolution and provider status
- add Atlas Cloud to the setup provider picker and model suggestions
- update the existing provider compatibility docs table only

## Validation
- `PYTHONPATH=src uv run --python /Users/zby/.local/bin/python3.11 --with pytest --with pytest-asyncio --with pydantic --with typer --with rich --with httpx --with anthropic --with openai --with pyyaml --with questionary --with croniter --with watchfiles --with websockets --with mcp --with pyperclip --with slack-sdk --with python-telegram-bot --with discord.py --with lark-oapi python -m pytest tests/test_config/test_settings.py::TestAtlasCloudProvider tests/test_commands/test_cli.py::test_setup_flow_creates_atlascloud_profile_with_profile_scoped_key -q`
- `PYTHONPATH=src uv run --python /Users/zby/.local/bin/python3.11 --with ruff ruff check src/openharness/config/settings.py src/openharness/auth/manager.py src/openharness/cli.py src/openharness/ui/backend_host.py tests/test_config/test_settings.py tests/test_commands/test_cli.py`
- `git diff --check`
- `PYTHONPATH=src /Users/zby/.local/bin/python3.11 -m compileall -q src/openharness tests/test_config/test_settings.py tests/test_commands/test_cli.py`

## Notes
- No sponsor block, logo wall, credits, or partner copy was added.
- README changes are limited to the existing provider compatibility section.
- Atlas Cloud model IDs were checked against the live public model catalog before opening this PR.
