### PR TITLE
feat(goal): add /goal goal-driven autonomy loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ frontend/terminal/node_modules/
 .openharness/
 react_tui_smoke.txt
 
+# Qoder IDE
+.qoder/
+
+# Local learning notes
+learn/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/docs/goal.md
+++ b/docs/goal.md
@@ -1,0 +1,155 @@
+# /goal: Goal-Driven Autonomy
+
+`/goal` lets OpenHarness work toward a **completion condition** over many turns
+without you prompting each step. After every turn, a lightweight **verifier
+model** judges whether the goal is satisfied; if not, its verdict is fed back
+as the next step and the loop continues — until the goal is done or a budget
+is exhausted.
+
+The design follows Claude Code's execution loop (built into the REPL, small
+fast model verifies after each turn) and borrows Codex's persistence (goal
+state survives restarts, resume with `/goal resume`).
+
+## Usage
+
+Start `oh` and set a goal:
+
+```text
+/goal <completion condition>
+```
+
+Examples:
+
+```text
+/goal Fix the login bug and make `uv run pytest tests/test_auth` pass
+/goal Add rate limiting to the API and document it in README.md
+```
+
+Manage the running goal:
+
+| Command | Effect |
+|---|---|
+| `/goal status` | Show the condition, verifier model, turns/tokens used, budget, and last verdict |
+| `/goal pause` | Pause after the current turn (status `paused`) |
+| `/goal resume` | Resume a paused or failed goal; also used after restarting `oh` |
+| `/goal clear` | Delete the goal state and start fresh |
+
+Flags at creation time:
+
+```text
+/goal --verifier-model gpt-5-mini --max-turns 50 <completion condition>
+```
+
+## Configuring the Verifier Model
+
+Priority order (highest first):
+
+1. **Command flag** — per-goal, wins over everything else:
+
+   ```text
+   /goal --verifier-model gpt-5-mini <completion condition>
+   ```
+
+2. **Environment variable**:
+
+   ```powershell
+   $env:OPENHARNESS_GOAL_VERIFIER_MODEL = "gpt-5-mini"
+   ```
+
+3. **Settings file** — `~/.openharness/settings.json`:
+
+   ```json
+   {
+     "goal": {
+       "verifier_model": "gpt-5-mini",
+       "max_turns": 100,
+       "max_tokens": null
+     }
+   }
+   ```
+
+4. **Fallback** — when nothing is configured, the verifier uses the active
+   conversation model. This works but costs a full main-model call per
+   judgement, so configuring a small model is recommended.
+
+A small, cheap model is ideal (`gpt-5-mini`, `sonnet`, etc.). The verifier
+only needs to read the goal, recent conversation, and answer with a JSON
+verdict.
+
+Budget limits can also come from the environment:
+`OPENHARNESS_GOAL_MAX_TURNS` and `OPENHARNESS_GOAL_MAX_TOKENS`.
+
+## Budget and Safety Nets
+
+- **Turn budget** (`max_turns`, default 100): total goal-loop iterations.
+  Note this counts *outer* goal turns, not individual LLM calls — each outer
+  turn is itself a full inner agent loop.
+- **Token budget** (`max_tokens`): stops once conversation usage reaches the
+  limit. Unset by default.
+- **Verifier failure cutoff**: if the verifier output is unparseable or the
+  call fails 3 times in a row, the goal fails instead of spinning forever.
+  A hung verifier call is also capped at 60 seconds and counted as a
+  failure, so the UI never stays stuck on "Running agent loop...".
+- When a budget is exhausted the goal status becomes `failed`; you can then
+  readjust and `/goal resume`.
+
+## Persistence and Recovery
+
+Goal state (condition, budgets, turns run, last verdict) is stored per
+project under `~/.openharness/data/goals/` and written after every turn.
+When `oh` starts and finds an unfinished active goal it prints:
+
+```text
+[goal] 检测到未完成的目标…（已跑 N 轮），输入 /goal resume 继续
+```
+
+`/goal` is interactive-only (`remote_invocable=False`); it is not exposed on
+remote channels (Feishu/Telegram/etc.).
+
+## /goal vs. the Agent's Inner Loop
+
+OpenHarness already has an **inner agentic loop** on every message: the model
+requests tools, tools execute, results are fed back, and this repeats until
+the model stops requesting tools (or `max_turns` hits). `/goal` adds a second
+layer on top:
+
+| | Inner loop (always on) | Outer `/goal` loop (opt-in) |
+|---|---|---|
+| Drives | LLM ↔ tool calls within one submission | Whole working sessions |
+| Ends when | model stops requesting tools / `max_turns` | verifier says done / budget exhausted |
+| Unit of work | one tool-use round-trip | one complete turn (an entire inner loop) |
+| Who decides next | the main model | the verifier model + its `next_step_hint` |
+| Persisted across restarts | via session snapshot | yes, with resume support |
+
+In short: without `/goal`, each of your messages launches one inner loop and
+stops. With `/goal`, the outer loop keeps launching inner loops and asks a
+judge whether the announced finish line has actually been crossed.
+
+## When to Use /goal
+
+Good fits:
+
+- Long tasks with an **objective, checkable acceptance criterion** (tests
+  pass, files exist, CI green, a report is produced).
+- Work that needs many iterations you don't want to hand-hold: bug-fix loops,
+  refactors with a test suite, batch migrations, multi-file features,
+  "research X and write the findings to a file".
+- Sessions you expect to interrupt and resume later.
+
+Poor fits:
+
+- Exploratory work without a clear finish condition ("look around the repo
+  and see what's wrong").
+- Tasks needing frequent human judgement or step-by-step approval.
+- Risky irreversible operations — the permission mode still applies inside
+  the loop, but the whole point of `/goal` is lengthier autonomy.
+- Small one-shot tasks where a normal prompt is cheaper and faster.
+
+### Writing good completion conditions
+
+State deliverables and evidence, not effort:
+
+- ✔ "Make `uv run pytest tests/ -q` pass and update CHANGELOG.md"
+- ✔ "Generate `docs/architecture.md` describing the module layout"
+- ✘ "Improve the codebase"
+- ✘ "Fix things until it feels right"

--- a/src/openharness/commands/registry.py
+++ b/src/openharness/commands/registry.py
@@ -29,9 +29,17 @@ from openharness.bridge import get_bridge_manager
 from openharness.bridge.types import WorkSecret
 from openharness.bridge.work_secret import build_sdk_url, decode_work_secret, encode_work_secret
 from openharness.api.provider import auth_status, detect_provider
-from openharness.config.settings import Settings, display_model_setting, load_settings, save_settings
+from openharness.config.settings import (
+    GoalSettings,
+    Settings,
+    display_model_setting,
+    load_settings,
+    save_settings,
+)
 from openharness.engine.messages import ConversationMessage, sanitize_conversation_messages
 from openharness.engine.query_engine import QueryEngine
+from openharness.goal.store import GoalStore
+from openharness.goal.types import GoalDefinition
 from openharness.memory import (
     add_memory_entry,
     get_memory_entrypoint,
@@ -112,6 +120,7 @@ class CommandResult:
     refresh_runtime: bool = False
     submit_prompt: str | None = None
     submit_model: str | None = None
+    goal: GoalDefinition | None = None
 
 
 @dataclass(frozen=True)
@@ -2318,6 +2327,131 @@ def create_default_command_registry(
             )
         )
 
+    async def _goal_handler(args: str, context: CommandContext) -> CommandResult:
+        goal_store = GoalStore(context.cwd)
+        tokens = args.split()
+        sub = tokens[0].lower() if tokens else ""
+
+        if sub in {"status", "show"}:
+            goal = goal_store.load()
+            if goal is None:
+                return CommandResult(message="No goal set. Use /goal <completion condition>.")
+            verdict_line = ""
+            if goal.last_verdict is not None:
+                verdict_line = (
+                    f"\nLast verdict: done={goal.last_verdict.done} "
+                    f"conf={goal.last_verdict.confidence:.2f} — {goal.last_verdict.rationale}"
+                )
+            budget = f"{goal.max_turns_budget} turns"
+            if goal.max_tokens_budget is not None:
+                budget += f" / {goal.max_tokens_budget} tokens"
+            return CommandResult(
+                message=(
+                    f"Goal [{goal.status}]: {goal.condition}\n"
+                    f"Verifier model: {goal.verifier_model or context.engine.model}\n"
+                    f"Turns: {goal.turns_run} | Tokens used: {goal.tokens_used}\n"
+                    f"Budget: {budget}"
+                    f"{verdict_line}"
+                )
+            )
+
+        if sub == "clear":
+            if goal_store.load() is None:
+                return CommandResult(message="No goal set.")
+            goal_store.clear()
+            return CommandResult(message="Goal cleared.")
+
+        if sub == "pause":
+            goal = goal_store.load()
+            if goal is None:
+                return CommandResult(message="No goal set.")
+            if goal.status != "active":
+                return CommandResult(message=f"Goal is {goal.status}, nothing to pause.")
+            goal.status = "paused"
+            goal_store.save(goal)
+            return CommandResult(message=f"Goal paused after {goal.turns_run} turns.")
+
+        if sub == "resume":
+            goal = goal_store.load()
+            if goal is None:
+                return CommandResult(message="No goal set. Use /goal <completion condition>.")
+            if goal.status in {"completed", "cancelled"}:
+                return CommandResult(
+                    message=f"Goal is {goal.status}; use /goal <completion condition> to start a new one."
+                )
+            goal.status = "active"
+            goal_store.save(goal)
+            return CommandResult(goal=goal, message=f"Resuming goal after {goal.turns_run} turns.")
+
+        # Create a new goal: parse optional flags, then the completion condition.
+        parsed_verifier: str | None = None
+        parsed_max_turns: int | None = None
+        condition_tokens: list[str] = []
+        idx = 0
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token == "--verifier-model" and idx + 1 < len(tokens):
+                parsed_verifier = tokens[idx + 1]
+                idx += 2
+                continue
+            if token == "--max-turns" and idx + 1 < len(tokens):
+                try:
+                    parsed_max_turns = int(tokens[idx + 1])
+                except ValueError:
+                    return CommandResult(
+                        message="Usage: /goal [--verifier-model MODEL] [--max-turns N] <completion condition>"
+                    )
+                idx += 2
+                continue
+            condition_tokens.append(token)
+            idx += 1
+
+        condition = " ".join(condition_tokens).strip()
+        if not condition:
+            return CommandResult(
+                message="Usage: /goal [--verifier-model MODEL] [--max-turns N] <completion condition>"
+            )
+
+        existing = goal_store.load()
+        if existing is not None and existing.status in {"active", "paused"}:
+            return CommandResult(
+                message=f"A goal is already {existing.status}. Run /goal clear first."
+            )
+
+        settings = load_settings()
+        env_goal = GoalSettings.from_env()
+        verifier_model = parsed_verifier or env_goal.verifier_model or settings.goal.verifier_model
+
+        if parsed_max_turns is not None:
+            max_turns = parsed_max_turns
+        else:
+            env_turns = os.environ.get("OPENHARNESS_GOAL_MAX_TURNS", "").strip()
+            max_turns = settings.goal.max_turns
+            if env_turns:
+                try:
+                    max_turns = int(env_turns)
+                except ValueError:
+                    max_turns = settings.goal.max_turns
+
+        max_tokens: int | None = None
+        env_tokens = os.environ.get("OPENHARNESS_GOAL_MAX_TOKENS", "").strip()
+        if env_tokens:
+            try:
+                max_tokens = int(env_tokens)
+            except ValueError:
+                max_tokens = settings.goal.max_tokens
+        else:
+            max_tokens = settings.goal.max_tokens
+
+        goal = GoalDefinition(
+            condition=condition,
+            verifier_model=verifier_model,
+            max_turns_budget=max_turns,
+            max_tokens_budget=max_tokens,
+        )
+        goal_store.save(goal)
+        return CommandResult(message=f"Goal set: {condition}", goal=goal)
+
     registry.register(SlashCommand("help", "Show available commands", _help_handler))
     registry.register(
         SlashCommand("exit", "Exit OpenHarness", _exit_handler, aliases=("quit",))
@@ -2341,6 +2475,14 @@ def create_default_command_registry(
     registry.register(SlashCommand("stats", "Show session statistics", _stats_handler))
     registry.register(SlashCommand("dream", "Consolidate memory", _dream_handler))
     registry.register(SlashCommand("memory", "Inspect and manage project memory", _memory_handler))
+    registry.register(
+        SlashCommand(
+            "goal",
+            "Pursue a goal autonomously until the verifier declares it done",
+            _goal_handler,
+            remote_invocable=False,
+        )
+    )
     registry.register(SlashCommand("hooks", "Show configured hooks", _hooks_handler))
     registry.register(
         SlashCommand(

--- a/src/openharness/config/settings.py
+++ b/src/openharness/config/settings.py
@@ -563,6 +563,43 @@ class VisionModelConfig(BaseModel):
         return bool(self.model and self.api_key)
 
 
+class GoalSettings(BaseModel):
+    """Configuration for the /goal autonomous work loop.
+
+    The verifier model judges continue/done after each turn. When unset,
+    the verifier falls back to the active conversation model.
+    """
+
+    verifier_model: str = ""
+    max_turns: int = 100
+    max_tokens: int | None = None
+
+    @classmethod
+    def from_env(cls) -> "GoalSettings":
+        """Load goal config from environment variables."""
+        max_tokens_raw = os.environ.get("OPENHARNESS_GOAL_MAX_TOKENS", "").strip()
+        max_tokens: int | None
+        if max_tokens_raw:
+            try:
+                max_tokens = int(max_tokens_raw)
+            except ValueError:
+                max_tokens = None
+        else:
+            max_tokens = None
+        max_turns_raw = os.environ.get("OPENHARNESS_GOAL_MAX_TURNS", "").strip()
+        max_turns = 100
+        if max_turns_raw:
+            try:
+                max_turns = int(max_turns_raw)
+            except ValueError:
+                max_turns = 100
+        return cls(
+            verifier_model=os.environ.get("OPENHARNESS_GOAL_VERIFIER_MODEL", "").strip(),
+            max_turns=max_turns,
+            max_tokens=max_tokens,
+        )
+
+
 class Settings(BaseModel):
     """Main settings model for OpenHarness."""
 
@@ -584,6 +621,7 @@ class Settings(BaseModel):
     system_prompt: str | None = None
     permission: PermissionSettings = Field(default_factory=PermissionSettings)
     hooks: dict[str, list[HookDefinition]] = Field(default_factory=dict)
+    goal: GoalSettings = Field(default_factory=GoalSettings)
     memory: MemorySettings = Field(default_factory=MemorySettings)
     sandbox: SandboxSettings = Field(default_factory=SandboxSettings)
     web: WebSettings = Field(default_factory=WebSettings)

--- a/src/openharness/goal/__init__.py
+++ b/src/openharness/goal/__init__.py
@@ -1,0 +1,13 @@
+"""Goal-driven autonomy: the ``/goal`` slash command machinery."""
+
+from openharness.goal.store import GoalStore
+from openharness.goal.types import GoalDefinition, GoalStatus, VerifierVerdict
+from openharness.goal.runner import run_goal_loop
+
+__all__ = [
+    "GoalDefinition",
+    "GoalStatus",
+    "GoalStore",
+    "VerifierVerdict",
+    "run_goal_loop",
+]

--- a/src/openharness/goal/prompts.py
+++ b/src/openharness/goal/prompts.py
@@ -1,0 +1,70 @@
+"""Prompt templates for the goal verifier and goal context injection."""
+
+from __future__ import annotations
+
+VERIFIER_SYSTEM_PROMPT = """You are a goal verifier for an autonomous coding agent.
+
+The agent has been working toward a goal defined by the user. You decide
+whether the goal has been achieved. Judge strictly: the completion
+condition must be satisfied by real evidence (tests passing, code written,
+results produced) — do not accept an agent's mere claim of completion.
+
+Respond with a single JSON object only, no commentary, shaped like:
+
+{"done": false, "confidence": 0.0, "rationale": "...",
+ "next_step_hint": "...", "progress_summary": "..."}
+
+- "done": true only when the completion condition is satisfied.
+- "confidence": 0.0-1.0, your confidence in the verdict.
+- "rationale": short reason for the verdict (1-3 sentences).
+- "next_step_hint": when "done" is false, a specific instruction for the
+  agent's next step; empty when done.
+- "progress_summary": one sentence describing progress so far.
+"""
+
+VERIFIER_INPUT_TEMPLATE = """Goal (completion condition):
+{condition}
+
+Recent conversation:
+{transcript}
+
+Judge whether the goal is achieved. Output only a JSON object with the
+keys "done", "confidence", "rationale", "next_step_hint", and
+"progress_summary" — no other text."""
+
+#: Fallback instruction used when the verifier returns a continue verdict
+#: without a usable next-step hint.
+DEFAULT_CONTINUE_PROMPT = (
+    "Continue working toward the goal. Report concrete progress and verify "
+    "your work with real evidence (tests, commands, file contents)."
+)
+
+GOAL_SYSTEM_BLOCK_TEMPLATE = """
+
+## Active Goal (set via /goal)
+
+{condition}
+
+You are pursuing this goal autonomously. Work step by step and verify your
+own work with real evidence (run tests, inspect files, execute commands)
+before considering the goal complete. The goal is complete only when the
+completion condition above is fully satisfied.
+"""
+
+MAX_TRANSCRIPT_MESSAGES = 24
+MAX_BLOCK_CHARS = 500
+
+MAX_VERIFIER_PARSE_FAILURES = 3
+
+
+def build_verifier_prompt(goal_condition: str, transcript: str) -> str:
+    """Render the verifier input prompt for one judgement call."""
+    return VERIFIER_INPUT_TEMPLATE.format(
+        condition=goal_condition,
+        transcript=transcript.strip() or "(no conversation yet)",
+    )
+
+
+def build_goal_system_block(condition: str) -> str:
+    """Render the goal context block injected into the main system prompt."""
+    return GOAL_SYSTEM_BLOCK_TEMPLATE.format(condition=condition)

--- a/src/openharness/goal/runner.py
+++ b/src/openharness/goal/runner.py
@@ -1,0 +1,200 @@
+"""Goal runner: the outer autonomy loop driving the engine toward a goal.
+
+Layout of one goal session:
+
+    first turn (condition) -> [ budget check -> verifier -> continue? ]*
+    -> completed / failed
+
+The loop is hosted by the interactive runtime so every turn renders as a
+normal conversation turn. Progress is persisted to the goal store and the
+session snapshot after every turn, so a killed process resumes cleanly
+with ``/goal resume``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from openharness.engine.messages import (
+    ConversationMessage,
+    sanitize_conversation_messages,
+)
+from openharness.engine.query import MaxTurnsExceeded
+from openharness.goal.prompts import (
+    DEFAULT_CONTINUE_PROMPT,
+    MAX_VERIFIER_PARSE_FAILURES,
+    build_goal_system_block,
+)
+from openharness.goal.store import GoalStore
+from openharness.goal.types import GoalDefinition
+from openharness.goal.verifier import run_goal_verifier
+
+if TYPE_CHECKING:
+    from openharness.ui.runtime import RuntimeBundle
+
+log = logging.getLogger(__name__)
+
+# Hard cap for a verifier judgement: flash-scale models answer in seconds, so
+# anything beyond this means the upstream hung and we should count a failure
+# instead of leaving the UI stuck in the busy state forever.
+VERIFIER_TIMEOUT_SECONDS = 60.0
+
+SystemPrinter = Callable[[str], Awaitable[None]]
+StreamRenderer = Callable[[object], Awaitable[None]]
+
+
+async def _submit_turn(engine, prompt: str, render_event: StreamRenderer) -> bool:
+    """Run one engine turn, returning False when the inner loop hit max_turns."""
+    try:
+        async for event in engine.submit_message(prompt):
+            await render_event(event)
+    except MaxTurnsExceeded:
+        return False
+    return True
+
+
+async def _save_progress(goal_store: GoalStore, goal: GoalDefinition) -> None:
+    goal_store.save(goal)
+
+
+async def run_goal_loop(
+    bundle: "RuntimeBundle",
+    goal: GoalDefinition,
+    render_event: StreamRenderer,
+    print_system: SystemPrinter,
+    *,
+    verifier_timeout: float = VERIFIER_TIMEOUT_SECONDS,
+) -> None:
+    """Drive the engine toward ``goal`` until done or budget exhausted."""
+    engine = bundle.engine
+    settings = bundle.current_settings()
+    goal_store = GoalStore(bundle.cwd)
+
+    if goal.status != "active":
+        await print_system(f"Goal is {goal.status}, nothing to run.")
+        return
+
+    # When resuming a goal in a fresh process the engine has no conversation
+    # history, so the verifier would judge against an empty transcript and
+    # always say "no evidence".  Restore the latest session snapshot so the
+    # judge can see the tool calls/results that already happened.
+    if goal.turns_run > 0 and len(engine.messages) < 3:
+        snapshot = bundle.session_backend.load_latest(bundle.cwd)
+        if snapshot and snapshot.get("messages"):
+            try:
+                restored = sanitize_conversation_messages(
+                    [ConversationMessage.model_validate(m) for m in snapshot["messages"]]
+                )
+                if restored:
+                    engine.load_messages(restored)
+                    await print_system(
+                        f"[goal] Restored {len(restored)} messages from the "
+                        "session snapshot so the verifier can see prior evidence."
+                    )
+            except Exception as exc:
+                log.warning("Failed to restore session for goal resume: %s", exc)
+
+    if bundle.enforce_max_turns:
+        engine.set_max_turns(settings.max_turns)
+
+    # Keep the goal in view for the main model (Codex-style).
+    engine.set_system_prompt(
+        engine.system_prompt + build_goal_system_block(goal.condition)
+    )
+    await print_system(f"[goal] x{goal.turns_run} Active goal: {goal.condition}")
+
+    try:
+        # First turn executes the completion condition directly, skipping
+        # the verifier so the agent starts working instead of judging.
+        if goal.turns_run == 0:
+            await _submit_turn(engine, goal.condition, render_event)
+            goal.turns_run = 1
+            goal.tokens_used = engine.total_usage.total_tokens
+            await _save_progress(goal_store, goal)
+            await bundle.session_backend.save_snapshot(
+                cwd=bundle.cwd,
+                model=settings.model,
+                system_prompt=engine.system_prompt,
+                messages=engine.messages,
+                usage=engine.total_usage,
+                session_id=bundle.session_id,
+                tool_metadata=engine.tool_metadata,
+            )
+
+        while goal.status == "active":
+            # Budget checks take priority over any further model calls.
+            if goal.budget_exhausted(engine.total_usage.total_tokens):
+                goal.status = "failed"
+                await _save_progress(goal_store, goal)
+                await print_system(
+                    f"[goal] Budget exhausted after {goal.turns_run} turns "
+                    f"({engine.total_usage.total_tokens} tokens). "
+                    "Run /goal resume to raise the budget or continue."
+                )
+                break
+
+            try:
+                await print_system("[goal] verifier judging progress...")
+                verdict = await asyncio.wait_for(
+                    run_goal_verifier(
+                        engine.api_client,
+                        goal,
+                        engine.messages,
+                        fallback_model=engine.model,
+                    ),
+                    timeout=verifier_timeout,
+                )
+                goal.verifier_failures = 0
+                goal.last_verdict = verdict
+                goal.next_step_hint = verdict.next_step_hint
+            except Exception as exc:
+                goal.verifier_failures += 1
+                log.warning("Goal verifier failed: %s", exc)
+                goal.last_verdict = None
+                if goal.verifier_failures >= MAX_VERIFIER_PARSE_FAILURES:
+                    goal.status = "failed"
+                    await _save_progress(goal_store, goal)
+                    await print_system(
+                        f"[goal] Stopped: verifier failed "
+                        f"{goal.verifier_failures} times in a row."
+                    )
+                    break
+                # Keep working with a safe, deterministic nudge.
+                goal.next_step_hint = DEFAULT_CONTINUE_PROMPT
+                await print_system(
+                    "[goal] verifier unavailable "
+                    f"(attempt {goal.verifier_failures}/"
+                    f"{MAX_VERIFIER_PARSE_FAILURES}), continuing."
+                )
+
+            if goal.last_verdict is not None and goal.last_verdict.done:
+                goal.status = "completed"
+                goal.next_step_hint = ""
+                await _save_progress(goal_store, goal)
+                summary = goal.last_verdict.progress_summary or goal.last_verdict.rationale
+                await print_system(
+                    f"[goal] Completed after {goal.turns_run} turns"
+                    + (f": {summary}" if summary else "")
+                )
+                break
+
+            hint = goal.next_step_hint.strip() or DEFAULT_CONTINUE_PROMPT
+            if goal.last_verdict is not None and goal.last_verdict.rationale:
+                await print_system(f"[goal] continue — {goal.last_verdict.rationale}")
+            await _submit_turn(engine, hint, render_event)
+            goal.turns_run += 1
+            goal.tokens_used = engine.total_usage.total_tokens
+            await _save_progress(goal_store, goal)
+            await bundle.session_backend.save_snapshot(
+                cwd=bundle.cwd,
+                model=settings.model,
+                system_prompt=engine.system_prompt,
+                messages=engine.messages,
+                usage=engine.total_usage,
+                session_id=bundle.session_id,
+                tool_metadata=engine.tool_metadata,
+            )
+    finally:
+        await _save_progress(goal_store, goal)

--- a/src/openharness/goal/store.py
+++ b/src/openharness/goal/store.py
@@ -1,0 +1,56 @@
+"""Persistent storage for goal state.
+
+Goals survive process restarts: each project gets its own JSON file under
+``~/.openharness/data/goals/`` sharded by a hash of the project path, same
+scheme as session snapshots.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha1
+from pathlib import Path
+
+from openharness.config.paths import get_data_dir
+from openharness.utils.fs import atomic_write_text
+
+from openharness.goal.types import GoalDefinition
+
+
+def _get_goal_file(cwd: str | Path) -> Path:
+    """Return the per-project goal state file path."""
+    path = Path(cwd).resolve()
+    digest = sha1(str(path).encode("utf-8")).hexdigest()[:12]
+    goals_dir = get_data_dir() / "goals" / f"{path.name}-{digest}"
+    goals_dir.mkdir(parents=True, exist_ok=True)
+    return goals_dir / "goal.json"
+
+
+class GoalStore:
+    """JSON-backed store for one active goal per project."""
+
+    def __init__(self, cwd: str | Path) -> None:
+        self._file = _get_goal_file(cwd)
+
+    @property
+    def file_path(self) -> Path:
+        """Return the backing JSON file path."""
+        return self._file
+
+    def save(self, goal: GoalDefinition) -> None:
+        """Persist the goal definition atomically."""
+        goal.touch()
+        atomic_write_text(self._file, goal.model_dump_json(indent=2))
+
+    def load(self) -> GoalDefinition | None:
+        """Load the persisted goal, or None when absent or corrupt."""
+        if not self._file.exists():
+            return None
+        try:
+            return GoalDefinition.model_validate_json(self._file.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def clear(self) -> None:
+        """Delete the persisted goal state."""
+        if self._file.exists():
+            self._file.unlink()

--- a/src/openharness/goal/types.py
+++ b/src/openharness/goal/types.py
@@ -1,0 +1,56 @@
+"""Goal-driven autonomy data models.
+
+These models back the ``/goal`` slash command: a completion condition the
+main model pursues over many turns, with a lightweight verifier model
+judging continue/done after each turn.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GoalStatus = Literal["active", "paused", "completed", "failed", "cancelled"]
+
+
+class VerifierVerdict(BaseModel):
+    """Structured verdict returned by the goal verifier model."""
+
+    done: bool = False
+    confidence: float = 0.0
+    rationale: str = ""
+    next_step_hint: str = ""
+    progress_summary: str = ""
+
+
+class GoalDefinition(BaseModel):
+    """Persistent definition and runtime state of one ``/goal``."""
+
+    goal_id: str = Field(default_factory=lambda: f"goal_{uuid.uuid4().hex[:8]}")
+    condition: str
+    verifier_model: str = ""
+    max_turns_budget: int = 100
+    max_tokens_budget: int | None = None
+    turns_run: int = 0
+    tokens_used: int = 0
+    verifier_failures: int = 0
+    last_verdict: VerifierVerdict | None = None
+    next_step_hint: str = ""
+    status: GoalStatus = "active"
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+
+    def touch(self) -> None:
+        """Refresh the updated-at timestamp."""
+        self.updated_at = time.time()
+
+    def budget_exhausted(self, total_tokens: int) -> bool:
+        """Return whether the turn or token budget has been exhausted."""
+        if self.turns_run >= self.max_turns_budget:
+            return True
+        if self.max_tokens_budget is not None and total_tokens >= self.max_tokens_budget:
+            return True
+        return False

--- a/src/openharness/goal/verifier.py
+++ b/src/openharness/goal/verifier.py
@@ -1,0 +1,146 @@
+"""Goal verifier: a lightweight model judges continue/done after each turn."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from openharness.api.client import (
+    ApiMessageRequest,
+    ApiTextDeltaEvent,
+    SupportsStreamingMessages,
+)
+from openharness.engine.messages import (
+    ConversationMessage,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+from openharness.goal.prompts import (
+    MAX_BLOCK_CHARS,
+    MAX_TRANSCRIPT_MESSAGES,
+    VERIFIER_SYSTEM_PROMPT,
+    build_verifier_prompt,
+)
+from openharness.goal.types import GoalDefinition, VerifierVerdict
+
+log = logging.getLogger(__name__)
+
+
+def build_transcript(messages: list[ConversationMessage]) -> str:
+    """Render a compact text transcript from recent conversation messages.
+
+    Tool calls and their results are included so the verifier sees the actual
+    evidence (command output, file contents) rather than only the agent's prose
+    claims.  Otherwise a tool-heavy agent loop looks "unverified" to the judge
+    and keeps being told to continue, spinning forever.
+    """
+    lines: list[str] = []
+    for message in messages[-MAX_TRANSCRIPT_MESSAGES:]:
+        parts: list[str] = []
+        for block in message.content:
+            if isinstance(block, TextBlock):
+                parts.append(block.text)
+            elif isinstance(block, ToolUseBlock):
+                params = json.dumps(block.input, ensure_ascii=False)
+                if len(params) > 200:
+                    params = params[:200] + "..."
+                parts.append(f"[tool_use] {block.name}({params})")
+            elif isinstance(block, ToolResultBlock):
+                prefix = "[tool_result_error] " if block.is_error else "[tool_result] "
+                result_text = block.content
+                if len(result_text) > MAX_BLOCK_CHARS:
+                    result_text = result_text[: MAX_BLOCK_CHARS - 3] + "..."
+                parts.append(prefix + result_text)
+        text = "\n".join(part.strip() for part in parts if part and part.strip())
+        if not text:
+            continue
+        text = text.replace("\r\n", "\n")
+        if len(text) > MAX_BLOCK_CHARS:
+            text = text[: MAX_BLOCK_CHARS - 3] + "..."
+        lines.append(f"{message.role}: {text}")
+    return "\n".join(lines)
+
+
+def render_verdict(text: str) -> VerifierVerdict:
+    """Parse the verifier's JSON output into a structured verdict.
+
+    Falls back to a continue verdict (via exception) when the output is not
+    parseable so that a garbled verifier reply never falsely declares the
+    goal complete.
+    """
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        fence = "```"
+        stripped = stripped[len(fence):].strip()
+        if stripped.endswith(fence):
+            stripped = stripped[:-len(fence)].strip()
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        # Tolerate a leading prose prefix by extracting the first JSON object.
+        brace_open = stripped.find("{")
+        if brace_open >= 0:
+            try:
+                decoder = json.JSONDecoder()
+                data, _ = decoder.raw_decode(stripped[brace_open:])
+            except json.JSONDecodeError:
+                data = None
+        else:
+            data = None
+    if not isinstance(data, dict):
+        log.warning("Goal verifier returned unparseable output (first 200 chars): %r", stripped[:200])
+        raise ValueError("verifier output is not a JSON object")
+    try:
+        return VerifierVerdict(
+            done=bool(data.get("done", False)),
+            confidence=float(data.get("confidence", 0.0) or 0.0),
+            rationale=str(data.get("rationale", "") or ""),
+            next_step_hint=str(data.get("next_step_hint", "") or ""),
+            progress_summary=str(data.get("progress_summary", "") or ""),
+        )
+    except (TypeError, ValueError) as exc:
+        log.warning("Goal verifier verdict fields invalid: %s", exc)
+        raise ValueError("verifier output fields invalid") from exc
+
+
+async def run_goal_verifier(
+    api_client: SupportsStreamingMessages,
+    goal: GoalDefinition,
+    messages: list[ConversationMessage],
+    *,
+    fallback_model: str = "",
+) -> VerifierVerdict:
+    """Ask the verifier model to judge whether the goal is achieved.
+
+    ``goal.verifier_model`` wins when set; otherwise the caller-supplied
+    ``fallback_model`` (typically the main engine model) is used.
+    """
+    model = goal.verifier_model.strip() or fallback_model
+    prompt = build_verifier_prompt(goal.condition, build_transcript(messages))
+    request = ApiMessageRequest(
+        model=model,
+        messages=[ConversationMessage.from_user_text(prompt)],
+        system_prompt=VERIFIER_SYSTEM_PROMPT,
+        max_tokens=1024,
+    )
+    text_parts: list[str] = []
+    async for event in api_client.stream_message(request):
+        if isinstance(event, ApiTextDeltaEvent):
+            text_parts.append(event.text)
+    text = "".join(text_parts)
+    log.debug("Goal verifier raw output: %r", text[:500])
+    verdict = render_verdict(text)
+    # A verdict with every field empty carries no signal (e.g. the model
+    # echoed `{}` back).  Treat it as a failure so the runner counts it and
+    # stops after repeated attempts instead of looping on a prompt the model
+    # never answers in the expected JSON shape.
+    if (
+        not verdict.done
+        and not verdict.rationale.strip()
+        and not verdict.next_step_hint.strip()
+        and not verdict.progress_summary.strip()
+    ):
+        log.warning("Goal verifier returned an empty verdict: %r", text[:200])
+        raise ValueError("verifier returned an empty (no-signal) verdict")
+    return verdict

--- a/src/openharness/ui/app.py
+++ b/src/openharness/ui/app.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from pathlib import Path
 
 from openharness.coordinator.coordinator_mode import is_coordinator_mode
 
 from openharness.api.client import SupportsStreamingMessages
 from openharness.engine.stream_events import StreamEvent
+from openharness.goal.store import GoalStore
 from openharness.ui.backend_host import run_backend_host
 from openharness.ui.coordinator_drain import drain_coordinator_async_agents
 from openharness.ui.react_launcher import launch_react_tui
@@ -55,6 +57,14 @@ async def run_repl(
     permission_mode: str | None = None,
 ) -> None:
     """Run the default OpenHarness interactive application (React TUI)."""
+    active_cwd = cwd or str(Path.cwd())
+    leftover_goal = GoalStore(active_cwd).load()
+    if leftover_goal is not None and leftover_goal.status == "active":
+        print(
+            f"[goal] 检测到未完成的目标：{leftover_goal.condition}"
+            f"（已跑 {leftover_goal.turns_run} 轮），输入 /goal resume 继续"
+        )
+
     if backend_only:
         await run_backend_host(
             cwd=cwd,

--- a/src/openharness/ui/runtime.py
+++ b/src/openharness/ui/runtime.py
@@ -660,6 +660,10 @@ async def handle_line(
         if result.refresh_runtime:
             refresh_runtime_client(bundle)
         await _render_command_result(result, print_system, clear_output, render_event)
+        if result.goal is not None:
+            from openharness.goal.runner import run_goal_loop
+
+            await run_goal_loop(bundle, result.goal, render_event, print_system)
         if result.submit_prompt is not None:
             original_model = bundle.engine.model
             if result.submit_model:

--- a/tests/test_goal/test_command.py
+++ b/tests/test_goal/test_command.py
@@ -1,0 +1,170 @@
+"""Tests for the /goal slash command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openharness.commands.registry import CommandContext, create_default_command_registry
+from openharness.config.settings import load_settings
+from openharness.engine.query_engine import QueryEngine
+from openharness.goal.store import GoalStore
+from openharness.permissions import PermissionChecker
+from openharness.tools import create_default_tool_registry
+
+
+class FakeApiClient:
+    async def stream_message(self, request):
+        del request
+        raise AssertionError("stream_message should not be called in command tests")
+
+
+def _make_context(tmp_path: Path) -> CommandContext:
+    return CommandContext(
+        engine=QueryEngine(
+            api_client=FakeApiClient(),
+            tool_registry=create_default_tool_registry(),
+            permission_checker=PermissionChecker(load_settings().permission),
+            cwd=tmp_path,
+            model="claude-test",
+            system_prompt="system",
+        ),
+        cwd=str(tmp_path),
+    )
+
+
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.delenv("OPENHARNESS_GOAL_VERIFIER_MODEL", raising=False)
+    monkeypatch.delenv("OPENHARNESS_GOAL_MAX_TURNS", raising=False)
+    monkeypatch.delenv("OPENHARNESS_GOAL_MAX_TOKENS", raising=False)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_goal_creates_goal_and_returns_it(isolated_env):
+    registry = create_default_command_registry()
+    command, args = registry.lookup("/goal fix the bug and run tests")
+    assert command is not None
+    result = await command.handler(args, _make_context(isolated_env))
+    assert result.goal is not None
+    assert result.goal.condition == "fix the bug and run tests"
+    assert result.goal.status == "active"
+    # Persisted immediately.
+    assert GoalStore(isolated_env).load().condition == "fix the bug and run tests"
+
+
+@pytest.mark.asyncio
+async def test_goal_rejects_second_active_goal(isolated_env):
+    registry = create_default_command_registry()
+    context = _make_context(isolated_env)
+    command, args = registry.lookup("/goal first goal")
+    await command.handler(args, context)
+    result = await command.handler("second goal", context)
+    assert result.goal is None
+    assert "already" in (result.message or "")
+
+
+@pytest.mark.asyncio
+async def test_goal_verifier_model_flag_wins(isolated_env):
+    registry = create_default_command_registry()
+    command, args = registry.lookup("/goal --verifier-model gpt-5-mini build it")
+    result = await command.handler(args, _make_context(isolated_env))
+    assert result.goal is not None
+    assert result.goal.verifier_model == "gpt-5-mini"
+    assert result.goal.condition == "build it"
+
+
+@pytest.mark.asyncio
+async def test_goal_verifier_model_from_env(isolated_env, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_GOAL_VERIFIER_MODEL", "gpt-5-nano")
+    registry = create_default_command_registry()
+    command, args = registry.lookup("/goal build it")
+    result = await command.handler(args, _make_context(isolated_env))
+    assert result.goal is not None
+    assert result.goal.verifier_model == "gpt-5-nano"
+
+
+@pytest.mark.asyncio
+async def test_goal_max_turns_flag_and_env(isolated_env, monkeypatch):
+    registry = create_default_command_registry()
+    context = _make_context(isolated_env)
+
+    command, args = registry.lookup("/goal --max-turns 7 do it")
+    result = await command.handler(args, context)
+    assert result.goal is not None
+    assert result.goal.max_turns_budget == 7
+
+    await command.handler("clear", context)
+    monkeypatch.setenv("OPENHARNESS_GOAL_MAX_TURNS", "9")
+    result = await command.handler("do it again", context)
+    assert result.goal is not None
+    assert result.goal.max_turns_budget == 9
+
+
+@pytest.mark.asyncio
+async def test_goal_status_show_and_clear(isolated_env):
+    registry = create_default_command_registry()
+    context = _make_context(isolated_env)
+
+    status_command, status_args = registry.lookup("/goal status")
+    status_result = await status_command.handler(status_args, context)
+    assert "No goal set" in (status_result.message or "")
+
+    create_command, _ = registry.lookup("/goal do the thing")
+    await create_command.handler("do the thing", context)
+
+    status_result = await status_command.handler(status_args, context)
+    assert "do the thing" in (status_result.message or "")
+    assert "Verifier model:" in (status_result.message or "")
+
+    clear_command, clear_args = registry.lookup("/goal clear")
+    clear_result = await clear_command.handler(clear_args, context)
+    assert "cleared" in (clear_result.message or "")
+    assert GoalStore(isolated_env).load() is None
+
+
+@pytest.mark.asyncio
+async def test_goal_pause_and_resume(isolated_env):
+    registry = create_default_command_registry()
+    context = _make_context(isolated_env)
+
+    create_command, _ = registry.lookup("/goal make progress")
+    await create_command.handler("make progress", context)
+    pause_command, pause_args = registry.lookup("/goal pause")
+    pause_result = await pause_command.handler(pause_args, context)
+    assert "paused" in (pause_result.message or "")
+    assert GoalStore(isolated_env).load().status == "paused"
+
+    resume_command, resume_args = registry.lookup("/goal resume")
+    resume_result = await resume_command.handler(resume_args, context)
+    assert resume_result.goal is not None
+    assert resume_result.goal.status == "active"
+
+
+@pytest.mark.asyncio
+async def test_goal_resume_completed_rejected(isolated_env):
+    registry = create_default_command_registry()
+    context = _make_context(isolated_env)
+
+    create_command, _ = registry.lookup("/goal make progress")
+    await create_command.handler("make progress", context)
+    goal = GoalStore(isolated_env).load()
+    goal.status = "completed"
+    GoalStore(isolated_env).save(goal)
+
+    resume_command, resume_args = registry.lookup("/goal resume")
+    result = await resume_command.handler(resume_args, context)
+    assert result.goal is None
+    assert "completed" in (result.message or "")
+
+
+@pytest.mark.asyncio
+async def test_goal_hidden_from_remote_channels():
+    registry = create_default_command_registry()
+    command, _ = registry.lookup("/goal x")
+    assert command is not None
+    assert command.remote_invocable is False

--- a/tests/test_goal/test_loop.py
+++ b/tests/test_goal/test_loop.py
@@ -1,0 +1,338 @@
+"""Tests for the goal runner loop with fakes for the engine and verifier."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from openharness.api.client import ApiTextDeltaEvent
+from openharness.api.usage import UsageSnapshot
+from openharness.config.settings import Settings
+from openharness.engine.messages import ConversationMessage, TextBlock
+from openharness.engine.stream_events import AssistantTurnComplete, StreamEvent
+from openharness.goal.prompts import build_goal_system_block
+from openharness.goal.runner import run_goal_loop
+from openharness.goal.store import GoalStore
+from openharness.goal.types import GoalDefinition
+
+
+class FakeVerifierClient:
+    """Yields a canned verdict per call from ``verdicts`` (dicts or errors)."""
+
+    def __init__(self, verdicts):
+        self.verdicts = list(verdicts)
+        self.calls = []
+
+    async def stream_message(self, request):
+        self.calls.append(request)
+        item = self.verdicts.pop(0) if self.verdicts else {"done": True}
+        if isinstance(item, Exception):
+            raise item
+        yield ApiTextDeltaEvent(text=json.dumps(item))
+
+
+class SlowVerifierClient(FakeVerifierClient):
+    """Yields a done verdict after sleeping, simulating a hung upstream."""
+
+    def __init__(self, sleep_seconds):
+        super().__init__([])
+        self.sleep_seconds = sleep_seconds
+
+    async def stream_message(self, request):
+        self.calls.append(request)
+        await asyncio.sleep(self.sleep_seconds)
+        yield ApiTextDeltaEvent(text=json.dumps({"done": True}))
+
+
+class FakeEngine:
+    def __init__(self, verifier_client, tokens_per_turn=0):
+        self.api_client = verifier_client
+        self.model = "test-model"
+        self._messages = [ConversationMessage.from_user_text("initial")]
+        self._usage = UsageSnapshot()
+        self._tokens_per_turn = tokens_per_turn
+        self._system_prompt = "base system prompt"
+        self.submitted_prompts = []
+        self.max_turns_set = []
+        self._fail_next_submit = False
+
+    @property
+    def messages(self):
+        return self._messages
+
+    @property
+    def total_usage(self):
+        return self._usage
+
+    @property
+    def system_prompt(self):
+        return self._system_prompt
+
+    def set_system_prompt(self, prompt):
+        self._system_prompt = prompt
+
+    def set_max_turns(self, turns):
+        self.max_turns_set.append(turns)
+
+    def load_messages(self, messages):
+        self._messages = list(messages)
+
+    @property
+    def tool_metadata(self):
+        return {}
+
+    async def submit_message(self, prompt):
+        if self._fail_next_submit:
+            self._fail_next_submit = False
+            from openharness.engine.query import MaxTurnsExceeded
+
+            raise MaxTurnsExceeded(1)
+        self.submitted_prompts.append(prompt)
+        self._messages.append(ConversationMessage.from_user_text(prompt))
+        self._messages.append(
+            ConversationMessage(role="assistant", content=[TextBlock(text="working...")])
+        )
+        self._usage = UsageSnapshot(
+            input_tokens=self._usage.input_tokens + self._tokens_per_turn,
+            output_tokens=self._usage.output_tokens + 10,
+        )
+        yield AssistantTurnComplete(
+            message=self._messages[-1], usage=self._usage
+        )
+
+
+class FakeSessionBackend:
+    def __init__(self):
+        self.snapshots = []
+        self._latest_snapshot = None
+
+    async def save_snapshot(self, **kwargs):
+        del kwargs
+        self.snapshots.append(1)
+
+    def load_latest(self, cwd):
+        return self._latest_snapshot
+
+
+class FakeBundle:
+    def __init__(self, engine, cwd, enforce_max_turns=True):
+        self.engine = engine
+        self.cwd = str(cwd)
+        self.enforce_max_turns = enforce_max_turns
+        self.session_id = "sess-1"
+        self.session_backend = FakeSessionBackend()
+
+    def current_settings(self):
+        return Settings()
+
+
+async def _collect_events(events):
+    return [event async for event in events]
+
+
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+    return tmp_path
+
+
+async def _noop_render(event: StreamEvent) -> None:
+    del event
+
+
+async def _run(bundle, goal, prints=None, verifier_timeout=None):
+    printed = []
+
+    async def print_system(message: str) -> None:
+        printed.append(message)
+
+    kwargs = {} if verifier_timeout is None else {"verifier_timeout": verifier_timeout}
+    await run_goal_loop(bundle, goal, _noop_render, print_system, **kwargs)
+    return printed
+
+
+@pytest.mark.asyncio
+async def test_loop_completes_when_verifier_says_done(isolated_env):
+    engine = FakeEngine(FakeVerifierClient([{"done": True, "rationale": "tests pass"}]))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="fix the bug", max_turns_budget=10)
+
+    printed = await _run(bundle, goal)
+
+    assert goal.status == "completed"
+    assert goal.turns_run == 1
+    assert len(engine.submitted_prompts) == 1  # first turn only
+    assert engine.submitted_prompts[0] == "fix the bug"
+    assert any("Completed" in line for line in printed)
+    # Goal context injected into the main system prompt.
+    assert build_goal_system_block("fix the bug") in engine.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_loop_continues_until_verifier_says_done(isolated_env):
+    verdicts = [
+        {"done": False, "rationale": "still red", "next_step_hint": "run tests"},
+        {"done": False, "rationale": "one more", "next_step_hint": "fix assertion"},
+        {"done": True},
+    ]
+    engine = FakeEngine(FakeVerifierClient(verdicts))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="ship it", max_turns_budget=10)
+
+    await _run(bundle, goal)
+
+    assert goal.status == "completed"
+    assert goal.turns_run == 3
+    assert engine.submitted_prompts == ["ship it", "run tests", "fix assertion"]
+    assert goal.last_verdict is not None and goal.last_verdict.done
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_on_turn_budget(isolated_env):
+    # Verifier never says done; budget forces failure after the allotted turns.
+    engine = FakeEngine(FakeVerifierClient([{"done": False, "next_step_hint": "keep going"}] * 10))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="endless", max_turns_budget=3)
+
+    printed = await _run(bundle, goal)
+
+    assert goal.status == "failed"
+    assert goal.turns_run == 3
+    assert any("Budget exhausted" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_on_token_budget(isolated_env):
+    engine = FakeEngine(
+        FakeVerifierClient([{"done": False, "next_step_hint": "keep going"}] * 5),
+        tokens_per_turn=100,
+    )
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="thirsty", max_tokens_budget=250)
+
+    await _run(bundle, goal)
+
+    assert goal.status == "failed"
+    assert engine.total_usage.total_tokens >= 250
+
+
+@pytest.mark.asyncio
+async def test_loop_resumes_without_first_turn(isolated_env):
+    engine = FakeEngine(FakeVerifierClient([{"done": True}]))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="resumed goal", max_turns_budget=10, turns_run=2)
+
+    await _run(bundle, goal)
+
+    assert goal.status == "completed"
+    assert engine.submitted_prompts == []  # no first turn on resume
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_after_repeated_verifier_failures(isolated_env):
+    engine = FakeEngine(FakeVerifierClient([ValueError("bad")] * 5))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="x", max_turns_budget=20, turns_run=1)
+
+    printed = await _run(bundle, goal)
+
+    assert goal.status == "failed"
+    assert goal.verifier_failures >= 3
+    assert any("verifier failed" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_loop_caps_verifier_timeout_as_failure(isolated_env):
+    engine = FakeEngine(SlowVerifierClient(sleep_seconds=2.0))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="verdict is slow", max_turns_budget=20, turns_run=1)
+
+    printed = await _run(bundle, goal, verifier_timeout=0.05)
+
+    assert goal.status == "failed"
+    assert goal.verifier_failures == 3
+    assert any("verifier failed" in line for line in printed)
+    assert any("attempt 2/3" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_loop_verifier_succeeds_within_timeout(isolated_env):
+    engine = FakeEngine(SlowVerifierClient(sleep_seconds=0.01))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="quick verdict", max_turns_budget=10)
+
+    printed = await _run(bundle, goal, verifier_timeout=5.0)
+
+    assert goal.status == "completed"
+    assert goal.verifier_failures == 0
+    assert goal.last_verdict is not None and goal.last_verdict.done
+    assert any("verifier judging" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_loop_persists_progress_after_every_turn(isolated_env):
+    engine = FakeEngine(FakeVerifierClient([{"done": True}]))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="record me", max_turns_budget=10)
+
+    await _run(bundle, goal)
+
+    stored = GoalStore(isolated_env).load()
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.turns_run == 1
+    assert bundle.session_backend.snapshots  # session snapshot written
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_inner_max_turns(isolated_env):
+    verdicts = [
+        {"done": False, "next_step_hint": "try again"},
+        {"done": True},
+    ]
+    engine = FakeEngine(FakeVerifierClient(verdicts))
+    engine._fail_next_submit = True  # first submission hits MaxTurnsExceeded
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="resilient", max_turns_budget=10)
+
+    await _run(bundle, goal)
+
+    assert goal.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_run_when_not_active(isolated_env):
+    engine = FakeEngine(FakeVerifierClient([]))
+    bundle = FakeBundle(engine, isolated_env)
+    goal = GoalDefinition(condition="paused goal", status="paused")
+
+    printed = await _run(bundle, goal)
+
+    assert len(engine.submitted_prompts) == 0
+    assert any("nothing to run" in line for line in printed)
+
+
+@pytest.mark.asyncio
+async def test_loop_restores_session_on_resume(isolated_env):
+    # Simulate a fresh process: engine starts empty, session snapshot has history.
+    engine = FakeEngine(FakeVerifierClient([{"done": True}]))
+    engine._messages = []
+    bundle = FakeBundle(engine, isolated_env)
+    bundle.session_backend._latest_snapshot = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "fix the bug"}]},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "tool_1", "name": "bash", "input": {"command": "git status"}}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tool_1", "content": ".qoder/ ignored"}]},
+        ]
+    }
+    goal = GoalDefinition(condition="fix bug", turns_run=2)
+
+    printed = await _run(bundle, goal)
+
+    # Engine messages restored from snapshot so verifier sees prior evidence.
+    assert len(engine.messages) >= 3
+    assert goal.status == "completed"
+    assert any("Restored" in line and "messages" in line for line in printed)

--- a/tests/test_goal/test_settings.py
+++ b/tests/test_goal/test_settings.py
@@ -1,0 +1,54 @@
+"""GoalSettings configuration tests."""
+
+from __future__ import annotations
+
+from openharness.config.settings import GoalSettings
+
+
+class TestGoalSettingsFromEnv:
+    def test_defaults_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("OPENHARNESS_GOAL_VERIFIER_MODEL", raising=False)
+        monkeypatch.delenv("OPENHARNESS_GOAL_MAX_TURNS", raising=False)
+        monkeypatch.delenv("OPENHARNESS_GOAL_MAX_TOKENS", raising=False)
+        cfg = GoalSettings.from_env()
+        assert cfg.verifier_model == ""
+        assert cfg.max_turns == 100
+        assert cfg.max_tokens is None
+
+    def test_reads_all_environment_variables(self, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_GOAL_VERIFIER_MODEL", "gpt-5-mini")
+        monkeypatch.setenv("OPENHARNESS_GOAL_MAX_TURNS", "42")
+        monkeypatch.setenv("OPENHARNESS_GOAL_MAX_TOKENS", "5000")
+        cfg = GoalSettings.from_env()
+        assert cfg.verifier_model == "gpt-5-mini"
+        assert cfg.max_turns == 42
+        assert cfg.max_tokens == 5000
+
+    def test_ignores_non_numeric_limits(self, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_GOAL_MAX_TURNS", "lots")
+        monkeypatch.setenv("OPENHARNESS_GOAL_MAX_TOKENS", "many")
+        cfg = GoalSettings.from_env()
+        assert cfg.max_turns == 100
+        assert cfg.max_tokens is None
+
+
+class TestGoalSettingsDefaults:
+    def test_settings_model_exposes_goal_section(self):
+        from openharness.config.settings import Settings
+
+        settings = Settings()
+        assert settings.goal.verifier_model == ""
+        assert settings.goal.max_turns == 100
+        assert settings.goal.max_tokens is None
+
+    def test_settings_parses_goal_from_config_file(self, tmp_path, monkeypatch):
+        from openharness.config.settings import Settings
+
+        monkeypatch.setenv("OPENHARNESS_CONFIG_DIR", str(tmp_path))
+        (tmp_path / "settings.json").write_text(
+            '{"goal": {"verifier_model": "gpt-5-nano", "max_turns": 7}}',
+            encoding="utf-8",
+        )
+        settings = Settings.model_validate_json((tmp_path / "settings.json").read_text(encoding="utf-8"))
+        assert settings.goal.verifier_model == "gpt-5-nano"
+        assert settings.goal.max_turns == 7

--- a/tests/test_goal/test_store.py
+++ b/tests/test_goal/test_store.py
@@ -1,0 +1,59 @@
+"""GoalStore persistence tests."""
+
+from __future__ import annotations
+
+from openharness.goal.store import GoalStore
+from openharness.goal.types import GoalDefinition
+
+
+class TestGoalStore:
+    def test_save_load_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        store = GoalStore(tmp_path / "proj")
+        goal = GoalDefinition(condition="do the thing", max_turns_budget=7)
+        store.save(goal)
+
+        loaded = store.load()
+        assert loaded is not None
+        assert loaded.condition == "do the thing"
+        assert loaded.max_turns_budget == 7
+        assert loaded.goal_id == goal.goal_id
+
+    def test_load_missing_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        store = GoalStore(tmp_path / "proj")
+        assert store.load() is None
+
+    def test_clear_removes_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        store = GoalStore(tmp_path / "proj")
+        store.save(GoalDefinition(condition="x"))
+        assert store.load() is not None
+        store.clear()
+        assert store.load() is None
+
+    def test_save_roundtrip_survives_new_store_instance(self, tmp_path, monkeypatch):
+        """A new GoalStore instance (stand-in for a restarted process) reads
+        the same persisted state."""
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        first = GoalStore(tmp_path / "proj")
+        first.save(GoalDefinition(condition="x", turns_run=4))
+
+        second = GoalStore(tmp_path / "proj")
+        loaded = second.load()
+        assert loaded is not None
+        assert loaded.turns_run == 4
+
+    def test_load_corrupt_file_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        store = GoalStore(tmp_path / "proj")
+        store.file_path.parent.mkdir(parents=True, exist_ok=True)
+        store.file_path.write_text("{not json", encoding="utf-8")
+        assert store.load() is None
+
+    def test_projects_are_isolated(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENHARNESS_DATA_DIR", str(tmp_path / "data"))
+        store_a = GoalStore(tmp_path / "proj-a")
+        store_b = GoalStore(tmp_path / "proj-b")
+        store_a.save(GoalDefinition(condition="goal a"))
+        assert store_b.load() is None

--- a/tests/test_goal/test_types.py
+++ b/tests/test_goal/test_types.py
@@ -1,0 +1,55 @@
+"""Goal data model tests."""
+
+from __future__ import annotations
+
+from openharness.goal.types import GoalDefinition, VerifierVerdict
+
+
+class TestGoalDefinition:
+    def test_serialization_roundtrip(self):
+        goal = GoalDefinition(
+            condition="fix the bug and run tests",
+            verifier_model="gpt-5-mini",
+            max_turns_budget=10,
+            max_tokens_budget=1000,
+            turns_run=2,
+            tokens_used=800,
+            last_verdict=VerifierVerdict(
+                done=False, confidence=0.7, rationale="still failing", next_step_hint="run pytest"
+            ),
+        )
+        raw = goal.model_dump_json()
+        restored = GoalDefinition.model_validate_json(raw)
+        assert restored == goal
+
+    def test_defaults(self):
+        goal = GoalDefinition(condition="do X")
+        assert goal.status == "active"
+        assert goal.turns_run == 0
+        assert goal.verifier_model == ""
+        assert goal.max_turns_budget == 100
+        assert goal.max_tokens_budget is None
+        assert goal.last_verdict is None
+
+    def test_budget_exhausted_by_turns(self):
+        goal = GoalDefinition(condition="x", max_turns_budget=3, turns_run=3)
+        assert goal.budget_exhausted(0) is True
+        goal.turns_run = 2
+        assert goal.budget_exhausted(0) is False
+
+    def test_budget_exhausted_by_tokens(self):
+        goal = GoalDefinition(condition="x", max_tokens_budget=500)
+        assert goal.budget_exhausted(500) is True
+        assert goal.budget_exhausted(499) is False
+
+    def test_budget_unlimited_when_not_configured(self):
+        goal = GoalDefinition(condition="x")
+        assert goal.budget_exhausted(10**9) is False
+
+    def test_touch_updates_timestamp(self):
+        import time
+
+        goal = GoalDefinition(condition="x")
+        time.sleep(0.01)
+        goal.touch()
+        assert goal.updated_at >= goal.created_at

--- a/tests/test_goal/test_verifier.py
+++ b/tests/test_goal/test_verifier.py
@@ -1,0 +1,132 @@
+"""Goal verifier tests: verdict parsing and transcript building."""
+
+from __future__ import annotations
+
+import pytest
+
+from openharness.api.client import ApiTextDeltaEvent
+from openharness.engine.messages import ConversationMessage, ToolResultBlock, ToolUseBlock
+from openharness.goal.prompts import VERIFIER_SYSTEM_PROMPT, build_verifier_prompt
+from openharness.goal.types import GoalDefinition
+from openharness.goal.verifier import build_transcript, render_verdict, run_goal_verifier
+
+
+class TestRenderVerdict:
+    def test_parses_done_verdict(self):
+        verdict = render_verdict(
+            '{"done": true, "confidence": 0.9, "rationale": "tests pass", '
+            '"next_step_hint": "", "progress_summary": "all done"}'
+        )
+        assert verdict.done is True
+        assert verdict.confidence == 0.9
+        assert verdict.rationale == "tests pass"
+        assert verdict.progress_summary == "all done"
+
+    def test_parses_continue_verdict(self):
+        verdict = render_verdict(
+            '{"done": false, "confidence": 0.4, "rationale": "still red", '
+            '"next_step_hint": "run pytest next"}'
+        )
+        assert verdict.done is False
+        assert verdict.next_step_hint == "run pytest next"
+
+    def test_tolerates_markdown_fence(self):
+        verdict = render_verdict("```json\n{\"done\": true}\n```")
+        assert verdict.done is True
+
+    def test_tolerates_prose_prefix(self):
+        verdict = render_verdict('Here is the JSON: {"done": true}')
+        assert verdict.done is True
+
+    def test_unparseable_output_raises(self):
+        with pytest.raises(ValueError):
+            render_verdict("sorry, I cannot comply")
+
+    def test_missing_fields_default(self):
+        verdict = render_verdict("{}")
+        assert verdict.done is False
+        assert verdict.confidence == 0.0
+        assert verdict.next_step_hint == ""
+
+
+class TestBuildTranscript:
+    def test_renders_role_prefixed_lines(self):
+        messages = [
+            ConversationMessage.from_user_text("fix the bug"),
+            ConversationMessage.from_user_text("and run tests"),
+        ]
+        transcript = build_transcript(messages)
+        assert "user: fix the bug" in transcript
+        assert "user: and run tests" in transcript
+
+    def test_truncates_long_message_text(self):
+        from openharness.goal.prompts import MAX_BLOCK_CHARS
+
+        long_text = "x" * (MAX_BLOCK_CHARS + 100)
+        transcript = build_transcript([ConversationMessage.from_user_text(long_text)])
+        assert len(transcript) <= MAX_BLOCK_CHARS + 32  # role prefix + truncation
+
+    def test_includes_tool_calls_and_results(self):
+        messages = [
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    ToolUseBlock(name="bash", input={"command": "git check-ignore .qoder"}),
+                    ToolResultBlock(tool_use_id="x", content=".qoder/"),
+                ],
+            ),
+        ]
+        transcript = build_transcript(messages)
+        assert "[tool_use] bash" in transcript
+        assert "[tool_result] .qoder/" in transcript
+
+
+class TestBuildVerifierPrompt:
+    def test_includes_condition_and_transcript(self):
+        prompt = build_verifier_prompt("ship the feature", "user: working on it")
+        assert "ship the feature" in prompt
+        assert "user: working on it" in prompt
+
+
+class _CaptureClient:
+    """Streams a fixed text reply and records the request for inspection."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.request = None
+
+    async def stream_message(self, request):
+        self.request = request
+        yield ApiTextDeltaEvent(text=self.text)
+
+
+class TestRunGoalVerifier:
+    def _messages(self):
+        return [ConversationMessage.from_user_text("working on it")]
+
+    @pytest.mark.asyncio
+    async def test_sends_verifier_system_prompt(self):
+        client = _CaptureClient('{"done": true, "rationale": "tests pass"}')
+        goal = GoalDefinition(condition="ship it")
+
+        verdict = await run_goal_verifier(client, goal, self._messages())
+
+        assert verdict.done is True
+        assert client.request.system_prompt == VERIFIER_SYSTEM_PROMPT
+
+    @pytest.mark.asyncio
+    async def test_rejects_signal_free_verdict(self):
+        client = _CaptureClient("{}")
+        goal = GoalDefinition(condition="ship it")
+
+        with pytest.raises(ValueError):
+            await run_goal_verifier(client, goal, self._messages())
+
+    @pytest.mark.asyncio
+    async def test_accepts_done_without_hint(self):
+        client = _CaptureClient('{"done": true}')
+        goal = GoalDefinition(condition="ship it")
+
+        verdict = await run_goal_verifier(client, goal, self._messages())
+
+        assert verdict.done is True


### PR DESCRIPTION
Add a goal-driven autonomy mode inspired by Claude Code's goal-based loop and Codex's persistence: the main model works toward a completion condition over multiple turns while a lightweight verifier model judges continue/done after each turn.

- goal module: types, prompts, store, verifier, runner

- /goal command with status/pause/resume/clear subcommands

- verifier model config: CLI flag > env > settings.json > fallback

- 60s verifier timeout + empty-verdict guard + session restore on resume

- persist goal state per project, resume across restarts

- docs/goal.md and tests/test_goal (51 tests)