### PR TITLE
fix(mcp): adapt to mcp 2.0.0 SDK API changes

### DIFF
--- a/src/openharness/mcp/client.py
+++ b/src/openharness/mcp/client.py
@@ -147,8 +147,8 @@ class McpClientManager:
                 parts.append(getattr(item, "text", ""))
             else:
                 parts.append(item.model_dump_json())
-        if result.structuredContent and not parts:
-            parts.append(str(result.structuredContent))
+        if result.structured_content and not parts:
+            parts.append(str(result.structured_content))
         if not parts:
             parts.append("(no output)")
         return "\n".join(parts).strip()
@@ -221,7 +221,7 @@ class McpClientManager:
             http_client = await stack.enter_async_context(
                 httpx.AsyncClient(headers=config.headers or None)
             )
-            read_stream, write_stream, _get_session_id = await stack.enter_async_context(
+            read_stream, write_stream = await stack.enter_async_context(
                 streamable_http_client(config.url, http_client=http_client)
             )
             await self._register_connected_session(
@@ -273,7 +273,7 @@ class McpClientManager:
                 server_name=name,
                 name=tool.name,
                 description=tool.description or "",
-                input_schema=dict(tool.inputSchema or {"type": "object", "properties": {}}),
+                input_schema=dict(tool.input_schema or {"type": "object", "properties": {}}),
             )
             for tool in tool_result.tools
         ]

--- a/tests/fixtures/fake_mcp_server.py
+++ b/tests/fixtures/fake_mcp_server.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-server = FastMCP("fixture-demo")
+server = MCPServer("fixture-demo")
 
 
 @server.tool()

--- a/tests/test_mcp/test_client_errors.py
+++ b/tests/test_mcp/test_client_errors.py
@@ -181,7 +181,7 @@ async def test_connect_all_marks_http_server_failed_when_initialize_is_cancelled
     monkeypatch.setattr(
         client_module,
         "streamable_http_client",
-        lambda *args, **kwargs: _AsyncContextManager((object(), object(), AsyncMock())),
+        lambda *args, **kwargs: _AsyncContextManager((object(), object())),
     )
     manager._register_connected_session = AsyncMock(
         side_effect=asyncio.CancelledError("simulated cancellation")

--- a/tests/test_mcp/test_http_flow.py
+++ b/tests/test_mcp/test_http_flow.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 
 import openharness.mcp.client as client_module
@@ -18,10 +18,7 @@ from openharness.tools.base import ToolExecutionContext
 
 @pytest.mark.asyncio
 async def test_http_mcp_manager_connects_and_executes_in_process_server(monkeypatch):
-    server = FastMCP(
-        "demo-http",
-        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
-    )
+    server = MCPServer("demo-http")
 
     @server.tool()
     def hello(name: str) -> str:
@@ -31,7 +28,9 @@ async def test_http_mcp_manager_connects_and_executes_in_process_server(monkeypa
     def readme() -> str:
         return "http fixture resource contents"
 
-    app = server.streamable_http_app()
+    app = server.streamable_http_app(
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False)
+    )
     transport = httpx.ASGITransport(app=app)
     original_async_client = client_module.httpx.AsyncClient
     seen_headers: list[dict[str, str] | None] = []


### PR DESCRIPTION
## Summary
- `pyproject.toml`'s `mcp>=1.0.0` constraint currently resolves to `mcp==2.0.0`, a breaking release of the official MCP Python SDK, which broke `uv run pytest` on a fresh clone (`ModuleNotFoundError: No module named 'mcp.server.fastmcp'`).
- Adapts the codebase and tests to the 2.0.0 API instead of pinning to an older SDK version:
  - `mcp.server.fastmcp.FastMCP` -> `mcp.server.mcpserver.MCPServer`
  - `transport_security` moved from the `MCPServer()` constructor to `.streamable_http_app()`
  - `Tool.inputSchema` -> `Tool.input_schema`, `CallToolResult.structuredContent` -> `CallToolResult.structured_content` (SDK renamed several fields to snake_case)
  - `streamable_http_client(...)` now yields a 2-tuple `(read_stream, write_stream)` instead of 3 (dropped an unused session-id callback)

## Test plan
- [x] `uv run pytest -q` — 1153 passed, 6 skipped, 0 failed (previously failed at collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)