### PR TITLE
fix(plugins): use plugin.json name for the installed plugin directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- `oh plugin install`: plugin identity now reads `name` from `plugin.json` instead of using the source directory basename. Ex. passing `src/` no longer installs the plugin as `src`.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/plugins/installer.py
+++ b/src/openharness/plugins/installer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -23,7 +24,12 @@ def _resolve_user_plugin_dir(name: str) -> Path:
 def install_plugin_from_path(source: str | Path) -> Path:
     """Install a plugin directory into the user plugin directory."""
     src = Path(source).resolve()
-    dest = get_user_plugins_dir() / src.name
+    manifest = src / "plugin.json"
+    if manifest.exists():
+        name = json.loads(manifest.read_text())["name"]
+    else:
+        name = src.name
+    dest = get_user_plugins_dir() / name
     if dest.exists():
         shutil.rmtree(dest)
     shutil.copytree(src, dest)

--- a/tests/test_plugins/test_lifecycle_flow.py
+++ b/tests/test_plugins/test_lifecycle_flow.py
@@ -94,6 +94,28 @@ async def test_plugin_install_load_and_uninstall_flow(tmp_path: Path, monkeypatc
     assert load_plugins(load_settings(), project) == []
 
 
+def test_install_plugin_from_path_uses_plugin_json_name(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    plugin_dir = tmp_path / "src"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.json").write_text('{"name": "my-plugin"}', encoding="utf-8")
+
+    dest = install_plugin_from_path(plugin_dir)
+
+    assert dest.name == "my-plugin"
+    assert (dest / "plugin.json").exists()
+
+
+def test_install_plugin_from_path_falls_back_to_dir_name(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    plugin_dir = tmp_path / "my-plugin"
+    plugin_dir.mkdir()
+
+    dest = install_plugin_from_path(plugin_dir)
+
+    assert dest.name == "my-plugin"
+
+
 def test_uninstall_plugin_rejects_traversal_name_without_deleting_sibling(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
  - `install_plugin_from_path` named the destination directory after the source directory basename instead of the name field in plugin.json. Installing a plugin by pointing at its src/ directory would place it under <plugins_dir>/src/ rather than
    <plugins_dir>/my-plugin/, causing potentially overlapping plugin directory names if two plugins used say `src` directory. This also affects `plugin uninstall` CLI command since the `plugin list` will show the plugin name from the `plugin.json` where as the uninstall command looks for the directory `src` and does not uninstall at all.

  - Read name from plugin.json when present to determine the destination directory; fall back to the source directory
    basename only when there is no manifest.

## Validation

  - [x] uv run ruff check src tests scripts
  - [x] uv run pytest -q

## Notes

- Related issue: - 
- Follow-up work: - 
