### PR TITLE
fix(permissions): stop decoy raw keys from shadowing real tool paths

### DIFF
--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -1023,16 +1023,23 @@ def _resolve_permission_file_path(
     raw_input: dict[str, object],
     parsed_input: object,
 ) -> str | None:
-    for key in ("file_path", "path", "root"):
-        value = raw_input.get(key)
+    # Permission must judge exactly what execution will touch. Execution
+    # receives only the validated model (tool.execute(parsed_input, ...)), so
+    # parsed fields are authoritative. Checking raw keys first lets a decoy
+    # field Pydantic drops during validation (e.g. `file_path` on read_file,
+    # whose schema field is `path`) shadow the real path and bypass deny
+    # rules (issue #348). Raw keys remain a fallback for dynamic-schema tools
+    # (MCP proxies) whose parsed model exposes no path attributes.
+    for attr in ("file_path", "path", "root"):
+        value = getattr(parsed_input, attr, None)
         if isinstance(value, str) and value.strip():
             path = Path(value).expanduser()
             if not path.is_absolute():
                 path = cwd / path
             return str(path.resolve())
 
-    for attr in ("file_path", "path", "root"):
-        value = getattr(parsed_input, attr, None)
+    for key in ("file_path", "path", "root"):
+        value = raw_input.get(key)
         if isinstance(value, str) and value.strip():
             path = Path(value).expanduser()
             if not path.is_absolute():
@@ -1046,11 +1053,13 @@ def _extract_permission_command(
     raw_input: dict[str, object],
     parsed_input: object,
 ) -> str | None:
-    value = raw_input.get("command")
+    # Parsed-first for the same reason as _resolve_permission_file_path: a
+    # raw key the schema dropped must never shadow what execution will run.
+    value = getattr(parsed_input, "command", None)
     if isinstance(value, str) and value.strip():
         return value
 
-    value = getattr(parsed_input, "command", None)
+    value = raw_input.get("command")
     if isinstance(value, str) and value.strip():
         return value
 

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -990,6 +990,80 @@ async def test_execute_tool_call_applies_path_rules_to_directory_roots(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_call_decoy_file_path_cannot_shadow_deny_rule(tmp_path: Path):
+    """Issue #348: a raw `file_path` key that Pydantic drops during validation
+    must not shadow the schema's real `path` field during permission checks."""
+    blocked_dir = tmp_path / "work" / "blocked"
+    blocked_dir.mkdir(parents=True)
+    (blocked_dir / "secret.txt").write_text("top-secret\n", encoding="utf-8")
+    readme = tmp_path / "README.md"
+    readme.write_text("hello\n", encoding="utf-8")
+
+    registry = ToolRegistry()
+    registry.register(create_default_tool_registry().get("read_file"))
+    settings = PermissionSettings(
+        mode=PermissionMode.FULL_AUTO,
+        path_rules=[{"pattern": str(blocked_dir) + "/*", "allow": False}],
+    )
+
+    # The PoC pair: decoy allowed path + real denied path.
+    result = await _execute_tool_call(
+        _tool_context(tmp_path, registry, settings),
+        "read_file",
+        "toolu_read_poc",
+        {"file_path": str(readme), "path": "work/blocked/secret.txt", "offset": 0, "limit": 10},
+    )
+    assert result.is_error is True
+    assert "deny" in result.content.lower() or str(blocked_dir) in result.content
+
+    # Control: the same call without the decoy was already blocked before.
+    control = await _execute_tool_call(
+        _tool_context(tmp_path, registry, settings),
+        "read_file",
+        "toolu_read_control",
+        {"path": "work/blocked/secret.txt", "offset": 0, "limit": 10},
+    )
+    assert control.is_error is True
+
+    # The decoy alone must not grant access either way round: real field
+    # pointing at an allowed file stays allowed (no over-blocking).
+    ok = await _execute_tool_call(
+        _tool_context(tmp_path, registry, settings),
+        "read_file",
+        "toolu_read_ok",
+        {"path": "README.md", "file_path": "work/blocked/secret.txt"},
+    )
+    assert ok.is_error is False
+    assert "hello" in (ok.content or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_decoy_file_path_cannot_shadow_write_deny_rule(tmp_path: Path):
+    blocked_dir = tmp_path / "work" / "blocked"
+    blocked_dir.mkdir(parents=True)
+
+    registry = ToolRegistry()
+    registry.register(create_default_tool_registry().get("write_file"))
+
+    result = await _execute_tool_call(
+        _tool_context(
+            tmp_path,
+            registry,
+            PermissionSettings(
+                mode=PermissionMode.FULL_AUTO,
+                path_rules=[{"pattern": str(blocked_dir) + "/*", "allow": False}],
+            ),
+        ),
+        "write_file",
+        "toolu_write_poc",
+        {"file_path": "README.md", "path": "work/blocked/output.txt", "content": "poc"},
+    )
+
+    assert result.is_error is True
+    assert not (blocked_dir / "output.txt").exists()
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_call_returns_actionable_reason_when_user_denies_confirmation(tmp_path: Path):
     async def _deny(_tool_name: str, _reason: str) -> bool:
         return False


### PR DESCRIPTION
Fixes #348

## Root cause

`_resolve_permission_file_path` in `src/openharness/engine/query.py` checked **raw** `tool_input` keys (`file_path` first) before the validated model, but execution runs on **`parsed_input` only** — `tool.execute(parsed_input, ...)`. Since every built-in file tool's schema field is `path` (read_file, write_file, edit), a model-supplied `file_path` key is dropped by Pydantic as an unknown field while still winning the permission check. Deny rules evaluated the decoy; execution touched the real path.

The same raw-first pattern existed in `_extract_permission_command`.

## Change

Both resolvers now treat validated model fields as authoritative and fall back to raw keys only for dynamic-schema tools (MCP proxies) whose parsed models expose no path/command attributes:

```python
# parsed first — execution uses exactly these values
for attr in ("file_path", "path", "root"):
    value = getattr(parsed_input, attr, None)
    ...
# fallback for dynamic-schema tools
for key in ("file_path", "path", "root"):
    value = raw_input.get(key)
```

## Verification

Engine-level regressions reproduce the issue PoC without any live model endpoint:

- read_file with `{"file_path": "README.md", "path": "work/blocked/secret.txt"}` under a deny rule → blocked (was: returned file contents)
- write_file with the same decoy pair under FULL_AUTO + deny rule → blocked, nothing written (was: wrote into denied path)
- Control cases preserved: no-decoy calls still deny; a real allowed path with a decoy pointing at a denied one still succeeds (no over-blocking)

```
pytest tests/test_engine/test_query_engine.py -k decoy        # 2 failed on vulnerable code -> 3 passed with fix
pytest tests/test_engine tests/test_permissions tests/test_tools  # 190 passed; identical 3 pre-existing env failures on clean main
```

---
This change was prepared with AI assistance under human direction and review.
