### PR TITLE
fix(ohmo): suppress disabled tool hints in gateway bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project currently tracks chang
 
 ### Fixed
 
+- Ohmo gateway now respects `send_tool_hints = false` in the bridge, preventing disabled tool hints from being published to the outbound bus or written to INFO logs.
 - Codex subscription requests now pass reasoning effort separately, enabling `gpt-5.5` with `xhigh` effort instead of treating `gpt-5.5 xhigh` as an unsupported model name.
 - Telegram channel now delivers replies again under `ohmo init --no-interactive` and other configs that do not write a `reply_to_message` field. `TelegramConfig` declares `reply_to_message: bool = True` so the attribute access in `TelegramChannel.send` no longer raises `AttributeError` and outbound progress/tool-hint/final messages are sent as expected. See issue #243.
 

--- a/ohmo/gateway/bridge.py
+++ b/ohmo/gateway/bridge.py
@@ -64,12 +64,14 @@ class OhmoGatewayBridge:
         restart_gateway: Callable[[object, str], Awaitable[None] | None] | None = None,
         workspace: str | Path | None = None,
         feishu_group_policy: str = "open",
+        send_tool_hints: bool = True,
     ) -> None:
         self._bus = bus
         self._runtime_pool = runtime_pool
         self._restart_gateway = restart_gateway
         self._workspace = workspace
         self._feishu_group_policy = _normalize_feishu_group_policy(feishu_group_policy)
+        self._send_tool_hints = send_tool_hints
         self._running = False
         self._session_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_cancel_reasons: dict[str, str] = {}
@@ -266,6 +268,8 @@ class OhmoGatewayBridge:
                     final_metadata = dict(update.metadata or {})
                     continue
                 if not update.text:
+                    continue
+                if update.kind == "tool_hint" and not self._send_tool_hints:
                     continue
                 logger.info(
                     "ohmo outbound update channel=%s chat_id=%s session_key=%s kind=%s content=%r",

--- a/ohmo/gateway/service.py
+++ b/ohmo/gateway/service.py
@@ -70,6 +70,7 @@ class OhmoGatewayService:
             feishu_group_policy=str(
                 self._config.channel_configs.get("feishu", {}).get("group_policy", "managed_or_mention")
             ),
+            send_tool_hints=self._config.send_tool_hints,
         )
 
     @property

--- a/tests/test_ohmo/test_gateway.py
+++ b/tests/test_ohmo/test_gateway.py
@@ -1880,6 +1880,41 @@ async def test_gateway_bridge_publishes_progress_updates():
 
 
 @pytest.mark.asyncio
+async def test_gateway_bridge_suppresses_disabled_tool_hints(caplog):
+    bus = MessageBus()
+
+    class FakeRuntimePool:
+        async def stream_message(self, message, session_key):
+            yield SimpleNamespace(
+                kind="tool_hint",
+                text="🛠️ 正在使用 web_fetch: https://example.com",
+                metadata={"_progress": True, "_tool_hint": True, "_session_key": session_key},
+            )
+            yield SimpleNamespace(kind="final", text="Done", metadata={"_session_key": session_key})
+
+    caplog.set_level(logging.INFO, logger="ohmo.gateway.bridge")
+    bridge = OhmoGatewayBridge(
+        bus=bus,
+        runtime_pool=FakeRuntimePool(),
+        send_tool_hints=False,
+    )
+    task = asyncio.create_task(bridge.run())
+    try:
+        await bus.publish_inbound(
+            InboundMessage(channel="feishu", sender_id="u1", chat_id="c1", content="hi")
+        )
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=1.0)
+    finally:
+        bridge.stop()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert outbound.content == "Done"
+    assert "kind=tool_hint" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_gateway_bridge_does_not_thread_private_feishu_replies():
     bus = MessageBus()
 


### PR DESCRIPTION
## Summary

- propagate the gateway send_tool_hints setting into OhmoGatewayBridge
- skip tool-hint updates before INFO logging and outbound publication when the setting is disabled
- add a regression test covering the quiet path while preserving the final response
- document the fix in the Unreleased changelog

Fixes #352.

## Validation

- [x] uv run pytest -q tests/test_ohmo/test_gateway.py (77 passed)
- [x] focused regression tests (2 passed)
- [x] targeted Ruff E/F checks and compileall
- [ ] uv run ruff check src tests scripts (existing baseline: 718 errors across unrelated files)
- [ ] uv run pytest -q (collection blocked by the current unconstrained mcp 2.x dependency removing mcp.server.fastmcp; unrelated to this change)
- [ ] frontend TypeScript check (frontend not touched)

## Notes

- Related issue: #352
- Follow-up work: none