### PR TITLE
feat(plugins): support git URL in oh plugin install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Added
 
+- `oh plugin install` now accepts git URLs (`https://`, `git+https://`). The repository is cloned with `--depth=1` into a temporary directory and installed from there.
 - Hooks now support a `priority` field (default `0`). Within an event, hooks run highest-priority first, and hooks sharing a priority keep their registration order. This lets users order, for example, a security-check hook ahead of a logging hook regardless of where each is declared in settings or contributed by plugins.
 - `edit_file` and `write_file` in the React TUI now preview a unified diff before applying file changes, let users approve once or for the rest of the session, and skip the extra prompt automatically in `full_auto` mode.
 
 ### Fixed
 
+- `oh plugin install` help text advertised URL support that was not implemented; the implementation now matches the documented behaviour.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/cli.py
+++ b/src/openharness/cli.py
@@ -858,12 +858,17 @@ def plugin_list() -> None:
 
 @plugin_app.command("install")
 def plugin_install(
-    source: str = typer.Argument(..., help="Plugin source (path or URL)"),
+    source: str = typer.Argument(..., help="Plugin source (local path or git URL)"),
 ) -> None:
-    """Install a plugin from a source path."""
-    from openharness.plugins.installer import install_plugin_from_path
+    """Install a plugin from a local path or git URL."""
+    if source.startswith(("http://", "https://", "git+")):
+        from openharness.plugins.installer import install_plugin_from_url
 
-    result = install_plugin_from_path(source)
+        result = install_plugin_from_url(source)
+    else:
+        from openharness.plugins.installer import install_plugin_from_path
+
+        result = install_plugin_from_path(source)
     print(f"Installed plugin: {result}")
 
 

--- a/src/openharness/plugins/installer.py
+++ b/src/openharness/plugins/installer.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 from openharness.plugins.loader import get_user_plugins_dir
@@ -28,6 +31,31 @@ def install_plugin_from_path(source: str | Path) -> Path:
         shutil.rmtree(dest)
     shutil.copytree(src, dest)
     return dest
+
+
+def install_plugin_from_url(url: str) -> Path:
+    """Clone a git URL into a temp directory and install from there."""
+    clone_url = url.removeprefix("git+")
+    with tempfile.TemporaryDirectory() as tmp:
+        cloned = Path(tmp) / "cloned"
+        result = subprocess.run(
+            ["git", "clone", "--depth=1", clone_url, str(cloned)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"git clone failed for {url!r}:\n{result.stderr.strip()}")
+        manifest = cloned / "plugin.json"
+        if manifest.exists():
+            name = json.loads(manifest.read_text())["name"]
+            # Rename so install_plugin_from_path uses the declared name as the
+            # destination directory. Once PR #354 lands (install_plugin_from_path
+            # reads name from plugin.json directly), this rename can be removed.
+            named = Path(tmp) / name
+            cloned.rename(named)
+            return install_plugin_from_path(named)
+        return install_plugin_from_path(cloned)
 
 
 def uninstall_plugin(name: str) -> bool:

--- a/tests/test_plugins/test_lifecycle_flow.py
+++ b/tests/test_plugins/test_lifecycle_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -12,7 +13,11 @@ from openharness.config.settings import Settings, load_settings
 from openharness.mcp.client import McpClientManager
 from openharness.mcp.config import load_mcp_server_configs
 from openharness.plugins import load_plugins
-from openharness.plugins.installer import install_plugin_from_path, uninstall_plugin
+from openharness.plugins.installer import (
+    install_plugin_from_path,
+    install_plugin_from_url,
+    uninstall_plugin,
+)
 from openharness.tools import create_default_tool_registry
 from openharness.tools.base import ToolExecutionContext
 
@@ -107,3 +112,48 @@ def test_uninstall_plugin_rejects_traversal_name_without_deleting_sibling(
 
     assert victim.exists()
     assert (victim / "marker.txt").read_text(encoding="utf-8") == "keep"
+
+
+def _make_bare_repo(tmp_path: Path, plugin_name: str) -> Path:
+    src = tmp_path / "plugin_src"
+    src.mkdir()
+    (src / "plugin.json").write_text(f'{{"name": "{plugin_name}"}}', encoding="utf-8")
+    subprocess.run(["git", "init", str(src)], check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(src),
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+            "--author=Test <test@example.com>",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(src), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(src), "commit", "-m", "add plugin", "--author=Test <test@example.com>"],
+        check=True,
+        capture_output=True,
+    )
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "clone", "--bare", str(src), str(bare)], check=True, capture_output=True)
+    return bare
+
+
+def test_install_plugin_from_url_clones_and_installs(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    bare = _make_bare_repo(tmp_path, "url-plugin")
+
+    dest = install_plugin_from_url(f"file://{bare}")
+
+    assert dest.name == "url-plugin"
+    assert (dest / "plugin.json").exists()
+
+
+def test_install_plugin_from_url_invalid_raises(tmp_path: Path):
+    with pytest.raises(RuntimeError, match="git clone failed"):
+        install_plugin_from_url(f"file://{tmp_path}/nonexistent")


### PR DESCRIPTION
## Summary
- oh plugin install accepted a source argument documented as "path or URL" but passed it directly to
    `Path(source).resolve()`, silently turning any URL into a nonsensical local path.
- Added `install_plugin_from_url` in `installer.py` that clones the repo with git clone --depth=1 into a temp directory and
    delegates to the existing path install logic. URL detection (http://, https://, git+) is handled in the CLI before
    dispatching to the right function.
- Updated the help text and docstring to match the now-accurate behaviour.

## Validation

- [x] uv run ruff check src tests scripts
- [x] uv run pytest -q

## Notes

- Related issue: —
- Follow-up work: Once PR #354 merges, the directory rename in `install_plugin_from_url` (used to pass the correct name to `install_plugin_from_path`) can be removed.
