### PR TITLE
fix(swarm): deliver leader messages to in-process teammates

### DIFF
--- a/src/openharness/swarm/in_process.py
+++ b/src/openharness/swarm/in_process.py
@@ -242,7 +242,9 @@ async def start_in_process_teammate(
     )
     set_teammate_context(ctx)
 
-    mailbox = TeammateMailbox(team_name=config.team, agent_id=agent_id)
+    # Poll the inbox keyed by the bare agent name — that is where the leader's
+    # send_message() delivers, not the fully-qualified ``name@team`` id.
+    mailbox = TeammateMailbox(team_name=config.team, agent_id=config.name)
 
     logger.debug("[in_process] %s: starting", agent_id)
 

--- a/tests/test_swarm/test_in_process.py
+++ b/tests/test_swarm/test_in_process.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from openharness.swarm.in_process import (
     InProcessBackend,
+    TeammateAbortController,
     TeammateContext,
     get_teammate_context,
     set_teammate_context,
+    start_in_process_teammate,
 )
 from openharness.swarm.types import TeammateMessage, TeammateSpawnConfig
 
@@ -153,6 +156,45 @@ async def test_send_message_writes_to_mailbox(backend, tmp_path, monkeypatch):
 async def test_send_message_invalid_agent_id_raises(backend):
     with pytest.raises(ValueError, match="agentName@teamName"):
         await backend.send_message("no-at-sign", TeammateMessage(text="hi", from_agent="l"))
+
+
+async def test_teammate_receives_message_sent_by_leader(backend, tmp_path, monkeypatch):
+    # send_message writes to the inbox keyed by the bare agent name, so the
+    # running teammate must poll that same inbox. Regression guard for the key
+    # mismatch where start_in_process_teammate polled "name@team" instead and
+    # every leader -> teammate message was silently dropped.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    config = TeammateSpawnConfig(
+        name="rcvr",
+        team="myteam",
+        prompt="wait",
+        cwd="/tmp",
+        parent_session_id="s",
+    )
+
+    await backend.send_message(
+        "rcvr@myteam", TeammateMessage(text="work on it", from_agent="leader")
+    )
+
+    # Drive a single query turn so the teammate drains its mailbox exactly once.
+    async def fake_run_query(query_context, messages):
+        yield SimpleNamespace(type="text"), None
+
+    monkeypatch.setattr("openharness.engine.query.run_query", fake_run_query)
+
+    await start_in_process_teammate(
+        config=config,
+        agent_id="rcvr@myteam",
+        abort_controller=TeammateAbortController(),
+        query_context=object(),
+    )
+
+    from openharness.swarm.mailbox import TeammateMailbox
+
+    inbox = TeammateMailbox(team_name="myteam", agent_id="rcvr")
+    assert await inbox.read_all(unread_only=True) == []
+    delivered = await inbox.read_all(unread_only=False)
+    assert any(m.payload.get("content") == "work on it" for m in delivered)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

Issue: #336

## Problem

For teammates on the in-process backend, messages the leader sends never reach
the teammate — the write and read sides key the mailbox directory differently.

Mailboxes live at `~/.openharness/teams/<team>/agents/<agent_id>/inbox/`.

- `InProcessBackend.send_message(agent_id="name@team", ...)` writes to the inbox
  keyed by the **bare agent name** — `agents/<name>/inbox/`
  (`src/openharness/swarm/in_process.py:525`). This is the convention used
  everywhere else in the swarm (`write_to_mailbox(recipient_name, ...)`,
  `permission_sync`'s `worker_id` / `leader_id="leader"`, and the `"leader"`
  idle-notification target at `in_process.py:284`), and it is pinned by the
  existing `test_send_message_writes_to_mailbox`.
- `start_in_process_teammate` polls the inbox keyed by the **fully-qualified**
  `name@team` id — `agents/<name@team>/inbox/`
  (`src/openharness/swarm/in_process.py:245`).

`agents/<name>/inbox/` ≠ `agents/<name@team>/inbox/`, so the teammate polls a
directory the leader never writes to. Both `user_message` and mailbox-based
`shutdown` deliveries are silently dropped.

## Change

- Poll the inbox keyed by `config.name` (the bare agent name) so the read side
  matches the write side and the rest of the swarm.
- Add `test_teammate_receives_message_sent_by_leader`, which drives one real
  teammate query turn (stubbing `run_query` to yield a single event) and
  asserts the leader's message is drained and marked read from the inbox. It
  fails on `main` (message stays `read=False`) and passes with this change.

One-line runtime change; no public API change.

## Verification

```
uv run pytest tests/test_swarm/ -q      # 138 passed (137 before + the new test)
uv run pytest -q                        # only the 2 pre-existing, unrelated
                                        # skill-registry failures remain
```

The new test fails without the fix and passes with it.