### PR TITLE
fix(session): preserve session ID after resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- `/resume <session_id>` now keeps writing subsequent turns to the restored session instead of creating a new session snapshot under the runtime's startup ID.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -112,6 +112,7 @@ class CommandResult:
     refresh_runtime: bool = False
     submit_prompt: str | None = None
     submit_model: str | None = None
+    resumed_session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -814,6 +815,7 @@ def create_default_command_registry(
                 message=f"Restored {len(messages)} messages from session {sid}"
                 + (f" ({summary})" if summary else ""),
                 replay_messages=messages,
+                resumed_session_id=str(snapshot.get("session_id") or sid),
             )
 
         # /resume — list sessions (for the TUI to show a picker)
@@ -830,6 +832,7 @@ def create_default_command_registry(
             return CommandResult(
                 message=f"Restored {len(messages)} messages from the latest session.",
                 replay_messages=messages,
+                resumed_session_id=str(snapshot.get("session_id") or "") or None,
             )
 
         # Format session list for display / picker

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -657,6 +657,9 @@ async def handle_line(
             args,
             command_context,
         )
+        if result.resumed_session_id is not None:
+            bundle.session_id = result.resumed_session_id
+            bundle.engine.tool_metadata["session_id"] = result.resumed_session_id
         if result.refresh_runtime:
             refresh_runtime_client(bundle)
         await _render_command_result(result, print_system, clear_output, render_event)

--- a/tests/test_ui/test_runtime_plan_mode.py
+++ b/tests/test_ui/test_runtime_plan_mode.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from openharness.api.client import ApiMessageCompleteEvent
+from openharness.api.usage import UsageSnapshot
+from openharness.engine.messages import ConversationMessage, TextBlock
 from openharness.ui.runtime import build_runtime, close_runtime, handle_line
 
 
@@ -12,6 +15,19 @@ class _StaticApiClient:
         del request
         if False:
             yield None
+
+
+class _ReplyingApiClient:
+    async def stream_message(self, request):
+        del request
+        yield ApiMessageCompleteEvent(
+            message=ConversationMessage(
+                role="assistant",
+                content=[TextBlock(text="continued")],
+            ),
+            usage=UsageSnapshot(input_tokens=1, output_tokens=1),
+            stop_reason=None,
+        )
 
 
 @pytest.mark.asyncio
@@ -45,5 +61,69 @@ async def test_plan_command_refreshes_engine_system_prompt(tmp_path: Path, monke
         assert bundle.app_state.get().permission_mode == "plan"
         assert "Plan mode is enabled" in bundle.engine.system_prompt
         assert "Do not call mutating tools" in bundle.engine.system_prompt
+    finally:
+        await close_runtime(bundle)
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_session_id_for_next_snapshot(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("OPENHARNESS_LOGS_DIR", str(tmp_path / "logs"))
+
+    bundle = await build_runtime(cwd=str(tmp_path), api_client=_ReplyingApiClient())
+    original_session_id = bundle.session_id
+    resumed_session_id = "resume-me"
+    bundle.session_backend.save_snapshot(
+        cwd=bundle.cwd,
+        model=bundle.engine.model,
+        system_prompt=bundle.engine.system_prompt,
+        messages=[ConversationMessage(role="user", content=[TextBlock(text="before")])],
+        usage=UsageSnapshot(),
+        session_id=resumed_session_id,
+        tool_metadata={},
+    )
+
+    async def print_system(text: str) -> None:
+        del text
+
+    async def render_event(event) -> None:
+        del event
+
+    async def clear_output() -> None:
+        pass
+
+    try:
+        await handle_line(
+            bundle,
+            f"/resume {resumed_session_id}",
+            print_system=print_system,
+            render_event=render_event,
+            clear_output=clear_output,
+        )
+
+        assert bundle.session_id == resumed_session_id
+        assert bundle.engine.tool_metadata["session_id"] == resumed_session_id
+
+        await handle_line(
+            bundle,
+            "continue this session",
+            print_system=print_system,
+            render_event=render_event,
+            clear_output=clear_output,
+        )
+
+        resumed = bundle.session_backend.load_by_id(bundle.cwd, resumed_session_id)
+        assert resumed is not None
+        assert resumed["session_id"] == resumed_session_id
+        message_texts = {
+            (message["role"], block["text"])
+            for message in resumed["messages"]
+            for block in message["content"]
+            if block.get("type") == "text"
+        }
+        assert ("user", "continue this session") in message_texts
+        assert ("assistant", "continued") in message_texts
+        assert bundle.session_backend.load_by_id(bundle.cwd, original_session_id) is None
     finally:
         await close_runtime(bundle)


### PR DESCRIPTION
## Summary

- Fixes `/resume <session_id>` restoring messages without updating the runtime's active session ID.
- Carries the restored ID explicitly through `CommandResult`, then updates both the runtime bundle and engine tool metadata before the next turn.
- Adds an end-to-end regression test proving that the next prompt is saved back to the restored session instead of a new startup session.

## Validation

- [x] `pytest tests/test_ui/test_runtime_plan_mode.py tests/test_commands/test_registry.py -k "resume or plan_mode" -q`
- [x] `ruff check --select F src/openharness/commands/registry.py src/openharness/ui/runtime.py tests/test_ui/test_runtime_plan_mode.py`
- [ ] `uv run ruff check src tests scripts` (`uv` is not available in the local Windows test environment)
- [ ] `uv run pytest -q` (the full local run reached 1094 passed / 11 skipped; remaining failures require subprocess, TTY, symlink, or timezone capabilities unavailable in the Windows sandbox)
- [ ] `cd frontend/terminal && npx tsc --noEmit` (frontend not touched)

## Notes

- Related issue: Fixes #345
- Follow-up work: None. This intentionally does not change session storage format or `/resume` selection behavior.
