### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,11 +864,11 @@ MIT — see [LICENSE](LICENSE).
 </p>
 
 <div align="center">
-  <a href="https://star-history.com/#HKUDS/OpenHarness&Date">
+  <a href="https://star-history.dera.page/#HKUDS/OpenHarness&type=Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=HKUDS/OpenHarness&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=HKUDS/OpenHarness&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=HKUDS/OpenHarness&type=Date" style="border-radius: 15px; box-shadow: 0 0 30px rgba(0, 217, 255, 0.3);" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=HKUDS/OpenHarness&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=HKUDS/OpenHarness&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=HKUDS/OpenHarness&type=Date" style="border-radius: 15px; box-shadow: 0 0 30px rgba(0, 217, 255, 0.3);" />
     </picture>
   </a>
 </div>


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and shows no data because of GitHub stargazer API restrictions. This updates the chart to use a working endpoint that requires no API token, so the star history renders correctly again.