### PR TITLE
fix(engine): prevent agent hallucination on truncated tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Truncated tool output now includes an explicit instruction telling the agent not to infer or supplement omitted content from training knowledge. Previously, partial JSON previews could cause the agent to hallucinate missing information.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/src/openharness/engine/query.py
+++ b/src/openharness/engine/query.py
@@ -539,7 +539,7 @@ def _offload_tool_output_if_needed(
     preview = output[:tool_output_preview_chars()]
     omitted = max(0, len(output) - len(preview))
     inline = (
-        "[Tool output truncated]\n"
+        "[Tool output truncated — the preview below is incomplete]\n"
         f"Tool: {tool_name}\n"
         f"Tool use id: {tool_use_id}\n"
         f"Original size: {len(output)} chars\n"
@@ -548,6 +548,12 @@ def _offload_tool_output_if_needed(
     )
     if omitted:
         inline += f" ({omitted} chars omitted)"
+    inline += (
+        "\n\nIMPORTANT: The preview below is a partial fragment of the full output. "
+        "Do NOT infer, guess, or supplement the omitted content from training knowledge. "
+        "Only report what is explicitly present in the preview. "
+        "If you need the complete output, read the file at the path shown above."
+    )
     if preview:
         inline += f"\n\nPreview:\n{preview}"
     return inline, artifact_path

--- a/tests/test_engine/test_query_engine.py
+++ b/tests/test_engine/test_query_engine.py
@@ -1514,7 +1514,7 @@ async def test_query_engine_offloads_large_tool_result_outputs(tmp_path: Path, m
 
     completed = [event for event in events if isinstance(event, ToolExecutionCompleted)]
     assert len(completed) == 1
-    assert completed[0].output.startswith("[Tool output truncated]")
+    assert completed[0].output.startswith("[Tool output truncated — the preview below is incomplete]")
     assert "snapshot-line" in completed[0].output
 
     user_tool_messages = [


### PR DESCRIPTION
## Summary

- When tool output exceeded the inline limit, the truncation header gave no instruction on how to handle the missing
    content. For structured output like JSON, the preview looked syntactically complete even though it was a fragment,
    causing the agent to supplement missing data from training knowledge.
- Updated the truncation header to make the incomplete state explicit and added an IMPORTANT instruction telling the agent not to infer, guess, or supplement the omitted content, and to read the artifact file if the full output is needed.

## Validation

- [x] `uv run ruff check src tests scripts`
- [x] `uv run pytest -q`

## Notes

- Related issue: -
- Follow-up work: -
