### PR TITLE
fix(gateway): block bridge remote-admin bypass

### DIFF
--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -2365,7 +2365,6 @@ def create_default_command_registry(
             "Inspect bridge helpers and spawn bridge sessions",
             _bridge_handler,
             remote_invocable=False,
-            remote_admin_opt_in=True,
         )
     )
     registry.register(

--- a/tests/test_commands/test_registry.py
+++ b/tests/test_commands/test_registry.py
@@ -159,12 +159,12 @@ async def test_bridge_command_is_marked_local_only(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_bridge_command_supports_explicit_remote_admin_opt_in(tmp_path: Path, monkeypatch):
+async def test_bridge_command_is_not_remote_admin_opted_in(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
     registry = create_default_command_registry()
     command, _ = registry.lookup("/bridge spawn id")
     assert command is not None
-    assert getattr(command, "remote_admin_opt_in", False) is True
+    assert getattr(command, "remote_admin_opt_in", False) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -1143,9 +1143,19 @@ async def test_runtime_pool_blocks_bridge_spawn_from_remote_messages(tmp_path, m
 
 
 @pytest.mark.asyncio
-async def test_runtime_pool_blocks_registered_bridge_spawn_without_shelling_out(tmp_path, monkeypatch):
+async def test_runtime_pool_blocks_registered_bridge_spawn_when_remote_admin_allows_bridge(
+    tmp_path, monkeypatch
+):
     workspace = tmp_path / ".ohmo-home"
     initialize_workspace(workspace)
+    save_gateway_config(
+        GatewayConfig(
+            provider_profile="codex",
+            allow_remote_admin_commands=True,
+            allowed_remote_admin_commands=["bridge"],
+        ),
+        workspace,
+    )
     marker = tmp_path / "remote-bridge-marker.txt"
     payload = f"/bridge spawn printf REMOTE_BRIDGE_EXEC > {marker}"
     registry = create_default_command_registry()


### PR DESCRIPTION
## Summary

  - This PR fixes a remote-admin bypass for the `/bridge` command in the gateway message path.
  - The `bridge` command is intended to remain local-only (`remote_invocable=False`), but it was also registered with `remote_admin_opt_in=True`, which allowed the gateway runtime to
  accept it when remote-admin commands were enabled and `bridge` was allowlisted.
  - This change removes the remote-admin opt-in from `bridge` so it can no longer be elevated back into a remotely invocable command through the remote-admin override path.
  - This PR also updates regression coverage to verify that:
    - `/bridge` remains local-only
    - `bridge` is not remote-admin opted in
    - remote messages cannot invoke `/bridge spawn ...` even when remote-admin commands are enabled and `bridge` is allowlisted
    - other explicitly opted-in remote-admin commands continue to work

  ## Validation

  - [x] Targeted regression tests for the gateway and command registry passed

  Targeted checks run:

  ```bash
  python - <<'PY'
  import sys, types, pytest
  sys.modules['readline'] = types.ModuleType('readline')
  raise SystemExit(pytest.main([
      'tests/test_commands/test_registry.py::test_bridge_command_is_marked_local_only',
      'tests/test_commands/test_registry.py::test_bridge_command_is_not_remote_admin_opted_in',
      'tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_bridge_spawn_from_remote_messages',
      'tests/test_ohmo/test_gateway.py::test_runtime_pool_blocks_registered_bridge_spawn_when_remote_admin_allows_bridge',
      'tests/test_ohmo/test_gateway.py::test_runtime_pool_allows_opted_in_remote_admin_commands',
      '-q',
  ]))
  PY

  Observed result:

  5 passed in 2.02s

  ## Notes

  - Related issue: none
  - Follow-up work:
      - Consider whether other local-only commands should continue to support remote-admin elevation, or whether the gateway should enforce a stricter separation between local-only
        commands and remote-admin commands.