### PR TITLE
Add Gondola provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 - Hooks now support a `priority` field (default `0`). Within an event, hooks run highest-priority first, and hooks sharing a priority keep their registration order. This lets users order, for example, a security-check hook ahead of a logging hook regardless of where each is declared in settings or contributed by plugins.
 - `edit_file` and `write_file` in the React TUI now preview a unified diff before applying file changes, let users approve once or for the rest of the session, and skip the extra prompt automatically in `full_auto` mode.
+- Added Gondola as a built-in OpenAI-compatible gateway provider (`GONDOLA_API_KEY`, keys prefixed `gnd_`), a USDC-paid Venice AI inference marketplace.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Any provider implementing the OpenAI `/v1/chat/completions` style API works:
 |---------|----------|----------------|
 | **OpenAI** | `https://api.openai.com/v1` | `gpt-5.4`, `gpt-4.1` |
 | **OpenRouter** | `https://openrouter.ai/api/v1` | provider-specific |
+| **Gondola** | `https://api.gondola-ai.com/v1` | `claude-opus-5`, `deepseek-v3.2`, `kimi-k2-5` |
 | **Alibaba DashScope** | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen3.5-flash`, `qwen3-max`, `deepseek-r1` |
 | **DeepSeek** | `https://api.deepseek.com` | `deepseek-chat`, `deepseek-reasoner` |
 | **GitHub Models** | `https://models.inference.ai.azure.com` | `gpt-4o`, `Meta-Llama-3.1-405B-Instruct` |

--- a/src/openharness/api/registry.py
+++ b/src/openharness/api/registry.py
@@ -82,6 +82,20 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         is_local=False,
         is_oauth=False,
     ),
+    # Gondola: USDC-paid Venice AI marketplace gateway, keys start with "gnd_"
+    ProviderSpec(
+        name="gondola",
+        keywords=("gondola",),
+        env_key="GONDOLA_API_KEY",
+        display_name="Gondola",
+        backend_type="openai_compat",
+        default_base_url="https://api.gondola-ai.com/v1",
+        detect_by_key_prefix="gnd_",
+        detect_by_base_keyword="gondola",
+        is_gateway=True,
+        is_local=False,
+        is_oauth=False,
+    ),
     # AiHubMix: OpenAI-compatible gateway
     ProviderSpec(
         name="aihubmix",


### PR DESCRIPTION
Adds **Gondola** (https://gondola-ai.com) as a built-in provider, per the instructions in the `registry.py` header: one `ProviderSpec` (gateway, `openai_compat`, base URL `https://api.gondola-ai.com/v1`, key prefix `gnd_` for auto-detection), a README compatibility row, and a CHANGELOG line.

Gondola is a marketplace for Venice AI inference: 105 text models (GPT-5.6, Claude Opus 5, Gemini 3.6, Kimi K3, DeepSeek V4, plus uncensored lines), one OpenAI-compatible endpoint, paid per request in USDC, no subscription. Suppliers compete per request so prices sit below the official APIs (live board at https://gondola-ai.com/models). Public no-auth catalog at `GET /v1/models`, so model detection works out of the box.

Already usable today via `oh provider add`; this entry adds setup-picker visibility and key auto-detection. `ruff check` clean on the touched file, and no test references the provider registry. Setup guide for OpenHarness users: https://gondola-ai.com/guides/openharness
